### PR TITLE
feat: 收敛 #56/#59 状态检查与高频统一入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Loom 的执行内核目标，不是长期停留在“最小可执行”层面，
 - 事实链读取入口可通过 `python3 tools/loom_init.py fact-chain --target <repo>` 运行
 - 日常事实读取入口可通过 `python3 tools/loom_flow.py fact-chain --target <repo>` 运行
 - 运行时证据读取入口可通过 `python3 tools/loom_flow.py runtime-evidence --target <repo>` 运行
+- 状态一致性检查入口可通过 `python3 tools/loom_flow.py state-check --target <repo>` 运行
+- 高频预检统一入口可通过 `python3 tools/loom_flow.py flow pre-review --target <repo>` 运行
 - 日常执行入口可通过 `python3 tools/loom_flow.py <...>` 运行
 - 新项目 demo 可通过 `make loom-demo-new-project` 复验
 

--- a/docs/demo-new-project.md
+++ b/docs/demo-new-project.md
@@ -53,6 +53,8 @@ python3 .loom/bin/loom_init.py verify --target .
 python3 .loom/bin/loom_init.py fact-chain --target .
 python3 .loom/bin/loom_flow.py fact-chain --target . --item INIT-0001
 python3 .loom/bin/loom_flow.py runtime-evidence --target . --item INIT-0001
+python3 .loom/bin/loom_flow.py state-check --target . --item INIT-0001
+python3 .loom/bin/loom_flow.py flow pre-review --target . --item INIT-0001
 python3 .loom/bin/loom_flow.py checkpoint admission --target . --item INIT-0001
 python3 .loom/bin/loom_flow.py workspace locate --target . --item INIT-0001
 python3 .loom/bin/loom_flow.py purity-check --target . --item INIT-0001
@@ -65,6 +67,6 @@ python3 .loom/bin/loom_flow.py purity-check --target . --item INIT-0001
 - `bootstrap` 命令退出码为 `0`
 - `verify` 命令退出码为 `0`
 - `fact-chain` 命令退出码为 `0`
-- `loom_flow.py` 的 `fact-chain`、`runtime-evidence`、`checkpoint admission`、`workspace locate`、`purity-check` 命令都可读取当前样例
+- `loom_flow.py` 的 `fact-chain`、`runtime-evidence`、`state-check`、`flow pre-review`、`checkpoint admission`、`workspace locate`、`purity-check` 命令都可读取当前样例
 - `init-result.json` 含有 7 个必需区块
 - 首批 work item、recovery entry、状态面与 spec/plan 工件都已落位

--- a/harness/automation-frontload.md
+++ b/harness/automation-frontload.md
@@ -74,6 +74,8 @@ Loom 仓库当前通过以下入口承接最小 core 前置检查：
 - `python3 tools/loom_init.py fact-chain --target <repo>`
 - `python3 tools/loom_flow.py fact-chain --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py runtime-evidence --target <repo> [--item <id>]`
+- `python3 tools/loom_flow.py state-check --target <repo> [--item <id>]`
+- `python3 tools/loom_flow.py flow pre-review --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py checkpoint <admission|build|merge> --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py workspace <create|locate|cleanup|retire> --target <repo> --item <id>`
 - `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]`

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -15,6 +15,7 @@
 | `bootstrap` | `python3 tools/loom_init.py bootstrap --target <repo>` | intake + 仓库信号 | 初始化结果 JSON + 首批工件 | `skills/loom-init` 负责路由，CLI 负责落盘 |
 | `verify` | `python3 tools/loom_init.py verify --target <repo>` | init-result + fact-chain + flow 子命令 | `ok` / `errors` | 核验初始化产物与入口可读性 |
 | `fact-chain` | `python3 tools/loom_flow.py fact-chain --target <repo> [--item <id>]` | 单一事实链 | `pass` / `block` | 日常统一读取入口 |
