### PR TITLE
docs: 收敛 #43/#46/#49/#52 合同矩阵

### DIFF
--- a/harness/README.md
+++ b/harness/README.md
@@ -16,11 +16,11 @@
 - [execution-chain.md](./execution-chain.md)
   - 定义从初始化产物到 merge checkpoint 放行的最小执行链路
 - `checkpoint-model.md`
-  - 定义 `admission` / `build` checkpoint 的输入、输出、失败语义与回退去向（并行任务落位后作为稳定入口）
+  - 定义 `admission` / `build` checkpoint 的输入、输出、失败语义与回退去向
 - [workspace-model.md](./workspace-model.md)
   - 定义执行现场的隔离、定位与 clean state 要求
 - `workspace-lifecycle.md`
-  - 定义 `create`、`locate`、`cleanup`、`retire` 与 `purity-check` 的生命周期合同（并行任务落位后作为稳定入口）
+  - 定义 `create`、`locate`、`cleanup`、`retire` 与 `purity-check` 的生命周期合同
 - [recovery-model.md](./recovery-model.md)
   - 定义唯一恢复主入口、`checkpoint`、`resume`、`handoff` 与每轮回写合同
 - [status-surface.md](./status-surface.md)

--- a/harness/checkpoint-model.md
+++ b/harness/checkpoint-model.md
@@ -22,6 +22,19 @@ Loom 当前的 checkpoint 顺序固定为：
 - `merge checkpoint`
   - 只承接最终放行，见 [merge-checkpoint.md](./merge-checkpoint.md)
 
+## 1.1 统一合同矩阵
+
+| checkpoint | 读取重点 | 允许结果 | 默认回退去向 |
+| --- | --- | --- | --- |
+| `admission` | 事项目标/范围、事项绑定、恢复入口可读性 | `pass` / `block` / `fallback` | `admission` |
+| `build` | admission 已成立前提下的验证入口、状态链与 lane 一致性 | `pass` / `block` / `fallback` | `admission`（仅 admission 输入失真时） |
+| `merge` | build 结果、放行输入、风险/回滚与阻断项 | `allow` / `block` / `fallback` | `build` 或 `admission`（见 merge 合同） |
+
+说明：
+
+- `merge` 的结果词在执行侧仍以 [merge-checkpoint.md](./merge-checkpoint.md) 为准，本表只表达三类 checkpoint 的回退关系。
+- PR 模板可作为 `merge` 放行材料之一，但不会成为长期 authored 真相。
+
 ## 2. 统一读取基线
 
 任一 checkpoint 的机械读取都必须按以下顺序进行：
@@ -113,3 +126,15 @@ Loom 当前的 checkpoint 顺序固定为：
 - `merge checkpoint` 可以额外消费 PR 模板、reviewer 结论与运行证据，但这些都不是长期真相源
 - PR 模板只能作为 merge 放行的补充输入，不得反向覆盖 `work item`、恢复主入口或状态面的 authored 事实
 
+## 6. 失败分类最小语义
+
+为避免把失败原因混成单一“未通过”，三类 checkpoint 至少要能区分：
+
+- `missing_inputs`
+  - 必填输入缺失或不可定位
+- `inconsistent_facts`
+  - 字段可读但跨载体冲突
+- `scope_or_purity_risk`
+  - 范围或纯度信号显示当前阶段不应继续放行
+- `fallback_required`
+  - 当前阶段已无法在本阶段收口，必须回退前序

--- a/harness/fact-chain-contract.md
+++ b/harness/fact-chain-contract.md
@@ -71,6 +71,36 @@ Loom 的执行真相只允许沿一条事实链流动：
 
 它不得并行复制当前停点、下一步、阻断项、最近验证摘要或当前 checkpoint。
 
+## 2.4 标准事实模型与字段来源矩阵
+
+以下矩阵是 Loom 完整执行内核当前稳定的最小事实模型。
+
+| 字段 | 主来源 | 类型 | 允许消费方 |
+| --- | --- | --- | --- |
+| `item_id` | `work item` | authored | execution-context、status-surface、checkpoint、merge-checkpoint |
+| `goal` | `work item` | authored | execution-context、checkpoint、merge-checkpoint |
+| `scope` | `work item` | authored | execution-context、checkpoint、purity-check |
+| `execution_path` | `work item` | authored | execution-context、checkpoint |
+| `workspace_entry` | `work item` | authored | workspace-lifecycle、purity-check、status-surface |
+| `recovery_entry` | `work item` | authored | execution-context、workspace-lifecycle、checkpoint |
+| `validation_entry` | `work item` | authored | checkpoint、merge-checkpoint、verify |
+| `closing_condition` | `work item` | authored | checkpoint、merge-checkpoint |
+| `current_checkpoint` | recovery 主入口 | authored | status-surface、checkpoint、workspace-lifecycle |
+| `current_stop` | recovery 主入口 | authored | execution-context、checkpoint |
+| `next_step` | recovery 主入口 | authored | execution-context、status-surface、checkpoint |
+| `blockers` | recovery 主入口 | authored | execution-context、status-surface、checkpoint |
+| `latest_validation_summary` | recovery 主入口 | authored | status-surface、checkpoint、merge-checkpoint |
+| `recovery_boundary` | recovery 主入口 | authored | checkpoint、merge-checkpoint |
+| `current_lane` | recovery 主入口 | authored | status-surface、checkpoint、runtime-evidence |
+| `read_entry` | `init-result` | locator | verify、fact-chain、daily CLI |
+| `status_surface` locator | `init-result` + `work item` 派生 | derived | fact-chain、verify、checkpoint、workspace-lifecycle |
+| `runtime_evidence.*` | status-surface `Runtime Evidence` | derived | fact-chain、verify、merge-checkpoint、loom-check |
+
+约束：
+
+- `authored` 字段只能在主来源中维护。
+- `derived` 字段只能由读取脚本从主来源计算或映射，不得手工改写为第二真相。
+
 ## 3. 派生读面
 
 以下载体只允许派生读取，不允许独立 authored 字段覆盖主真相：

