### PR TITLE
feat: 完成 loom-handoff 场景入口

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -21,6 +21,7 @@
 - 复杂既有仓库真实验证：[validation-hotcp.md](./validation-hotcp.md)
 - 场景 skill `loom-adopt` 验证：[validation-skill-loom-adopt.md](./validation-skill-loom-adopt.md)
 - 场景 skill `loom-resume` 验证：[validation-skill-loom-resume.md](./validation-skill-loom-resume.md)
+- 场景 skill `loom-handoff` 验证：[validation-skill-loom-handoff.md](./validation-skill-loom-handoff.md)
 - 事实链消费验证：[validation-fact-chain-mail-listener.md](./validation-fact-chain-mail-listener.md)
 - checkpoint 链路复验：[validation-checkpoints-hotcp.md](./validation-checkpoints-hotcp.md)
 - 运行时证据复验：[validation-runtime-evidence-hotcp.md](./validation-runtime-evidence-hotcp.md)

--- a/adoption/validation-skill-loom-handoff.md
+++ b/adoption/validation-skill-loom-handoff.md
@@ -1,0 +1,56 @@
+# Skill Validation: `loom-handoff`
+
+## 1. 样本标识
+
+- 场景 skill：`loom-handoff`
+- 验证日期：`2026-04-16`
+- 对应 Loom issue：`#88`
+- 子 issue：`#89`、`#90`、`#91`
+
+## 2. 验证样本
+
+- Demo 仓库：`examples/new-project`
+- 复杂既有仓库：`/Users/mc/dev/hotcp`
+
+## 3. 显式触发验证
+
+执行：
+
+- `python3 tools/loom_init.py route --target examples/new-project --skill loom-handoff`
+
+期望：
+
+- 返回 `result: pass`
+- `selected_skill` 为 `loom-handoff`
+- 不被误路由到 `loom-resume`、`loom-retire` 或其他场景
+
+## 4. 隐式路由验证
+
+执行：
+
+- `python3 tools/loom_init.py route --target examples/new-project --task "请准备交接当前事项并回写停点"`
+
+期望：
+
+- 返回 `result: pass`
+- `selected_skill` 为 `loom-handoff`
+- `matched_signals` 能解释命中 handoff 场景
+
+## 5. 下游消费验证
+
+执行：
+
+- `python3 tools/loom_flow.py flow handoff --target examples/new-project --item INIT-0001`
+- `python3 tools/loom_check.py`
+
+结论：
+
+- `flow handoff` 固定按 `fact-chain -> state-check -> workspace-locate` 顺序编排
+- 输出会稳定给出 `recovery_entry`、`status_surface`、`current_stop`、`next_step`、`blockers`、`latest_validation_summary`、`fallback_target`
+- 该 flow 只生成最小回写清单与定位，不直接回写任何 authored 载体
+
+## 6. 关闭依据
+
+- `loom-handoff` 已从 skeleton 提升为正式场景入口
+- 显式触发、隐式路由与 `flow handoff` 下游消费均已有验证记录
+- gate 已把 `flow handoff` 的最小 JSON 语义纳入机械校验

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -18,7 +18,7 @@
 | `pre-review`（统一高频入口） | `python3 tools/loom_flow.py flow pre-review --target <repo> [--item <id>]` | fact-chain + state-check + runtime evidence + admission + workspace locate | `pass` / `block` / `fallback` | 第一版聚焦 review 前高频检查流 |
 | `checkpoint` | `python3 tools/loom_flow.py checkpoint <admission\\|build\\|merge> --target <repo> [--item <id>]` | fact-chain + purity + merge 放行材料 | `pass` / `block` / `fallback` | `merge` 可额外消费 PR 模板 |
 | `resume` | `python3 tools/loom_flow.py flow resume --target <repo> [--item <id>]` | fact-chain + state-check + workspace locate + recovery 的 `next_step` / `blockers` / `checkpoint` | `pass` / `block` | 只输出恢复摘要，不回写任何载体 |
-| `handoff` | 恢复主入口回写 + 状态面同步 | 当前停点/下一步/阻断项/验证摘要 | 可移交的恢复状态 | 不新增第二套 authored 状态 |
+| `handoff` | `python3 tools/loom_flow.py flow handoff --target <repo> [--item <id>]` | fact-chain + state-check + workspace locate + recovery/status locator + handoff writeback fields | `pass` / `block` | 只输出最小回写清单与载体定位，不直接写 authored 状态 |
 | `review` | `spec_review` / `code_review` + merge checkpoint 输入 | 最小必要上下文 + 前置检查结果 | `allow` / `block` / `fallback` | reviewer 负责语义判断，脚本负责机械判断 |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
 | `retire` | `python3 tools/loom_flow.py workspace retire --target <repo> --item <id>` | cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 不默认删除现场目录 |

--- a/skills/loom-handoff/SKILL.md
+++ b/skills/loom-handoff/SKILL.md
@@ -11,6 +11,12 @@ description: 负责交接当前事项。Use when Codex needs to prepare a handof
 
 - `python3 tools/loom_flow.py flow handoff --target <repo> [--item <id>]`
 
