### PR TITLE
feat: 收敛 #44/#47/#50/#53 统一执行入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Loom 的执行内核目标，不是长期停留在“最小可执行”层面，
 - 仓库自检可通过 `make loom-check` 运行
 - 初始化入口可通过 `python3 tools/loom_init.py bootstrap --target <repo>` 运行
 - 事实链读取入口可通过 `python3 tools/loom_init.py fact-chain --target <repo>` 运行
+- 日常事实读取入口可通过 `python3 tools/loom_flow.py fact-chain --target <repo>` 运行
+- 运行时证据读取入口可通过 `python3 tools/loom_flow.py runtime-evidence --target <repo>` 运行
 - 日常执行入口可通过 `python3 tools/loom_flow.py <...>` 运行
 - 新项目 demo 可通过 `make loom-demo-new-project` 复验
 

--- a/docs/demo-new-project.md
+++ b/docs/demo-new-project.md
@@ -51,6 +51,8 @@ python3 tools/loom_init.py bootstrap \
 cd examples/new-project
 python3 .loom/bin/loom_init.py verify --target .
 python3 .loom/bin/loom_init.py fact-chain --target .
+python3 .loom/bin/loom_flow.py fact-chain --target . --item INIT-0001
+python3 .loom/bin/loom_flow.py runtime-evidence --target . --item INIT-0001
 python3 .loom/bin/loom_flow.py checkpoint admission --target . --item INIT-0001
 python3 .loom/bin/loom_flow.py workspace locate --target . --item INIT-0001
 python3 .loom/bin/loom_flow.py purity-check --target . --item INIT-0001
@@ -63,6 +65,6 @@ python3 .loom/bin/loom_flow.py purity-check --target . --item INIT-0001
 - `bootstrap` 命令退出码为 `0`
 - `verify` 命令退出码为 `0`
 - `fact-chain` 命令退出码为 `0`
-- `loom_flow.py` 的 `checkpoint admission`、`workspace locate`、`purity-check` 命令都可读取当前样例
+- `loom_flow.py` 的 `fact-chain`、`runtime-evidence`、`checkpoint admission`、`workspace locate`、`purity-check` 命令都可读取当前样例
 - `init-result.json` 含有 7 个必需区块
 - 首批 work item、recovery entry、状态面与 spec/plan 工件都已落位

--- a/harness/automation-frontload.md
+++ b/harness/automation-frontload.md
@@ -54,6 +54,8 @@ Loom 仓库当前通过以下入口承接最小 core 前置检查：
 - `python3 tools/loom_check.py`
 - `python3 tools/loom_init.py verify --target <repo>`
 - `python3 tools/loom_init.py fact-chain --target <repo>`
+- `python3 tools/loom_flow.py fact-chain --target <repo> [--item <id>]`
+- `python3 tools/loom_flow.py runtime-evidence --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py checkpoint <admission|build|merge> --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py workspace <create|locate|cleanup|retire> --target <repo> --item <id>`
 - `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]`

--- a/harness/checkpoint-model.md
+++ b/harness/checkpoint-model.md
@@ -138,3 +138,13 @@ Loom 当前的 checkpoint 顺序固定为：
   - 范围或纯度信号显示当前阶段不应继续放行
 - `fallback_required`
   - 当前阶段已无法在本阶段收口，必须回退前序
+
+## 7. 执行入口与 gate 对齐
+
+三类 checkpoint 的执行入口固定为：
+
+- `python3 tools/loom_flow.py checkpoint admission --target <repo> [--item <id>]`
+- `python3 tools/loom_flow.py checkpoint build --target <repo> [--item <id>]`
+- `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]`
+
+`loom_init verify` 与 `loom_check` 会复用同一脚本面读取结果，不维护第二套 checkpoint 入口。

--- a/harness/fact-chain-contract.md
+++ b/harness/fact-chain-contract.md
@@ -141,6 +141,11 @@ Loom 的执行真相只允许沿一条事实链流动：
 
 不允许跳过主真相，直接把状态面或 merge checkpoint 输入当成 authored 真相。
 
+当前仓库中的统一读取入口包括：
+
+- `python3 tools/loom_init.py fact-chain --target <repo>`
+- `python3 tools/loom_flow.py fact-chain --target <repo> [--item <id>]`
+
 ## 6. 边界约束
 
 - Loom 固化的是字段归属与派生关系，不固化具体文件名或宿主平台字段名

