### PR TITLE
docs: 收敛场景 skills 发布与升级说明

### DIFF
--- a/adoption/execution-entry-compatibility.md
+++ b/adoption/execution-entry-compatibility.md
@@ -10,33 +10,39 @@
 
 | 层级 | 稳定入口 | 兼容承诺 |
 | --- | --- | --- |
-| 初始化与基础验证 | `loom_init bootstrap/verify/fact-chain` | 继续保留，不被 `loom_flow` 替换 |
+| root 入口与基础验证 | `loom_init bootstrap/verify/fact-chain/route` | `loom-init` 继续作为唯一 root entry，路由能力不替代底层 CLI |
 | 日常读取与检查 | `loom_flow fact-chain/runtime-evidence/state-check` | 输出保持 JSON 结果语义（`result/summary/missing_inputs/fallback_to`） |
 | checkpoint 执行 | `loom_flow checkpoint admission/build/merge` | 三阶段语义与回退关系保持不变 |
 | 现场与纯度治理 | `loom_flow workspace <create/locate/cleanup/retire>` + `purity-check` | 生命周期动作与失败语义保持不变 |
-| 高频组合入口 | `loom_flow flow pre-review` | 第一版聚合入口，不破坏单命令入口 |
+| 高频组合入口 | `loom_flow flow pre-review/resume/handoff/merge-ready` | 聚合入口扩张不破坏单命令入口，统一保持 JSON 结果语义 |
+| 场景 skills | `loom-adopt/resume/pre-review/handoff/retire/merge-ready` | 场景 skill 只做入口编排，不新增第二套事实真相源 |
 
 ## 2. 升级策略
 
 - 升级优先“加入口，不改旧入口语义”
-- 新增聚合入口（如 `flow pre-review`）不替换单命令入口
+- 新增聚合入口（如 `flow pre-review`、`flow merge-ready`）不替换单命令入口
+- 新增场景 skill 入口不替代 `loom-init` 的 root 身份，只补显式入口与隐式路由
 - gate 与 verify 始终复用同一 CLI，不维护第二套检查命令
 
 ## 3. 可复验操作流
 
 在样本副本中按以下顺序执行：
 
-1. `loom_init verify`
-2. `loom_flow fact-chain`
-3. `loom_flow runtime-evidence`
-4. `loom_flow state-check`
-5. `loom_flow flow pre-review`
-6. `loom_flow checkpoint admission/build/merge`
-7. `loom_flow workspace locate`
+1. `loom_init route`
+2. `loom_init verify`
+3. `loom_flow fact-chain`
+4. `loom_flow runtime-evidence`
+5. `loom_flow state-check`
+6. `loom_flow flow resume`
+7. `loom_flow flow pre-review`
+8. `loom_flow flow handoff`
+9. `loom_flow flow merge-ready`
+10. `loom_flow checkpoint admission/build/merge`
+11. `loom_flow workspace locate/cleanup/retire`
 
 预期：
 
-- 前 1-5 步提供“可继续执行/需阻断”的统一前置判断
+- 前 1-9 步提供“该进入哪个入口/可继续执行/需阻断/是否应回退”的统一判断
 - merge 阶段可按状态返回 `fallback`，而不是伪装成通过
 - 操作流既可拆分执行，也可通过聚合入口执行高频路径
 
@@ -44,9 +50,10 @@
 
 基于 `mail-listener`、`hotcp`、`loom-adoption-new-project` 的临时副本复验：
 
+- `route`：显式 skill 命中与隐式信号命中均可复验
 - `verify`：均返回 `ok: true`
 - `fact-chain/runtime-evidence/state-check`：均可读
-- `flow pre-review`：均可返回稳定 JSON 结果
+- `flow resume/pre-review/handoff/merge-ready`：均可返回稳定 JSON 结果
 - `checkpoint merge` 在当前样本阶段按预期返回 `fallback`
 
-因此，下游仓库可以按统一入口消费完整执行内核，不再依赖手工拼接散落流程说明。
+因此，下游仓库可以按 root skill 或显式场景 skill 消费完整执行内核，不再依赖手工拼接散落流程说明。

