### PR TITLE
docs: 收敛 #175 #176 issue 与宿主绑定合同

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -11,6 +11,8 @@
 
 当前承接的核心条目：
 
+- [issue-model.md](./issue-model.md)
+  - `#175`
 - [principles.md](./principles.md)
   - `EXT-0001` `EXT-0002` `EXT-0006` `EXT-0023`
 - [review-model.md](./review-model.md)

--- a/governance/host-object-taxonomy.md
+++ b/governance/host-object-taxonomy.md
@@ -62,6 +62,8 @@ Loom 当前固定四类对象：
 
 例如：
 
+- `active execution issue`
+  - 指当前被选为宿主执行对象的 issue，而不是 `work item`
 - `host merge`
   - 指宿主平台真正执行的 merge
 - `host branch`
@@ -113,6 +115,8 @@ Loom 当前固定以下命名规则：
   - 只表示 Loom 执行现场，不等于 `git worktree`
 - `git worktree`
   - 只表示 Git 宿主对象
+- issue activation
+  - 只表示宿主 issue 已进入当前执行，不等于 `work-item --activate`
 - `review record`
   - 只表示正式 review 真相
 - `PR`

--- a/governance/issue-model.md
+++ b/governance/issue-model.md
@@ -1,0 +1,127 @@
+# Issue Model
+
+本文件定义 Loom 2.0 当前稳定的执行型 issue 模型。
+
+本文件当前承接：
+
+- `#175`
+
+## 1. 文档定位
+
+本文件只回答四件事：
+
+- Loom 当前如何区分不同类型的 issue
+- 哪些 issue 可以作为执行对象进入活跃推进
+- parent / child issue 在 closeout 中各自承担什么角色
+- `absorbed` 这类结论如何被消费
+
+事项成熟度状态由 [state-machine.md](./state-machine.md) 承接。
+成熟度与关闭总原则由 [maturity-and-closing.md](./maturity-and-closing.md) 承接。
+宿主对象命名由 [host-object-taxonomy.md](./host-object-taxonomy.md) 承接。
+`active issue` 与 host branch / `git worktree` / PR / merge commit 的绑定证明见 [../harness/host-issue-binding.md](../harness/host-issue-binding.md)。
+
+## 2. 稳定 issue 类型
+
+Loom 当前固定三类 issue：
+
+- `spec / planning issue`
+  - 用于冻结目标、范围、方案、拆分或阶段判断
+  - 不是默认执行对象
+- `active execution issue`
+  - 用于承接当前真实实施缺口
+  - 是默认执行对象
+- `validation / closeout issue`
+  - 用于承接验证、对账、收口或主干真相同步
+  - 只在实现主体已基本完成、但仍存在独立收口工作时使用
+
+这三类是 Loom 对 issue 的稳定语义分类，不要求宿主平台直接提供同名字段。
+
+## 3. parent / child 语义
+
+在 issue tree 中：
+
+- parent issue
+  - 默认是范围、阶段或收口容器
+  - 不默认等于当前活跃执行对象
+- child issue
+  - 默认承接可独立推进的真实执行缺口
+  - 是否激活取决于是否已经进入当前轮次实施
+
+稳定约束：
+
+- 不得把历史规划 parent 长期冒充活跃执行 issue
+- 不得把尚未进入实施的 child issue 提前写成进行中
+- 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
+
+## 4. 激活规则
+
+### 4.1 issue 级激活
+
+issue 级激活表示：
+
+- 该 issue 已被选为当前轮次要推进的宿主执行对象
+- 它应在宿主控制面上体现为进行中或等价语义
+- 后续证据、PR、review 或 closeout 应围绕该 issue 建立一致关系
+
+issue 未被激活时，可以继续存在于 tree 中，但默认保持 `Todo` 或等价未开始语义。
+
+### 4.2 `work-item --activate`
+
+`work-item --activate` 表示：
+
+- Loom 执行现场把某个 `work item` 切换为当前 locator truth
+- 当前轮次恢复、停点与执行入口开始指向该 `work item`
+
+它不等于：
+
+- 自动激活对应 issue
+- 自动改变宿主 project / issue 状态
+- 自动宣称事项成熟度已进入下一阶段
+
+换句话说：
+
+- issue 级激活是宿主执行对象语义
+- `work-item --activate` 是 Loom 执行入口语义
+
+两者通常相关，但必须明确区分，不得互相偷换。
+
+## 5. 关闭与收口角色
+
+issue closeout 仍以 [state-machine.md](./state-machine.md) 的 `closed_out` 为前提。
+
+在 issue tree 中：
+
+- child issue
+  - 关闭取决于该 child 自身缺口是否已进入主干并完成收口
+- parent issue
+  - 关闭取决于其应消费的 child closeout 是否已经完成，且 parent 自身不再保留真实剩余缺口
+
+因此：
+
+- parent 可以作为收口容器消费多个 child 的 closeout 结果
+- child 不应因为 parent 仍 open 就被阻止关闭
+- parent 也不应因为某个 child 曾经被规划过就长期保持失真 open
+
+## 6. `absorbed` 的边界
+
+`absorbed` 不是成熟度状态。
+
+它只表示：
+
+- 某个原始 issue 所代表的缺口，已被其他已收敛的执行结果覆盖或吸收
+
+Loom 当前只稳定约束两点：
+
+- `absorbed` 可以被 parent closeout 消费
+- `absorbed` 也可以被 child issue closeout 消费
+
+本文件不定义：
+
+- `absorbed` 需要哪些 host 证明细节
+- 由哪一类宿主证据组合才能判定 `absorbed`
+
+这些证明细节属于具体仓库 closeout 实践，不属于 Loom 当前治理合同。
+
+## 7. 一句话结论
+
+Loom 的 issue 模型目标不是把所有 issue 都变成执行对象，而是稳定区分规划、执行、验证/收口三类语义，并让激活与 closeout 只围绕真实缺口发生。