--- a/harness/status-surface.md
+++ b/harness/status-surface.md
@@ -113,3 +113,8 @@ Loom 固化的是“可读取、可验证”的能力目标，不固化具体可
 - 状态面若展示的 `next_step`、`blockers`、`latest_validation_summary` 与恢复主入口不一致，应视为事实链断裂
 - `Runtime Evidence` 的 5 个字段必须全部出现；不允许用“缺字段”表达不适用
 - 运行时证据入口不等于完整 observability 平台设计；本文件只要求最小可读入口
+
+当前仓库中的统一读取入口包括：
+
+- `python3 tools/loom_init.py fact-chain --target <repo>`
+- `python3 tools/loom_flow.py runtime-evidence --target <repo> [--item <id>]`

--- a/harness/workspace-lifecycle.md
+++ b/harness/workspace-lifecycle.md
@@ -187,3 +187,15 @@ Loom 当前日常执行 CLI 至少提供以下入口：
 - PR purity
 
 这些项可以作为后续宿主适配扩展接入，但当前不改变生命周期命令的硬失败口径。
+
+## 8. 执行入口与 gate 对齐
+
+生命周期入口固定为：
+
+- `python3 tools/loom_flow.py workspace create --target <repo> --item <id>`
+- `python3 tools/loom_flow.py workspace locate --target <repo> --item <id>`
+- `python3 tools/loom_flow.py workspace cleanup --target <repo> --item <id>`
+- `python3 tools/loom_flow.py workspace retire --target <repo> --item <id>`
+- `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]`
+
+`loom_init verify` 与 `loom_check` 会复用同一组入口验证结果语义。

--- a/tools/loom_check.py
+++ b/tools/loom_check.py
@@ -520,6 +520,8 @@ def check_demo_assets(root: Path) -> list[Failure]:
         "tools/loom_init.py bootstrap",
         ".loom/bin/loom_init.py verify",
         ".loom/bin/loom_init.py fact-chain",
+        ".loom/bin/loom_flow.py fact-chain",
+        ".loom/bin/loom_flow.py runtime-evidence",
         ".loom/bin/loom_flow.py checkpoint admission",
         ".loom/bin/loom_flow.py workspace locate",
         ".loom/bin/loom_flow.py purity-check",