--- a/adoption/upstream-delivery-surface.md
+++ b/adoption/upstream-delivery-surface.md
@@ -15,10 +15,10 @@
 - `templates/`
   - 最小正式规约模板与最小 PR 模板
 - `skills/`
-  - 稳定入口合同与 `loom-init` 的输入 / 输出合同
+  - 稳定入口合同、`loom-init` root 路由、6 个场景 skills、`registry.json`、`upgrade-contract.json` 与 `route-matrix.md`
 - `adoption/`
   - 稳定 adoption 路径、经验回流、验证记录合同、版本化与升级路径
-  - 执行入口兼容说明与完整执行内核复验记录
+  - 执行入口兼容说明、6 个场景 skill 验证记录与完整执行内核复验记录
 - 发布说明
   - `docs/complete-kernel-release.md`
 
@@ -42,7 +42,7 @@ Loom 对下游交付的对象不是单个文件，而是以下组合：
 
 - 一组稳定规则真相
 - 一组最小模板
-- 一组可升级的入口合同
+- 一组可升级的入口合同与 root/scene 路由入口
 - 一组 adoption / upgrade 说明
 
 下游不应被要求复制候选材料，才能消费 Loom 的核心能力。

--- a/adoption/versioning-and-upgrades.md
+++ b/adoption/versioning-and-upgrades.md
@@ -85,6 +85,13 @@ Loom 采用语义版本：
 
 - `bootstrap/root contract` 的最小职责变化
 - 安装、发现、升级、版本识别或 adapter 失败可见性合同变化
+- `root_entry`、多 entry registry、隐式路由优先级或场景 skill 角色合同变化
+
+以下变化通常构成 `minor`：
+
+- 新增稳定场景 skill
+- 新增不破坏兼容的聚合 flow，并被场景 skill 正式消费
+- `skills/registry.json` 增加可发现 entry，但不改变既有 entry 的最小职责
 
 ### 5.5 `adoption`
 
@@ -114,7 +121,37 @@ Loom 采用语义版本：
 
 `skills` 的安装、发现、升级与 adapter 合同，由 [../skills/distribution-and-adapter-contract.md](../skills/distribution-and-adapter-contract.md) 承接。
 
-当前仓库中，`skills/upgrade-contract.json` 承接最小机读升级协议；它不替代本文的版本对象定义，只负责把显式升级与版本可见性落成可读取工件。
+当前仓库中：
+
+- `skills/registry.json`
+  - 承接 root entry、场景 entry、角色与合同版本的机读声明
+- `skills/upgrade-contract.json`
+  - 承接最小机读升级协议，声明宿主必须重新读取 `registry/manifest/executable/referenced_resources`
+
+它们不替代本文的版本对象定义，只负责把显式升级与版本可见性落成可读取工件。
+
+## 8. 场景 SKILLS 第一波的升级语义
+
+第一波稳定场景 skills 为：
+
+- `loom-adopt`
+- `loom-resume`
+- `loom-pre-review`
+- `loom-handoff`
+- `loom-retire`
+- `loom-merge-ready`
+
+这一波属于 `minor` 升级，原因是：
+
+- `loom-init` 仍保留唯一 root entry 身份
+- 既有 `bootstrap/verify/fact-chain` 语义未被破坏
+- 新增的是显式场景入口、root 隐式路由与聚合 flow，而不是替换旧入口
+
+下游升级时至少应确认：
+
+- 宿主能重新发现 7 个已注册 entries
+- 宿主知道 `loom-init route` 与 6 个显式场景 skill 的入口关系
+- 宿主刷新 `registry/manifest/executable/referenced_resources`
 
 本文只定义版本对象与升级说明格式，不重复宿主适配细节。
 

--- a/docs/complete-kernel-release.md
+++ b/docs/complete-kernel-release.md
@@ -1,8 +1,8 @@
 # Complete Kernel Release (2026-04-16)
 