--- a/governance/maturity-and-closing.md
+++ b/governance/maturity-and-closing.md
@@ -15,6 +15,7 @@
 - 事项何时可以关闭
 
 稳定状态名与转移规则见 [state-machine.md](./state-machine.md)。
+issue 类型、激活规则与 `absorbed` 的消费边界见 [issue-model.md](./issue-model.md)。
 
 ## 2. 成熟度先于关闭
 
@@ -39,6 +40,7 @@
 
 - 当前执行侧入口见 [../harness/closeout-gate.md](../harness/closeout-gate.md)
 - GitHub 与仓内真相如何同步，见 [truth-and-sync-boundary.md](./truth-and-sync-boundary.md)
+- parent / child issue 如何消费 closeout，见 [issue-model.md](./issue-model.md)
 
 ## 5. 规约完成与实现完成的分离语义
 

--- a/governance/state-machine.md
+++ b/governance/state-machine.md
@@ -16,6 +16,7 @@
 
 字段载体与同步边界由 [truth-and-sync-boundary.md](./truth-and-sync-boundary.md) 承接。
 执行侧 closeout 入口由 [../harness/closeout-gate.md](../harness/closeout-gate.md) 承接。
+issue 类型与激活语义由 [issue-model.md](./issue-model.md) 承接。
 
 ## 2. 稳定状态
 
@@ -121,11 +122,14 @@ Loom 当前固定四个成熟度状态：
   - 必须退回前一成熟度状态或前一执行链路
 - `retired`
   - 属于现场或恢复入口的终态，不等于事项已 `closed_out`
+- `absorbed`
+  - 属于 closeout 可消费结论，不等于事项成熟度状态
 
 换句话说：
 
 - `block` / `fallback` 是转移结果
 - `retired` 是执行现场状态
+- `absorbed` 是 closeout 可消费语义
 - 事项成熟度仍只落在四个稳定状态中
 
 ## 6. 关闭语义

--- a/harness/README.md
+++ b/harness/README.md
@@ -25,6 +25,8 @@
   - 定义 `create`、`locate`、`cleanup`、`retire` 与 `purity-check` 的生命周期合同
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 定义 Loom 与宿主 branch / PR / git worktree 生命周期的边界
+- [host-issue-binding.md](./host-issue-binding.md)
+  - 定义 Loom 消费 `active issue` 与 branch / git worktree / PR / merge commit 的绑定合同
 - [recovery-model.md](./recovery-model.md)
   - 定义唯一恢复主入口、`checkpoint`、`resume`、`handoff` 与每轮回写合同
 - [review-execution.md](./review-execution.md)

--- a/harness/closeout-gate.md
+++ b/harness/closeout-gate.md
@@ -21,10 +21,18 @@ closeout gate 用来回答两件事：
 - 本地 gate 结果
 - issue 状态
 - PR 是否已 merged