@@ -565,6 +567,24 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         return failures
 
     demo_commands = [
+        (
+            "fact-chain",
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", "examples/new-project", "--item", "INIT-0001"],
+            {"pass"},
+        ),
+        (
+            "runtime-evidence",
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "runtime-evidence",
+                "--target",
+                "examples/new-project",
+                "--item",
+                "INIT-0001",
+            ],
+            {"pass"},
+        ),
         (
             "admission",
             ["python3", "tools/loom_flow.py", "checkpoint", "admission", "--target", "examples/new-project", "--item", "INIT-0001"],

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -46,6 +46,14 @@ TERMINAL_CHECKPOINTS = {
     "archived",
 }
 
+RUNTIME_EVIDENCE_FIELDS = (
+    "run_entry",
+    "logs_entry",
+    "diagnostics_entry",
+    "verification_entry",
+    "lane_entry",
+)
+
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Loom daily execution checks against a target repository.")
@@ -75,6 +83,24 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     purity.add_argument("--target", required=True, help="Target repository root")
     purity.add_argument("--item", help="Expected current item id")
     purity.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+
+    fact_chain = subparsers.add_parser("fact-chain", help="Read and validate the Loom fact chain")
+    fact_chain.add_argument("--target", required=True, help="Target repository root")
+    fact_chain.add_argument("--item", help="Expected current item id")
+    fact_chain.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+
+    runtime = subparsers.add_parser("runtime-evidence", help="Read runtime evidence from the Loom fact chain")
+    runtime.add_argument("--target", required=True, help="Target repository root")
+    runtime.add_argument("--item", help="Expected current item id")
+    runtime.add_argument(
         "--output",
         default=".loom/bootstrap/init-result.json",
         help="Init-result path relative to the target root",
@@ -269,13 +295,9 @@ def dirty_paths_by_owner(target_root: Path) -> tuple[list[str], list[str]]:
 
 
 def load_context(target_root: Path, output_relative: str, expected_item: str | None) -> tuple[dict[str, Any], list[str]]:
-    report, errors = inspect_fact_chain(target_root, output_relative)
-    if errors and all("Runtime Evidence" in message for message in errors):
-        report, errors = inspect_fact_chain_legacy(target_root, output_relative)
+    report, errors = load_fact_chain_report(target_root, output_relative)
     if errors:
         return {}, errors
-    if not report:
-        return {}, ["no fact-chain report was produced"]
 
     item_id = report["fact_chain"]["entry_points"]["current_item_id"]
     if expected_item and expected_item != item_id:
@@ -315,6 +337,17 @@ def load_context(target_root: Path, output_relative: str, expected_item: str | N
         "read_entry": str(report["fact_chain"]["read_entry"]),
     }
     return context, []
+
+
+def load_fact_chain_report(target_root: Path, output_relative: str) -> tuple[dict[str, Any], list[str]]:
+    report, errors = inspect_fact_chain(target_root, output_relative)
+    if errors and all("Runtime Evidence" in message for message in errors):
+        report, errors = inspect_fact_chain_legacy(target_root, output_relative)
+    if errors:
+        return {}, errors
+    if not report:
+        return {}, ["no fact-chain report was produced"]
+    return report, []
 
 
 def inspect_fact_chain_legacy(target_root: Path, output_relative: str) -> tuple[dict[str, Any], list[str]]:
@@ -901,8 +934,122 @@ def handle_purity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_fact_chain(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    report, errors = load_fact_chain_report(target_root, args.output)
+    if errors:
+        return emit(
+            {
+                "command": "fact-chain",
+                "result": "block",
+                "summary": "fact-chain command could not read a valid Loom fact chain.",
+                "missing_inputs": [f"fact-chain: {message}" for message in errors],
+                "fallback_to": "admission",
+            }
+        )
+
+    item_id = report["fact_chain"]["entry_points"]["current_item_id"]
+    if args.item and args.item != item_id:
+        return emit(
+            {
+                "command": "fact-chain",
+                "result": "block",
+                "summary": "fact-chain command found an item mismatch.",
+                "missing_inputs": [f"current item mismatch: expected `{args.item}`, got `{item_id}`"],
+                "fallback_to": "admission",
+            }
+        )
+
+    return emit(
+        {
+            "command": "fact-chain",
+            "result": "pass",
+            "summary": "fact chain can be read and validated from a single entry.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "report": report,
+        }
+    )
+
+
+def handle_runtime_evidence(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    report, errors = load_fact_chain_report(target_root, args.output)
+    if errors:
+        return emit(
+            {
+                "command": "runtime-evidence",
+                "result": "block",
+                "summary": "runtime-evidence command could not read a valid Loom fact chain.",
+                "missing_inputs": [f"fact-chain: {message}" for message in errors],
+                "fallback_to": "admission",
+            }
+        )
+
+    item_id = report["fact_chain"]["entry_points"]["current_item_id"]
+    if args.item and args.item != item_id:
+        return emit(
+            {
+                "command": "runtime-evidence",
+                "result": "block",
+                "summary": "runtime-evidence command found an item mismatch.",
+                "missing_inputs": [f"current item mismatch: expected `{args.item}`, got `{item_id}`"],
+                "fallback_to": "admission",
+            }
+        )
+
+    runtime_evidence = report.get("runtime_evidence")
+    missing_inputs: list[str] = []
+    fields: dict[str, Any] = {}
+    if not isinstance(runtime_evidence, dict):
+        missing_inputs.append("runtime_evidence is missing from fact-chain report")
+    else:
+        for key in RUNTIME_EVIDENCE_FIELDS:
+            entry = runtime_evidence.get(key)
+            if not isinstance(entry, dict):
+                missing_inputs.append(f"runtime_evidence.{key} is missing")
+                continue
+            value = entry.get("value")
+            status = entry.get("status")
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"runtime_evidence.{key}.value must be a non-empty string")
+            if status not in {"present", "not_applicable"}:
+                missing_inputs.append(f"runtime_evidence.{key}.status must be `present` or `not_applicable`")
+            elif status == "present" and value == "not_applicable":
+                missing_inputs.append(f"runtime_evidence.{key} is `present` but uses `not_applicable`")
+            elif status == "not_applicable" and value != "not_applicable":
+                missing_inputs.append(f"runtime_evidence.{key} is `not_applicable` but value is `{value}`")
+            fields[key] = {
+                "value": value,
+                "status": status,
+                "source": entry.get("source"),
+            }
+
+    result = "pass" if not missing_inputs else "block"
+    summary = (
+        "runtime evidence entries are readable and distinguish `present` from `not_applicable`."
+        if result == "pass"
+        else "runtime evidence entries are incomplete or inconsistent."
+    )
+    return emit(
+        {
+            "command": "runtime-evidence",
+            "item_id": item_id,
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission" if missing_inputs else None,
+            "runtime_evidence": fields,
+        }
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
+    if args.command == "fact-chain":
+        return handle_fact_chain(args)
+    if args.command == "runtime-evidence":
+        return handle_runtime_evidence(args)
     if args.command == "checkpoint":
         return handle_checkpoint(args)
     if args.command == "workspace":

--- a/tools/loom_init.py
+++ b/tools/loom_init.py
@@ -888,6 +888,7 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
         if not (target_root / relative).exists():
             errors.append(f"missing required artifact: {relative}")
 
+    current_item_id: str | None = None
     if output_path.exists():
         try:
             result = read_json(output_path)
@@ -989,6 +990,81 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
         for needle in ("## Summary", "## Validation", "## Risks And Follow-ups", "## Related Work"):
             if needle not in text:
                 errors.append(f"PR template is missing section: {needle}")
+
+    flow_tool = target_root / ".loom/bin/loom_flow.py"
+    if flow_tool.exists():
+        commands: list[tuple[str, list[str], set[str]]] = [
+            (
+                "loom-flow fact-chain",
+                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
+                {"pass"},
+            ),
+            (
+                "loom-flow runtime-evidence",
+                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                {"pass"},
+            ),
+        ]
+        if current_item_id:
+            commands.extend(
+                [
+                    (
+                        "loom-flow checkpoint admission",
+                        [
+                            "python3",
+                            ".loom/bin/loom_flow.py",
+                            "checkpoint",
+                            "admission",
+                            "--target",
+                            ".",
+                            "--item",
+                            current_item_id,
+                        ],
+                        {"pass", "block", "fallback"},
+                    ),
+                    (
+                        "loom-flow workspace locate",
+                        [
+                            "python3",
+                            ".loom/bin/loom_flow.py",
+                            "workspace",
+                            "locate",
+                            "--target",
+                            ".",
+                            "--item",
+                            current_item_id,
+                        ],
+                        {"pass", "block"},
+                    ),
+                ]
+            )
+
+        for label, command, allowed in commands:
+            result = subprocess.run(
+                command,
+                cwd=target_root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            output = result.stdout.strip()
+            if not output:
+                detail = result.stderr.strip() or "no JSON output"
+                errors.append(f"{label} failed: {detail}")
+                continue
+            try:
+                payload = json.loads(output)
+            except json.JSONDecodeError as exc:
+                errors.append(f"{label} returned invalid JSON: {exc.msg}")
+                continue
+            if not isinstance(payload, dict):
+                errors.append(f"{label} must return a JSON object")
+                continue
+            command_result = payload.get("result")
+            if command_result not in allowed:
+                errors.append(
+                    f"{label} returned unexpected result `{command_result}` (allowed: {', '.join(sorted(allowed))})"
+                )
 
     return errors
 


### PR DESCRIPTION
## Summary
- 为 #44 增加 `loom_flow fact-chain` 统一读取入口，固定输出语义并支持 item 一致性校验
- 为 #53 增加 `loom_flow runtime-evidence` 统一读取入口，固定 `present/not_applicable` 语义校验
- 为 #47/#50 将 checkpoint/workspace 入口接入 `loom_init verify` 与 `loom_check` 的统一验证面
- 更新 demo 与 automation-frontload 文档，使入口集合与 gate 行为一致

## Validation
- python3 -m py_compile tools/loom_flow.py tools/loom_init.py tools/loom_check.py
- python3 tools/loom_flow.py fact-chain --target examples/new-project --item INIT-0001
- python3 tools/loom_flow.py runtime-evidence --target examples/new-project --item INIT-0001
- python3 tools/loom_init.py verify --target examples/new-project
- python3 tools/loom_check.py

## Risks And Follow-ups
- 本次不引入宿主特定 adapter；保持 Loom 内核入口宿主无关

## Related Work
- Closes #44
- Closes #47
- Closes #50
- Closes #53