+| `pre-review`（统一高频入口） | `python3 tools/loom_flow.py flow pre-review --target <repo> [--item <id>]` | fact-chain + state-check + runtime evidence + admission + workspace locate | `pass` / `block` / `fallback` | 第一版聚焦 review 前高频检查流 |
 | `checkpoint` | `python3 tools/loom_flow.py checkpoint <admission\\|build\\|merge> --target <repo> [--item <id>]` | fact-chain + purity + merge 放行材料 | `pass` / `block` / `fallback` | `merge` 可额外消费 PR 模板 |
 | `resume` | 恢复主入口 + execution-context 读取顺序 | work item + recovery entry + status-surface | 可继续执行的下一步上下文 | 语义落点在 `recovery-model.md` |
 | `handoff` | 恢复主入口回写 + 状态面同步 | 当前停点/下一步/阻断项/验证摘要 | 可移交的恢复状态 | 不新增第二套 authored 状态 |

--- a/harness/workspace-and-purity.md
+++ b/harness/workspace-and-purity.md
@@ -61,3 +61,5 @@ Loom 当前至少要求以下纯度：
   - `out_of_scope_changes`
 
 当 `scope_assessment.mode` 为 `constrained` 且出现 `out_of_scope_changes` 时，应视为范围越界阻断信号。
+
+`python3 tools/loom_flow.py state-check --target <repo> [--item <id>]` 会复用同一纯度结果，并额外检查活跃状态与 checkpoint 完整性。

--- a/tools/loom_check.py
+++ b/tools/loom_check.py
@@ -524,6 +524,8 @@ def check_demo_assets(root: Path) -> list[Failure]:
         ".loom/bin/loom_init.py fact-chain",
         ".loom/bin/loom_flow.py fact-chain",
         ".loom/bin/loom_flow.py runtime-evidence",
+        ".loom/bin/loom_flow.py state-check",
+        ".loom/bin/loom_flow.py flow pre-review",
         ".loom/bin/loom_flow.py checkpoint admission",
         ".loom/bin/loom_flow.py workspace locate",
         ".loom/bin/loom_flow.py purity-check",
@@ -586,6 +588,25 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 "INIT-0001",
             ],
             {"pass"},
+        ),
+        (
+            "state-check",
+            ["python3", "tools/loom_flow.py", "state-check", "--target", "examples/new-project", "--item", "INIT-0001"],
+            {"pass"},
+        ),
+        (
+            "flow-pre-review",
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "flow",
+                "pre-review",
+                "--target",
+                "examples/new-project",
+                "--item",
+                "INIT-0001",
+            ],
+            {"pass", "block", "fallback"},
         ),
         (
             "admission",
@@ -723,6 +744,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     Failure(
                         "daily-execution-cli",
                         f"`purity-check` negative sample must block, got `{payload.get('result')}`",
+                    )
+                )
+            state_payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "state-check",
+                    "--target",
+                    str(dirty_target),
+                    "--item",
+                    "INIT-0001",
+                ],
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`state-check` negative sample failed: {error}"))
+            elif state_payload.get("result") != "block":
+                failures.append(
+                    Failure(
+                        "daily-execution-cli",
+                        f"`state-check` negative sample must block, got `{state_payload.get('result')}`",
                     )
                 )
 

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -106,6 +106,28 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Init-result path relative to the target root",
     )
 
+    state = subparsers.add_parser(
+        "state-check",
+        help="Check active-state consistency, checkpoint completeness, and scope overflow signals",
+    )
+    state.add_argument("--target", required=True, help="Target repository root")
+    state.add_argument("--item", help="Expected current item id")
+    state.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+
+    flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
+    flow.add_argument("operation", choices=("pre-review",))
+    flow.add_argument("--target", required=True, help="Target repository root")
+    flow.add_argument("--item", help="Expected current item id")
+    flow.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+
     return parser.parse_args(argv)
 
 
@@ -1017,6 +1039,37 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
     )
 
 
