### PR TITLE
feat: 完成 loom-pre-review 场景入口

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -21,6 +21,7 @@
 - 复杂既有仓库真实验证：[validation-hotcp.md](./validation-hotcp.md)
 - 场景 skill `loom-adopt` 验证：[validation-skill-loom-adopt.md](./validation-skill-loom-adopt.md)
 - 场景 skill `loom-resume` 验证：[validation-skill-loom-resume.md](./validation-skill-loom-resume.md)
+- 场景 skill `loom-pre-review` 验证：[validation-skill-loom-pre-review.md](./validation-skill-loom-pre-review.md)
 - 事实链消费验证：[validation-fact-chain-mail-listener.md](./validation-fact-chain-mail-listener.md)
 - checkpoint 链路复验：[validation-checkpoints-hotcp.md](./validation-checkpoints-hotcp.md)
 - 运行时证据复验：[validation-runtime-evidence-hotcp.md](./validation-runtime-evidence-hotcp.md)

--- a/adoption/validation-skill-loom-pre-review.md
+++ b/adoption/validation-skill-loom-pre-review.md
@@ -1,0 +1,56 @@
+# Skill Validation: `loom-pre-review`
+
+## 1. 样本标识
+
+- 场景 skill：`loom-pre-review`
+- 验证日期：`2026-04-16`
+- 对应 Loom issue：`#84`
+- 子 issue：`#85`、`#86`、`#87`
+
+## 2. 验证样本
+
+- Demo 仓库：`examples/new-project`
+- 可运行样本：`/Users/mc/dev/hotcp`
+
+## 3. 显式触发验证
+
+执行：
+
+- `python3 tools/loom_init.py route --target examples/new-project --skill loom-pre-review`
+
+期望：
+
+- 返回 `result: pass`
+- `selected_skill` 为 `loom-pre-review`
+- 不被误路由到 `loom-resume`、`loom-merge-ready` 或其他场景
+
+## 4. 隐式路由验证
+
+执行：
+
+- `python3 tools/loom_init.py route --target examples/new-project --task "请在进入 review 前做统一检查"`
+
+期望：
+
+- 返回 `result: pass`
+- `selected_skill` 为 `loom-pre-review`
+- `matched_signals` 能解释命中 pre-review 场景
+
+## 5. 下游消费验证
+
+执行：
+
+- `python3 tools/loom_flow.py flow pre-review --target examples/new-project --item INIT-0001`
+- `python3 tools/loom_check.py`
+
+结论：
+
+- `flow pre-review` 固定按 `fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate` 顺序编排
+- 输出会稳定给出统一通过/阻断/回退摘要
+- skill 只负责进入 review 前的机械判断，不替代 reviewer 的语义审查
+
+## 6. 关闭依据
+
+- `loom-pre-review` 已从 skeleton 提升为正式场景入口
+- 显式触发、隐式路由与下游消费均已有验证记录
+- 该 skill 没有引入新的事实链载体或并行检查命令

--- a/skills/loom-pre-review/SKILL.md
+++ b/skills/loom-pre-review/SKILL.md
@@ -5,11 +5,63 @@ description: 负责统一 review 前检查。Use when Codex needs a single pre-r
 
 # Loom Pre Review
 
-这个 skill 包裹统一的 review 前 flow。
+这个 skill 承接 review 前统一检查场景。
 
-优先入口：
+它只包裹既有 `flow pre-review`，不生成语义 review 结论，也不新增并行状态源。
+
+## 1. 使用时机
+
+当任务满足以下任一条件时，进入 `loom-pre-review`：
+
+- 明确要求 review 前检查
+- 明确要求进入 review 前先做统一预检
+- 明确要求确认当前事项是否已经可 review
+- 明确要求先看阻断项、运行时证据与 admission checkpoint 是否齐全
+
+如果任务其实是在做初始化、恢复执行、handoff、retire 或 merge-ready，应回到 root route matrix，让 `loom-init` 路由到对应场景：
+
+- [../route-matrix.md](../route-matrix.md)
+
+## 2. 固定入口
+
+统一入口固定为：
 
 - `python3 tools/loom_flow.py flow pre-review --target <repo> [--item <id>]`