+- 事项对应实现是否已达到 `absorbed`
 - merged PR 是否已进入 `origin/main`
 - project 中对应 issue 的状态
 
 若这些事实不一致，结果必须返回 `block`。
+
+这里的 `absorbed` 只表示 host merge 后可证明的实现吸收结论，不等于 `closed_out`。
+因此，`closeout check` 至少要能区分：
+
+- 该 issue 已由其对应实现进入 `closed_out`
+- 该 issue 的实现已被其他 merged work `absorbed`，但控制面尚未完成 closeout sync
+- 该 issue 仍保留独立剩余缺口，不能被视为 `absorbed`
 
 ## 4. `sync` 最小动作
 
@@ -33,9 +41,12 @@ closeout gate 用来回答两件事：
 - 在条件满足时关闭 issue
 - 在 project 中把对应 item 状态设为 `Done`
 
+若 parent issue 通过 child issue 的 `closed_out` / `absorbed` 结果完成自身 closeout 判断，`sync` 只负责把这一已成立结论写回控制面，不替代 parent 对剩余缺口的判断。
+
 它不替代：
 
 - PR merge 动作
+- `absorbed` 证明本身
 - review 执行层
 - recovery writeback
 

--- a/harness/fact-chain-contract.md
+++ b/harness/fact-chain-contract.md
@@ -157,3 +157,4 @@ Loom 的执行真相只允许沿一条事实链流动：
 - 若某仓库还停留在 `checkpoint-lite`，也必须明确唯一动态事实承载面
 - 本文件不重复定义字段如何呈现在 Markdown、JSON 或其他载体；只定义谁拥有 authored 权限
 - issue / project / PR / checks 等 host control truth 不在本文件内定义 authored 归属
+- `active issue` 与 branch / `git worktree` / PR / merge commit 的绑定关系只可被本事实链消费，不进入仓内 authored 真相；其最小绑定合同见 [host-issue-binding.md](./host-issue-binding.md)

--- a/harness/host-issue-binding.md
+++ b/harness/host-issue-binding.md
@@ -1,0 +1,90 @@
+# Host Issue Binding
+
+本文件定义 Loom 当前消费 `active issue` 与宿主 branch、`git worktree`、PR、merge commit 之间绑定关系的最小合同。
+
+`active issue` 的主定义不在本文件。
+本文件只承接 Loom 为了执行、定位、放行与收口而必须消费的绑定事实。
+
+## 1. 能力定位
+
+本文件回答：
+
+- Loom 在执行侧最少需要读取哪些 host 绑定关系
+- 哪些绑定关系可用于判断实现是否已被 host merge 吸收
+- 单个 host PR 吸收多个 issue 时最少要能表达什么
+- 哪些结论仍不能直接等同于 `closed_out`
+
+## 2. 最小绑定对象
+
+当某正式事项进入实现与收口链路时，Loom 只消费以下绑定关系：
+
+- `active issue -> host branch`
+- `active issue -> git worktree`
+- `active issue -> host PR`
+- `host PR -> merge commit`
+
+这些绑定关系都属于 host control truth 或其派生读取结果。
+Loom 可以读取、校验、汇总并据此阻断，但不在仓内 authored 第二套主定义。
+
+## 3. 最小消费规则
+
+Loom 至少消费这些绑定关系用于以下动作：
+
+- `workspace locate` / recovery
+  - 判断当前执行现场是否仍服务同一正式事项
+- merge-ready / closeout check
+  - 判断实现载体、合并结果与主干事实是否一致
+- cleanup / retire
+  - 判断某 host branch 或 `git worktree` 是否仍被正式事项占用
+
+若绑定关系缺失、指向冲突或无法证明当前实现属于同一事项，结果必须返回 `block` 或显式 drift。
+
+## 4. 单 PR 吸收多事项
+
+单个 host PR 可以吸收多个 issue，但前提是这些 issue 的实现缺口确实都被该 PR 对应的 merge 结果覆盖。
+
+Loom 最少需要能机械回答两件事：
+
+- 这个 host PR 吸收了哪些 issue
+- 哪些相关 issue 仍保留独立剩余缺口，不能被一起判定为 `absorbed`
+
+因此：
+
+- PR body、closing rationale、merge commit 或等价宿主证据中，至少要有一处能稳定表达 issue 与 merged work 的对应关系
+- 若同一 PR 同时涉及 parent / child issue，默认只吸收被明确证明已覆盖的 issue，不得把整棵 tree 一并视为已吸收
+
+## 5. `absorbed`
+
+`absorbed` 是 Loom 在 harness 层定义的实现吸收结论。
+
+它只表示：
+
+- 某正式事项对应的实现已经通过 host merge 进入主干
+- 这一结论可以被宿主事实证明，而不是凭口头判断
+
+最小证明面至少包括：
+
+- 对应 host PR 已 merged
+- 对应 merge commit 可定位
+- merge commit 已被目标主干吸收
+
+`absorbed` 不等于：
+
+- `closed_out`
+- issue 已关闭
+- project 状态已同步完成
+- 恢复主入口或现场已清理完毕
+
+在 issue tree 中：
+
+- child issue
+  - 可以因自身缺口已被其他 merged work 覆盖而形成 `absorbed`
+- parent issue
+  - 可以消费 child 的 `absorbed` 结果，但不得仅因某个 child 被吸收就自动视为自身已 `closed_out`
+
+## 6. 边界约束
+
+- 本文件不主定义 `active issue` 的语义、生命周期或 authored 字段
+- 本文件不把 `workspace` 写成 `git worktree`
+- 本文件不要求每个宿主都必须暴露同名字段；只要求绑定关系可被稳定证明
+- 本文件不接管 branch、PR、`git worktree` 或 merge 的宿主生命周期动作

