### PR TITLE
fix: 对齐 loom-check 与 demo 资产初始化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: loom-check check loom-demo-new-project
 
-loom-check:
+loom-check: loom-demo-new-project
 	python3 tools/loom_check.py
 
 check: loom-check


### PR DESCRIPTION
## Summary
- make `loom-check` generate demo repository assets before running `tools/loom_check.py`
- align the CI gate with the repository test plan sequence
- remove the clean-runner failure where `examples/new-project/.loom/bin/*` was missing

## Validation
- `python3 tools/loom_check.py`
- `make loom-check`