+
+## 3. 固定编排
+
+`flow pre-review` 固定只编排以下读取链路：
+
+1. `fact-chain`
+2. `state-check`
+3. `runtime-evidence`
+4. `checkpoint admission`
+5. `workspace locate`
+
+这个 skill 不做以下事情：
+
+- 不替代 reviewer 的语义判断
+- 不直接执行 merge
+- 不回写事实链、恢复入口或状态面
+
+## 4. 输出要求
+
+输出必须是统一的 pre-review 摘要 JSON，至少要让执行者能读出：
+
+- 当前事项是什么
+- 当前是否可进入 review
+- 哪一步阻断了继续进入 review
+- 若阻断，应回退到哪里
+- 当前 steps 的机械结果是什么
+
+## 5. 完成标准
+
+只有当以下条件同时满足时，`loom-pre-review` 才算完成：
+
+- 显式调用 `loom-pre-review` 与 root 隐式路由都能稳定命中
+- `flow pre-review` 的步骤顺序稳定为 `fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate`
+- 输出 JSON 能直接支撑“是否进入 review 前语义审查”的判断
+- skill 自身不复制治理真相，也不冒充 reviewer 结论
 
 输入信号与输出合同见：
 

--- a/skills/loom-pre-review/contract.json
+++ b/skills/loom-pre-review/contract.json
@@ -20,10 +20,12 @@
   "output_contract": {
     "reference": "references/output-contract.md",
     "required_sections": [
+      "item",
       "result",
-      "blocking_reasons",
-      "fallback_target",
-      "latest_validation_summary"
+      "summary",
+      "missing_inputs",
+      "fallback_to",
+      "steps"
     ]
   },
   "routing": {

--- a/skills/loom-pre-review/references/input-signals.md
+++ b/skills/loom-pre-review/references/input-signals.md
@@ -5,3 +5,10 @@
 - review 前检查
 - 进入 review 前预检
 - 确认是否可 review
+- 确认阻断项、运行时证据和 admission checkpoint 是否齐全
+
+最小输入：
+
+- 目标仓库
+- 当前 review 意图
+- 当前事项编号，或允许从事实链定位活跃事项

--- a/skills/loom-pre-review/references/output-contract.md
+++ b/skills/loom-pre-review/references/output-contract.md
@@ -1,8 +1,18 @@
 # Loom Pre Review Output Contract
 
-输出至少需要给出：
+输出固定为统一 pre-review 摘要 JSON，至少需要给出：
 
-- 统一放行结果
-- 阻断项
-- 回退去向
-- 最近可用验证摘要
+- `item`
+  - 当前事项编号、目标、范围、执行路径
+- `result`
+  - `pass`、`block` 或 `fallback`
+- `summary`
+  - 当前是否可进入 review 的单句结论
+- `missing_inputs`
+  - 当前阻断需要补齐的信息；无阻断时为空数组
+- `fallback_to`
+  - 若当前不能继续进入 review，应回退到哪个 checkpoint；无回退时为 `null`
+- `steps`
+  - 固定按 `fact-chain -> state-check -> runtime-evidence -> checkpoint-admission -> workspace-locate` 顺序列出
+
+这个 skill 不产生 reviewer 结论；它只提供进入 review 前的统一机械判断。


### PR DESCRIPTION
## Summary
- 将 `loom-pre-review` 从 skeleton 补成正式场景 skill，写清使用时机、固定编排、输出要求与完成标准
- 收敛 `loom-pre-review` 的输入/输出合同，使其与既有 `flow pre-review` JSON 对齐
- 新增 `adoption/validation-skill-loom-pre-review.md`，记录显式触发、隐式路由与下游消费验证

## Validation
- `python3 tools/loom_init.py route --target examples/new-project --skill loom-pre-review`
- `python3 tools/loom_init.py route --target examples/new-project --task "请在进入 review 前做统一检查"`
- `python3 tools/loom_flow.py flow pre-review --target examples/new-project --item INIT-0001`
- `make loom-demo-new-project`
- `python3 tools/loom_init.py verify --target examples/new-project`
- `python3 tools/loom_check.py`

Closes #84
Closes #85
Closes #86
Closes #87