+执行要求：
+
+- 只读取现有事实链、状态检查和现场定位结果
+- 只输出 handoff 所需的最小回写清单与载体定位
+- 不直接写 recovery entry、status surface 或其他 authored 载体
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-handoff/agents/openai.yaml
+++ b/skills/loom-handoff/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Loom Handoff"
   short_description: "生成交接前最小回写清单"
-  default_prompt: "读取当前 Loom 事项状态，输出 handoff 所需的最小回写清单和定位信息。"
+  default_prompt: "读取当前 Loom 事项状态，只输出 handoff 所需的最小回写清单和定位信息，不直接回写任何 authored 载体。"

--- a/skills/loom-handoff/contract.json
+++ b/skills/loom-handoff/contract.json
@@ -21,13 +21,23 @@
   "output_contract": {
     "reference": "references/output-contract.md",
     "required_sections": [
+      "item",
+      "result",
+      "summary",
+      "missing_inputs",
+      "fallback_to",
+      "workspace",
+      "checkpoint",
+      "state_check",
+      "steps",
       "recovery_entry",
       "status_surface",
       "current_stop",
       "next_step",
       "blockers",
       "latest_validation_summary",
-      "fallback_target"
+      "fallback_target",
+      "writeback_fields"
     ]
   },
   "routing": {

--- a/skills/loom-handoff/references/output-contract.md
+++ b/skills/loom-handoff/references/output-contract.md
@@ -1,11 +1,40 @@
 # Loom Handoff Output Contract
 
-输出至少需要给出：
+输出固定为 handoff 摘要 JSON，至少需要给出：
 
-- recovery entry
-- status surface
-- current stop
-- next step
-- blockers
-- latest validation summary
-- not ready 时的 fallback target
+- `item`
+  - 当前事项编号、目标、范围、执行路径
+- `result`
+  - `pass` 或 `block`
+- `summary`
+  - 对当前 handoff 可移交状态的单句结论
+- `missing_inputs`
+  - 当前仍需补齐的阻断项；无阻断时为空数组
+- `fallback_to`
+  - 若当前状态不适合直接移交，应回退到哪个 checkpoint；无回退时为 `null`
+- `workspace`
+  - `workspace_entry`、解析后的现场路径、现场是否存在
+- `checkpoint`
+  - 原始 checkpoint 文本与归一化后的 checkpoint
+- `state_check`
+  - `state-check` 的结果、摘要、阻断项与检查分项
+- `recovery_entry`
+  - 当前 recovery entry 的定位字符串
+- `status_surface`
+  - 当前 status surface 的定位字符串
+- `current_stop`
+  - 当前执行停点，供交接前回写
+- `next_step`
+  - 下一个执行动作，供交接前回写
+- `blockers`
+  - 当前阻断项，供交接前回写
+- `latest_validation_summary`
+  - 最近验证摘要，供交接前回写
+- `fallback_target`
+  - 若当前未准备好移交，应优先回退到的目标；无回退时为 `null`
+- `writeback_fields`
+  - 固定为 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- `steps`
+  - 固定按 `fact-chain -> state-check -> workspace-locate` 顺序列出
+
+这个 skill 只生成回写清单和定位，不直接写文件，也不创建新的 authored 真相源。

--- a/tools/loom_check.py
+++ b/tools/loom_check.py
@@ -793,6 +793,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             {"pass"},
         ),
         (
+            "flow-handoff",
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "flow",
+                "handoff",
+                "--target",
+                "examples/new-project",
+                "--item",
+                "INIT-0001",
+            ],
+            {"pass", "block"},
+        ),
+        (
             "admission",
             ["python3", "tools/loom_flow.py", "checkpoint", "admission", "--target", "examples/new-project", "--item", "INIT-0001"],
             {"pass"},
@@ -893,6 +907,71 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+        if label == "flow-handoff":
+            if payload.get("command") != "flow":
+                failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
+            if payload.get("operation") != "handoff":
+                failures.append(Failure("daily-execution-cli", "`flow handoff` must report `operation: handoff`"))
+            if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+                failures.append(Failure("daily-execution-cli", "`flow handoff` must include a non-empty `summary`"))
+            if not isinstance(payload.get("missing_inputs"), list):
+                failures.append(Failure("daily-execution-cli", "`flow handoff` must include `missing_inputs`"))
+            if payload.get("fallback_to") not in {None, "admission"}:
+                failures.append(Failure("daily-execution-cli", "`flow handoff` fallback must be `null` or `admission`"))
+            for key in (
+                "item",
+                "workspace",
+                "checkpoint",
+                "state_check",
+            ):
+                if not isinstance(payload.get(key), dict):
+                    failures.append(Failure("daily-execution-cli", f"`flow handoff` must include `{key}`"))
+            for key in (
+                "recovery_entry",
+                "status_surface",
+                "current_stop",
+                "next_step",
+                "blockers",
+                "latest_validation_summary",
+            ):
+                value = payload.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure("daily-execution-cli", f"`flow handoff` must include non-empty `{key}`"))
+            if payload.get("fallback_target") not in {None, "admission"}:
+                failures.append(Failure("daily-execution-cli", "`flow handoff` fallback_target must be `null` or `admission`"))
+            writeback_fields = payload.get("writeback_fields")
+            if writeback_fields != [
+                "current_stop",
+                "next_step",
+                "blockers",
+                "latest_validation_summary",
+            ]:
+                failures.append(
+                    Failure(
+                        "daily-execution-cli",
+                        "`flow handoff` must report the stable writeback field list in order",
+                    )
+                )
+            steps = payload.get("steps")
+            if not isinstance(steps, list):
+                failures.append(Failure("daily-execution-cli", "`flow handoff` must include `steps`"))
+                continue
+            step_names = [step.get("name") for step in steps if isinstance(step, dict)]
+            if step_names != ["fact-chain", "state-check", "workspace-locate"]:
+                failures.append(
+                    Failure(
+                        "daily-execution-cli",
+                        "`flow handoff` must run fact-chain, state-check, and workspace-locate in order",
+                    )
+                )
+            state_check = payload.get("state_check")
+            if isinstance(state_check, dict):
+                if state_check.get("result") not in {"pass", "block"}:
+                    failures.append(
+                        Failure("daily-execution-cli", "`flow handoff` state_check.result must be `pass` or `block`")
+                    )
+                if not isinstance(state_check.get("checks"), dict):
+                    failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -119,7 +119,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
 
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
-    flow.add_argument("operation", choices=("pre-review", "resume"))
+    flow.add_argument("operation", choices=("pre-review", "resume", "handoff"))
     flow.add_argument("--target", required=True, help="Target repository root")
     flow.add_argument("--item", help="Expected current item id")
     flow.add_argument(
@@ -1222,7 +1222,7 @@ def handle_flow(args: argparse.Namespace) -> int:
             }
         )
 