-本文是 Loom 完整执行内核的上游发布与升级说明。
+本文是 Loom 完整执行内核与第一波场景 SKILLS 的上游发布与升级说明。
 
-对应 Loom issue：`#63`
+对应 Loom issue：`#63`、`#71`
 
 ## 1. 已发布的稳定能力面
 
@@ -11,6 +11,10 @@
 - 单一事实链读取与一致性校验
   - `loom_init fact-chain`
   - `loom_flow fact-chain`
+- root + 场景 SKILLS 入口层
+  - root entry：`loom-init`
+  - 场景 skills：`loom-adopt`、`loom-resume`、`loom-pre-review`、`loom-handoff`、`loom-retire`、`loom-merge-ready`
+  - 路由与升级工件：`skills/registry.json`、`skills/upgrade-contract.json`、`skills/route-matrix.md`
 - 三类 checkpoint 工程化入口
   - `loom_flow checkpoint admission|build|merge`
 - workspace 生命周期与纯度治理入口
@@ -21,6 +25,9 @@
 - 活跃状态/完整性检查与高频统一入口
   - `loom_flow state-check`
   - `loom_flow flow pre-review`
+  - `loom_flow flow resume`
+  - `loom_flow flow handoff`
+  - `loom_flow flow merge-ready`
 - gate 入口
   - `loom_check`
   - `loom_init verify`
@@ -30,15 +37,17 @@
 ### 2.1 新项目
 
 1. `loom_init bootstrap --write --verify`
-2. 使用 `fact-chain/state-check/flow pre-review` 建立日常读取与前置检查
-3. 按 checkpoint 链路推进（admission -> build -> merge）
+2. 让 root entry 或显式 skill 调用把执行者路由到正确场景
+3. 使用 `fact-chain/state-check/flow resume|pre-review|merge-ready` 建立日常读取、恢复、review 前检查与 merge 前放行
+4. 按 checkpoint 链路推进（admission -> build -> merge）
 
 ### 2.2 既有仓库（轻量到完整）
 
 1. 先接入 `bootstrap + verify + fact-chain`
 2. 接入 `checkpoint` 与 `workspace` 入口
-3. 接入 `runtime-evidence` 与 `state-check`
+3. 接入 `runtime-evidence`、`state-check` 与 3 个聚合 flow：`resume` / `handoff` / `merge-ready`
 4. 在 review 前统一走 `flow pre-review`
+5. 让宿主刷新 `skills/registry.json`、`skills/upgrade-contract.json`、skill manifests 与引用资源
 
 ### 2.3 兼容原则
 
@@ -52,6 +61,7 @@
 
 本次发布前已完成以下复验并回写到版本控制：
 
+- 6 个场景 skill 的显式触发、隐式路由与下游消费验证
 - 事实链复验：`mail-listener`
 - checkpoint 复验：`hotcp`
 - 运行时证据复验：`hotcp`
@@ -63,6 +73,8 @@
 
 ## 4. 发布后操作建议
 
-- 下游仓库先执行 `verify + flow pre-review`，再进入 review/merge
+- 下游仓库先执行 `verify`，再通过 root route 或显式 skill 调用进入对应场景
+- 日常恢复优先走 `flow resume`，交接优先走 `flow handoff`，merge 前统一走 `flow merge-ready`
+- review 前仍先执行 `flow pre-review`，再进入语义 review 或 merge
 - 如遇 `state-check` 或 `checkpoint` 阻断，先回退补齐事实链/范围/证据，不要绕过入口
 - 仅在宿主适配层补平台细节，避免反向污染 Loom 内核合同


### PR DESCRIPTION
## Summary
- 补齐第一波场景 skills 的发布说明，把 root entry、6 个场景 skill 和 3 个聚合 flow 写入正式发布面
- 对齐执行入口兼容、上游交付面与版本升级文档中的 root/scene 路由与 multi-entry 升级语义
- 保持主干 gate、验证记录和 release truth 一致

## Validation
- \loom_check: OK (/Users/mc/dev/Loom)
checked 13 surfaces

Refs #71