+def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    runtime_evidence = report.get("runtime_evidence")
+    missing_inputs: list[str] = []
+    fields: dict[str, Any] = {}
+    if not isinstance(runtime_evidence, dict):
+        missing_inputs.append("runtime_evidence is missing from fact-chain report")
+        return fields, missing_inputs
+
+    for key in RUNTIME_EVIDENCE_FIELDS:
+        entry = runtime_evidence.get(key)
+        if not isinstance(entry, dict):
+            missing_inputs.append(f"runtime_evidence.{key} is missing")
+            continue
+        value = entry.get("value")
+        status = entry.get("status")
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(f"runtime_evidence.{key}.value must be a non-empty string")
+        if status not in {"present", "not_applicable"}:
+            missing_inputs.append(f"runtime_evidence.{key}.status must be `present` or `not_applicable`")
+        elif status == "present" and value == "not_applicable":
+            missing_inputs.append(f"runtime_evidence.{key} is `present` but uses `not_applicable`")
+        elif status == "not_applicable" and value != "not_applicable":
+            missing_inputs.append(f"runtime_evidence.{key} is `not_applicable` but value is `{value}`")
+        fields[key] = {
+            "value": value,
+            "status": status,
+            "source": entry.get("source"),
+        }
+    return fields, missing_inputs
+
+
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     report, errors = load_fact_chain_report(target_root, args.output)
@@ -1043,32 +1096,7 @@ def handle_runtime_evidence(args: argparse.Namespace) -> int:
             }
         )
 
-    runtime_evidence = report.get("runtime_evidence")
-    missing_inputs: list[str] = []
-    fields: dict[str, Any] = {}
-    if not isinstance(runtime_evidence, dict):
-        missing_inputs.append("runtime_evidence is missing from fact-chain report")
-    else:
-        for key in RUNTIME_EVIDENCE_FIELDS:
-            entry = runtime_evidence.get(key)
-            if not isinstance(entry, dict):
-                missing_inputs.append(f"runtime_evidence.{key} is missing")
-                continue
-            value = entry.get("value")
-            status = entry.get("status")
-            if not isinstance(value, str) or not value.strip():
-                missing_inputs.append(f"runtime_evidence.{key}.value must be a non-empty string")
-            if status not in {"present", "not_applicable"}:
-                missing_inputs.append(f"runtime_evidence.{key}.status must be `present` or `not_applicable`")
-            elif status == "present" and value == "not_applicable":
-                missing_inputs.append(f"runtime_evidence.{key} is `present` but uses `not_applicable`")
-            elif status == "not_applicable" and value != "not_applicable":
-                missing_inputs.append(f"runtime_evidence.{key} is `not_applicable` but value is `{value}`")
-            fields[key] = {
-                "value": value,
-                "status": status,
-                "source": entry.get("source"),
-            }
+    fields, missing_inputs = runtime_evidence_from_report(report)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -1089,12 +1117,243 @@ def handle_runtime_evidence(args: argparse.Namespace) -> int:
     )
 
 