-    if args.operation not in {"pre-review", "resume"}:
+    if args.operation not in {"pre-review", "resume", "handoff"}:
         return emit(
             {
                 "command": "flow",
@@ -1270,7 +1270,7 @@ def handle_flow(args: argparse.Namespace) -> int:
         }
     )
 
-    if args.operation == "resume":
+    if args.operation in {"resume", "handoff"}:
         steps.append(locate_step)
     else:
         runtime_fields, runtime_missing = runtime_evidence_from_report(context["report"])
@@ -1321,6 +1321,12 @@ def handle_flow(args: argparse.Namespace) -> int:
             if result == "pass"
             else "resume flow rebuilt context but found blocking signals before execution can continue."
         )
+    elif args.operation == "handoff":
+        summary = (
+            "handoff flow produced the minimum writeback checklist and locator set."
+            if result == "pass"
+            else "handoff flow produced the minimum writeback checklist, but blocking signals remain before transfer."
+        )
     else:
         summary = (
             "pre-review flow is ready to proceed."
@@ -1356,13 +1362,6 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "path": locate_payload["workspace"]["path"],
                         "exists": locate_payload["workspace"]["exists"],
                     },
-                    "recovery": {
-                        "path": locate_payload["recovery"]["path"],
-                        "current_stop": locate_payload["recovery"]["current_stop"],
-                        "next_step": context["next_step"],
-                        "blockers": context["blockers"],
-                        "latest_validation_summary": context["latest_validation_summary"],
-                    },
                     "checkpoint": {
                         "raw": context["current_checkpoint_raw"],
                         "normalized": context["current_checkpoint"],
@@ -1375,7 +1374,39 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "checks": state_payload["checks"],
                     },
                 }
+                if args.operation in {"resume", "handoff"}
+                else {}
+            ),
+            **(
+                {
+                    "recovery": {
+                        "path": locate_payload["recovery"]["path"],
+                        "current_stop": locate_payload["recovery"]["current_stop"],
+                        "next_step": context["next_step"],
+                        "blockers": context["blockers"],
+                        "latest_validation_summary": context["latest_validation_summary"],
+                    },
+                }
                 if args.operation == "resume"
+                else {}
+            ),
+            **(
+                {
+                    "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
+                    "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
+                    "current_stop": context["current_stop"],
+                    "next_step": context["next_step"],
+                    "blockers": context["blockers"],
+                    "latest_validation_summary": context["latest_validation_summary"],
+                    "fallback_target": fallback_to,
+                    "writeback_fields": [
+                        "current_stop",
+                        "next_step",
+                        "blockers",
+                        "latest_validation_summary",
+                    ],
+                }
+                if args.operation == "handoff"
                 else {}
             ),
         }


### PR DESCRIPTION
## Summary
- add `python3 tools/loom_flow.py flow handoff` as the stable handoff aggregation entry
- align `skills/loom-handoff` contracts with the handoff JSON output
- extend `loom_check` and adoption records for handoff validation

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_check.py`
- `make loom-demo-new-project`
- `python3 tools/loom_flow.py flow handoff --target examples/new-project --item INIT-0001`
- `python3 tools/loom_check.py`

Closes #88
Closes #89
Closes #90
Closes #91