--- a/harness/status-surface.md
+++ b/harness/status-surface.md
@@ -54,6 +54,22 @@ Loom 当前至少要求状态面能展示：
 - locator 字符串
 - `not_applicable`
 
+## 3.1 字段合同矩阵
+
+| 字段 | 最小语义 | 允许值 | `not_applicable` 允许条件 |
+| --- | --- | --- | --- |
+| `Run Entry` | 告诉执行者去哪启动当前事项运行面 | locator / `not_applicable` | 事项不涉及可运行系统 |
+| `Logs Entry` | 告诉执行者去哪看运行输出或日志 | locator / `not_applicable` | 无运行进程或无日志载体 |
+| `Diagnostics Entry` | 指向指标、trace 或等价诊断入口 | locator / `not_applicable` | 当前事项没有诊断面 |
+| `Verification Entry` | 指向 UI/API/E2E 等可验证入口 | locator / `not_applicable` | 事项不涉及可验证运行结果 |
+| `Lane Entry` | 指向当前 lane 的运行/诊断读取入口 | locator / `not_applicable` | 事项没有 lane 区分 |
+
+判定规则：
+
+- 字段缺失始终是错误，不等同于 `not_applicable`。
+- `not_applicable` 必须按字段判断，不能整组一刀切。
+- 若某字段标记 `not_applicable`，应与 `current_lane`、`execution_path`、`latest_validation_summary` 等事实不冲突。
+
 ## 4. 运行时证据入口语义
 
 最小证据类别对应如下：

--- a/harness/workspace-lifecycle.md
+++ b/harness/workspace-lifecycle.md
@@ -25,6 +25,20 @@ Loom 当前日常执行 CLI 至少提供以下入口：
 
 它们不得新增第二套执行状态真相。
 
+## 1.1 生命周期合同矩阵
+
+| 阶段 | 输入重点 | 输出重点 | 失败默认语义 | 回退去向 |
+| --- | --- | --- | --- | --- |
+| `create` | `workspace_entry`、当前事项、当前 checkpoint | 现场已建立或已确认可用 | `block` | 回到 `workspace_entry` / 事实链修复 |
+| `locate` | 当前事项、`workspace_entry`、`recovery_entry` | 现场定位、恢复入口、checkpoint、purity 快照 | `block` | 回到 `create` 或事实链修复 |
+| `resume`（由恢复模型承接） | `locate` 输出 + recovery 主入口 | 下一步执行上下文 | `block` | 回到 recovery 回写修复 |
+| `cleanup` | Loom-owned 残留路径、现场纯度 | 仅 Loom 残留被清理 | `block` | 回到人工分流与纯度修复 |
+| `retire` | `cleanup` 结果 + recovery 主入口 | `current_checkpoint: retired` | `block` / `fallback` | 回到 `cleanup` 或 recovery 回写 |
+
+说明：
+
+- `resume` 的入口语义由 [recovery-model.md](./recovery-model.md) 承接，本文件只定义它与 `locate` 的边界关系。
+
 ## 2. 统一输入与输出
 
 ### 2.1 输入
@@ -94,6 +108,13 @@ Loom 当前日常执行 CLI 至少提供以下入口：
 - 恢复入口 `recovery`
 - 当前 checkpoint `checkpoint`
 - 当前 purity `purity`
+
+定位规则固定为：
+
+- 先用 `init-result` 找到当前事项与 carrier locator
+- 再由 `work item.workspace_entry` 定位现场
+- 再用 `work item.recovery_entry` 读取动态状态
+- 最后以 status-surface 给出派生汇总，不反向覆盖 recovery authored 值
 
 ### 4.2 失败语义
 
@@ -166,4 +187,3 @@ Loom 当前日常执行 CLI 至少提供以下入口：
 - PR purity
 
 这些项可以作为后续宿主适配扩展接入，但当前不改变生命周期命令的硬失败口径。
-


### PR DESCRIPTION
## Summary
- 补齐 #43 的标准事实模型字段来源矩阵，明确 authored 与 derived 字段边界
- 补齐 #46 的三类 checkpoint 统一合同矩阵与最小失败分类
- 补齐 #49 的生命周期合同矩阵与 locate 固定定位顺序
- 补齐 #52 的 Runtime Evidence 字段合同矩阵与 `not_applicable` 分项判定

## Validation
- python3 tools/loom_check.py

## Risks And Follow-ups
- 未改动宿主适配实现；仅强化稳定合同与读取语义

## Related Work
- Closes #43
- Closes #46
- Closes #49
- Closes #52