+def state_check_payload(context: dict[str, Any]) -> dict[str, Any]:
+    purity = purity_report_from_context(context)
+    active_state_failures: list[str] = []
+    checkpoint_failures: list[str] = []
+    scope_failures: list[str] = []
+
+    current_checkpoint = context["current_checkpoint"]
+    if current_checkpoint in TERMINAL_CHECKPOINTS:
+        active_state_failures.append(f"current checkpoint is terminal: `{current_checkpoint}`")
+
+    active_conflicts = active_workspace_conflicts(context["target_root"], context["item_id"], context["workspace_entry"])
+    if active_conflicts:
+        active_state_failures.append(
+            "workspace is shared by multiple active items: " + ", ".join(sorted(active_conflicts))
+        )
+
+    known_checkpoints = {"admission", "build", "merge", "retired"} | TERMINAL_CHECKPOINTS
+    if current_checkpoint not in known_checkpoints:
+        checkpoint_failures.append(f"unknown checkpoint value: `{context['current_checkpoint_raw']}`")
+    if current_checkpoint in {"admission", "build", "merge"}:
+        for field_name in ("current_stop", "next_step", "latest_validation_summary", "recovery_boundary", "current_lane"):
+            value = str(context[field_name]).strip()
+            if not value:
+                checkpoint_failures.append(f"checkpoint integrity missing `{field_name}`")
+
+    scope_assessment = purity.get("scope_assessment")
+    if isinstance(scope_assessment, dict):
+        out_of_scope_changes = scope_assessment.get("out_of_scope_changes")
+        if isinstance(out_of_scope_changes, list) and out_of_scope_changes:
+            preview = ", ".join(out_of_scope_changes[:5])
+            scope_failures.append(f"out-of-scope changes detected: {preview}")
+
+    missing_inputs: list[str] = []
+    for collection in (purity["hard_failures"], active_state_failures, checkpoint_failures, scope_failures):
+        for message in collection:
+            if message not in missing_inputs:
+                missing_inputs.append(message)
+
+    result = "pass" if not missing_inputs else "block"
+    summary = (
+        "active state, checkpoint integrity, and scope signals are consistent."
+        if result == "pass"
+        else "state-check found active-state conflicts, checkpoint gaps, or scope overflow signals."
+    )
+    return {
+        "command": "state-check",
+        "item": {
+            "id": context["item_id"],
+            "goal": context["goal"],
+            "scope": context["scope"],
+            "execution_path": context["execution_path"],
+        },
+        "checkpoint": {
+            "raw": context["current_checkpoint_raw"],
+            "normalized": current_checkpoint,
+        },
+        "workspace": {
+            "entry": context["workspace_entry"],
+            "path": relative_to_root(context["workspace_path"], context["target_root"]),
+        },
+        "checks": {
+            "active_state_failures": active_state_failures,
+            "checkpoint_failures": checkpoint_failures,
+            "scope_failures": scope_failures,
+        },
+        "purity": purity,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "fallback_to": "admission" if missing_inputs else None,
+    }
+
+
+def handle_state_check(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    context, errors = load_context(target_root, args.output, args.item)
+    if errors:
+        return emit(
+            {
+                "command": "state-check",
+                "result": "block",
+                "summary": "state-check could not read a valid Loom fact chain.",
+                "missing_inputs": [f"fact-chain: {message}" for message in errors],
+                "fallback_to": "admission",
+            }
+        )
+    return emit(state_check_payload(context))
+
+
+def handle_flow(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    context, errors = load_context(target_root, args.output, args.item)
+    if errors:
+        return emit(
+            {
+                "command": "flow",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "flow command could not read a valid Loom fact chain.",
+                "missing_inputs": [f"fact-chain: {message}" for message in errors],
+                "fallback_to": "admission",
+                "steps": [],
+            }
+        )
+
+    if args.operation != "pre-review":
+        return emit(
+            {
+                "command": "flow",
+                "operation": args.operation,
+                "result": "block",
+                "summary": f"unsupported flow operation: {args.operation}",
+                "missing_inputs": [f"unsupported operation: {args.operation}"],
+                "fallback_to": None,
+                "steps": [],
+            }
+        )
+
+    steps: list[dict[str, Any]] = []
+    steps.append(
+        {
+            "name": "fact-chain",
+            "result": "pass",
+            "summary": "fact chain is readable from a single entry.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    )
+
+    state_payload = state_check_payload(context)
+    steps.append(
+        {
+            "name": "state-check",
+            "result": state_payload["result"],
+            "summary": state_payload["summary"],
+            "missing_inputs": state_payload["missing_inputs"],
+            "fallback_to": state_payload["fallback_to"],
+        }
+    )
+
+    runtime_fields, runtime_missing = runtime_evidence_from_report(context["report"])
+    runtime_result = "pass" if not runtime_missing else "block"
+    steps.append(
+        {
+            "name": "runtime-evidence",
+            "result": runtime_result,
+            "summary": (
+                "runtime evidence entries are readable."
+                if runtime_result == "pass"
+                else "runtime evidence entries are incomplete or inconsistent."
+            ),
+            "missing_inputs": runtime_missing,
+            "fallback_to": "admission" if runtime_missing else None,
+            "runtime_evidence": runtime_fields,
+        }
+    )
+
+    admission_payload = checkpoint_payload("admission", context)
+    steps.append(
+        {
+            "name": "checkpoint-admission",
+            "result": admission_payload["result"],
+            "summary": admission_payload["summary"],
+            "missing_inputs": admission_payload["missing_inputs"],
+            "fallback_to": admission_payload["fallback_to"],
+        }
+    )
+
+    locate_payload = base_workspace_payload(context, "locate")
+    locate_result = "pass" if not locate_payload["purity"]["hard_failures"] else "block"
+    steps.append(
+        {
+            "name": "workspace-locate",
+            "result": locate_result,
+            "summary": (
+                "workspace is location-resolved and execution-ready."
+                if locate_result == "pass"
+                else "workspace is location-resolved but not execution-ready."
+            ),
+            "missing_inputs": list(locate_payload["purity"]["hard_failures"]),
+            "fallback_to": "admission" if locate_payload["purity"]["hard_failures"] else None,
+        }
+    )
+
+    result = "pass"
+    fallback_to: str | None = None
+    for step in steps:
+        step_result = step["result"]
+        if step_result == "fallback":
+            result = "fallback"
+            fallback_to = step.get("fallback_to") or "admission"
+            break
+        if step_result == "block" and result == "pass":
+            result = "block"
+            fallback_to = step.get("fallback_to")
+
+    summary = (
+        "pre-review flow is ready to proceed."
+        if result == "pass"
+        else "pre-review flow found blocking signals before review."
+    )
+    missing_inputs: list[str] = []
+    for step in steps:
+        if step["result"] in {"block", "fallback"}:
+            for message in step.get("missing_inputs", []):
+                if message not in missing_inputs:
+                    missing_inputs.append(message)
+
+    return emit(
+        {
+            "command": "flow",
+            "operation": "pre-review",
+            "item": {
+                "id": context["item_id"],
+                "goal": context["goal"],
+                "scope": context["scope"],
+                "execution_path": context["execution_path"],
+            },
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "steps": steps,
+        }
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     if args.command == "fact-chain":
         return handle_fact_chain(args)
     if args.command == "runtime-evidence":
         return handle_runtime_evidence(args)
+    if args.command == "state-check":
+        return handle_state_check(args)
+    if args.command == "flow":
+        return handle_flow(args)
     if args.command == "checkpoint":
         return handle_checkpoint(args)
     if args.command == "workspace":

--- a/tools/loom_init.py
+++ b/tools/loom_init.py
@@ -1023,6 +1023,19 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                         {"pass", "block", "fallback"},
                     ),
                     (
+                        "loom-flow state-check",
+                        [
+                            "python3",
+                            ".loom/bin/loom_flow.py",
+                            "state-check",
+                            "--target",
+                            ".",
+                            "--item",
+                            current_item_id,
+                        ],
+                        {"pass"},
+                    ),
+                    (
                         "loom-flow workspace locate",
                         [
                             "python3",
@@ -1035,6 +1048,20 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                             current_item_id,
                         ],
                         {"pass", "block"},
+                    ),
+                    (
+                        "loom-flow flow pre-review",
+                        [
+                            "python3",
+                            ".loom/bin/loom_flow.py",
+                            "flow",
+                            "pre-review",
+                            "--target",
+                            ".",
+                            "--item",
+                            current_item_id,
+                        ],
+                        {"pass", "block", "fallback"},
                     ),
                 ]
             )


### PR DESCRIPTION
## Summary
- 为 #56 新增 `loom_flow state-check`，覆盖活跃状态一致性、checkpoint 完整性与范围越界信号
- 将 `state-check` 接入 `loom_init verify` 与 `loom_check`，并补充负例阻断断言
- 为 #59 新增 `loom_flow flow pre-review`，将高频预检动作统一收敛到单入口
- 更新入口矩阵、frontload 与 demo 文档，确保脚本入口与交付说明一致

## Validation
- python3 -m py_compile tools/loom_flow.py tools/loom_init.py tools/loom_check.py tools/fact_chain_support.py
- python3 tools/loom_flow.py state-check --target examples/new-project --item INIT-0001
- python3 tools/loom_flow.py flow pre-review --target examples/new-project --item INIT-0001
- python3 tools/loom_check.py

## Risks And Follow-ups
- `flow pre-review` 当前只收敛第一组高频动作，后续可按同一 JSON 合同增量扩展

## Related Work
- Closes #56
- Closes #59
