### PR TITLE
feat: 完成 loom-retire 场景入口

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -23,6 +23,7 @@
 - 场景 skill `loom-resume` 验证：[validation-skill-loom-resume.md](./validation-skill-loom-resume.md)
 - 场景 skill `loom-pre-review` 验证：[validation-skill-loom-pre-review.md](./validation-skill-loom-pre-review.md)
 - 场景 skill `loom-handoff` 验证：[validation-skill-loom-handoff.md](./validation-skill-loom-handoff.md)
+- 场景 skill `loom-retire` 验证：[validation-skill-loom-retire.md](./validation-skill-loom-retire.md)
 - 事实链消费验证：[validation-fact-chain-mail-listener.md](./validation-fact-chain-mail-listener.md)
 - checkpoint 链路复验：[validation-checkpoints-hotcp.md](./validation-checkpoints-hotcp.md)
 - 运行时证据复验：[validation-runtime-evidence-hotcp.md](./validation-runtime-evidence-hotcp.md)

--- a/adoption/README.md
+++ b/adoption/README.md
@@ -21,6 +21,7 @@
 - 复杂既有仓库真实验证：[validation-hotcp.md](./validation-hotcp.md)
 - 场景 skill `loom-adopt` 验证：[validation-skill-loom-adopt.md](./validation-skill-loom-adopt.md)
 - 场景 skill `loom-resume` 验证：[validation-skill-loom-resume.md](./validation-skill-loom-resume.md)
+- 场景 skill `loom-retire` 验证：[validation-skill-loom-retire.md](./validation-skill-loom-retire.md)
 - 事实链消费验证：[validation-fact-chain-mail-listener.md](./validation-fact-chain-mail-listener.md)
 - checkpoint 链路复验：[validation-checkpoints-hotcp.md](./validation-checkpoints-hotcp.md)
 - 运行时证据复验：[validation-runtime-evidence-hotcp.md](./validation-runtime-evidence-hotcp.md)

--- a/adoption/validation-skill-loom-retire.md
+++ b/adoption/validation-skill-loom-retire.md
@@ -1,0 +1,59 @@
+# Skill Validation: `loom-retire`
+
+## 1. 样本标识
+
+- 场景 skill：`loom-retire`
+- 验证日期：`2026-04-16`
+- 对应 Loom issue：`#92`
+- 子 issue：`#93`、`#94`、`#95`
+
+## 2. 验证样本
+
+- Demo 仓库：`examples/new-project`
+- checkpoint-lite 样本：`/Users/mc/dev/mail-listener`
+- 可运行样本：`/Users/mc/dev/hotcp`
+
+## 3. 显式触发验证
+
+执行：
+
+- `python3 tools/loom_init.py route --target examples/new-project --skill loom-retire`
+
+期望：
+
+- 返回 `result: pass`
+- `selected_skill` 为 `loom-retire`
+- 不被误路由到 `loom-handoff` 或 `loom-merge-ready`
+
+## 4. 隐式路由验证
+
+执行：
+
+- `python3 tools/loom_init.py route --target examples/new-project --task "请清理现场并 retire 当前事项"`
+
+期望：
+
+- 返回 `result: pass`
+- `selected_skill` 为 `loom-retire`
+- `matched_signals` 能解释命中 retire 场景
+
+## 5. 下游消费验证
+
+执行：
+
+- `python3 tools/loom_flow.py purity-check --target examples/new-project --item INIT-0001`
+- `python3 tools/loom_flow.py workspace cleanup --target examples/new-project --item INIT-0001`
+- `python3 tools/loom_flow.py workspace retire --target examples/new-project --item INIT-0001`
+- `python3 tools/loom_check.py`
+
+结论：
+
+- `loom-retire` 默认先解释前置条件，再按 `purity-check -> workspace cleanup -> workspace retire` 顺序执行
+- `cleanup` 只清理 Loom 自己产生的残留，遇到无关脏改动不会自动丢弃用户变更
+- `retire` 会把恢复主入口回写到终态 `current_checkpoint: retired`，但不默认删除现场目录
+
+## 6. 关闭依据
+
+- `loom-retire` 已从 skeleton 提升为正式场景入口
+- 显式触发、隐式路由与 retire 链路消费均已有验证记录
+- gate 已复用既有 `purity-check` / `workspace cleanup` / `workspace retire` 入口做机械校验

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -21,7 +21,7 @@
 | `handoff` | 恢复主入口回写 + 状态面同步 | 当前停点/下一步/阻断项/验证摘要 | 可移交的恢复状态 | 不新增第二套 authored 状态 |
 | `review` | `spec_review` / `code_review` + merge checkpoint 输入 | 最小必要上下文 + 前置检查结果 | `allow` / `block` / `fallback` | reviewer 负责语义判断，脚本负责机械判断 |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