--- a/harness/host-lifecycle-boundary.md
+++ b/harness/host-lifecycle-boundary.md
@@ -3,6 +3,7 @@
 本文件定义 Loom 与宿主平台在 `workspace`、branch、PR、git worktree 之间的生命周期边界。
 
 稳定命名与对象分类见 [../governance/host-object-taxonomy.md](../governance/host-object-taxonomy.md)。
+`active issue` 与 branch / `git worktree` / PR / merge commit 的绑定消费见 [host-issue-binding.md](./host-issue-binding.md)。
 
 ## 1. 结论
 
@@ -20,9 +21,11 @@
 Loom 固定承接：
 
 - `workspace_entry` 对应的执行现场语义
+- 对 `active issue -> branch / git worktree / PR / merge commit` 绑定关系的读取与校验
 - recovery 与 checkpoint 对执行现场的绑定
 - branch / PR / worktree 是否已经影响执行正确性的边界检查结果
 - merge 前对 host merge 的统一放行判断
+- host merge 后实现是否已被 `absorbed` 的可证明结论
 
 ## 3. Loom 不承接什么
 
@@ -45,4 +48,5 @@ Loom 当前不提供以下原生命令：
 
 - branch / PR purity 可以被 Loom 报告和消费，但不意味着 Loom 接管其生命周期
 - `workspace` 是执行现场抽象，不等于 git worktree
+- Loom 只消费 `active issue` 与宿主对象的绑定，不在这里主定义 `active issue`
 - 宿主对象的 UI、命名、按钮与策略不进入 Loom 默认内核

--- a/harness/workspace-model.md
+++ b/harness/workspace-model.md
@@ -16,6 +16,7 @@
 
 - 为单一正式事项提供隔离现场
 - 为恢复动作提供可定位目标
+- 为该事项消费的 host branch / `git worktree` / PR 绑定提供执行侧锚点
 - 为初始化后的 clean state 提供承载边界
 
 ## 2. 最小现场规则
@@ -43,6 +44,7 @@
 ## 4. 边界约束
 
 Loom 只固化现场隔离、单事项和可恢复定位。
+必要时，Loom 会读取 `active issue` 与 host branch / `git worktree` / PR 的绑定来校验现场是否仍服务同一事项。
 
 Loom 当前不固化：
 
@@ -51,3 +53,4 @@ Loom 当前不固化：
 - 具体命令、脚本或平台命名约定
 
 branch、PR 与 git worktree 的宿主边界见 [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)。
+`active issue` 绑定消费见 [host-issue-binding.md](./host-issue-binding.md)。


### PR DESCRIPTION
## Summary
- 新增 issue 模型合同，冻结 planning / active execution / validation-closeout 三类 issue 语义
- 新增 host issue binding 合同，冻结 active issue 与 branch/worktree/PR/merge commit 的绑定与 absorbed 边界
- 补齐 governance 与 harness 现有合同的交叉引用与 closeout 消费边界

## Review
- 已复审相对 main 的变更，未发现需修复问题
- 已通过 `make loom-check`

Closes #175
Closes #176