-| `retire` | `python3 tools/loom_flow.py workspace retire --target <repo> --item <id>` | cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 不默认删除现场目录 |
+| `retire` | `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]` -> `workspace cleanup` -> `workspace retire` | purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录 |
 
 ## 2. 分层边界
 

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -21,7 +21,7 @@
 | `handoff` | `python3 tools/loom_flow.py flow handoff --target <repo> [--item <id>]` | fact-chain + state-check + workspace locate + recovery/status locator + handoff writeback fields | `pass` / `block` | 只输出最小回写清单与载体定位，不直接写 authored 状态 |
 | `review` | `spec_review` / `code_review` + merge checkpoint 输入 | 最小必要上下文 + 前置检查结果 | `allow` / `block` / `fallback` | reviewer 负责语义判断，脚本负责机械判断 |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
-| `retire` | `python3 tools/loom_flow.py workspace retire --target <repo> --item <id>` | cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 不默认删除现场目录 |
+| `retire` | `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]` -> `workspace cleanup` -> `workspace retire` | purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录 |
 
 ## 2. 分层边界
 

--- a/skills/loom-retire/SKILL.md
+++ b/skills/loom-retire/SKILL.md
@@ -13,6 +13,12 @@ description: 负责清理并退休当前事项现场。Use when Codex needs to c
 - `python3 tools/loom_flow.py workspace cleanup --target <repo> --item <id>`
 - `python3 tools/loom_flow.py workspace retire --target <repo> --item <id>`
 
+执行要求：
+
+- 默认先解释 retire 前置条件，再按 `purity-check -> workspace cleanup -> workspace retire` 顺序执行
+- 不自动丢弃用户改动，不默认删除现场目录
+- 退休完成后，以 recovery 主入口的 `current_checkpoint: retired` 作为终态依据
+
 输入信号与输出合同见：
 
 - [references/input-signals.md](./references/input-signals.md)

--- a/skills/loom-retire/contract.json
+++ b/skills/loom-retire/contract.json
@@ -21,10 +21,12 @@
   "output_contract": {
     "reference": "references/output-contract.md",
     "required_sections": [
+      "preconditions",
       "purity_result",
       "cleanup_result",
       "retire_result",
-      "final_checkpoint"
+      "final_checkpoint",
+      "workspace_policy"
     ]
   },
   "routing": {

--- a/skills/loom-retire/references/output-contract.md
+++ b/skills/loom-retire/references/output-contract.md
@@ -2,7 +2,9 @@
 
 输出至少需要给出：
 
-- 纯度判断
-- cleanup 结果
-- retire 结果
-- 最终 checkpoint
+- retire 前置条件说明
+- `purity-check` 的结果
+- `workspace cleanup` 的结果
+- `workspace retire` 的结果
+- 最终 checkpoint，固定以 `retired` 为终态
+- 现场策略说明：不自动丢弃用户改动，不默认删除目录


### PR DESCRIPTION
## Summary
- 将 `loom-retire` 补成正式场景 skill，明确 retire 前置条件、链路和输出合同
- 复用既有 `purity-check`、`workspace cleanup`、`workspace retire`，不新增新 CLI
- 新增 `adoption/validation-skill-loom-retire.md`，并更新日常入口矩阵与 adoption 索引

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_check.py`
- `python3 tools/loom_init.py route --target examples/new-project --skill loom-retire`
- `python3 tools/loom_init.py route --target examples/new-project --task "请清理并 retire 当前事项现场"`
- `python3 tools/loom_flow.py workspace retire --target examples/new-project --item INIT-0001`
- `make loom-demo-new-project`
- `python3 tools/loom_check.py`

Closes #92
Closes #93
Closes #94
Closes #95