### PR TITLE
feat: 收敛 #177 reconciliation audit 入口

### DIFF
--- a/adoption/execution-entry-compatibility.md
+++ b/adoption/execution-entry-compatibility.md
@@ -16,6 +16,7 @@
 | checkpoint 执行 | `loom_flow checkpoint admission/build/merge` | 三阶段语义与回退关系保持不变 |
 | 现场与纯度治理 | `loom_flow workspace <create/locate/cleanup/retire>` + `purity-check` | 生命周期动作与失败语义保持不变 |
 | 宿主边界与 closeout | `loom_flow host-lifecycle` + `closeout check|sync` | Loom 明确边界与控制面对齐，但不接管宿主 branch/PR/worktree 生命周期 |
+| drift 审计 | `loom_flow reconciliation audit` | 只生成 absorbed-but-open / parent drift / project drift 审计结论，不直接修改 GitHub 控制面 |
 | 高频组合入口 | `loom_flow flow pre-review/review/resume/handoff/merge-ready` | 聚合入口扩张不破坏单命令入口，统一保持 JSON 结果语义 |
 | 场景 skills | `loom-adopt/resume/pre-review/review/handoff/retire/merge-ready` | 场景 skill 只做入口编排，不新增第二套事实真相源 |
 
@@ -48,7 +49,8 @@
 14. `loom_flow checkpoint admission/build/merge`
 15. `loom_flow workspace locate/cleanup/retire`
 16. `loom_flow host-lifecycle`
-17. `loom_flow closeout check`
+17. `loom_flow reconciliation audit`
+18. `loom_flow closeout check`
 
 预期：
 
@@ -68,5 +70,6 @@
 - `flow resume/pre-review/review/handoff/merge-ready`：均可返回稳定 JSON 结果
 - `review record`、`recovery writeback`、`work-item create|update`：可显式回写 authored 结果而不引入第二真相
 - `checkpoint merge` 在当前样本阶段按预期返回 `fallback`
+- `reconciliation audit` 会把 GitHub drift 显式化，但不提前执行 sync
 
 因此，下游仓库可以按 root skill 或显式场景 skill 消费完整执行内核，不再依赖手工拼接散落流程说明。

--- a/governance/truth-and-sync-boundary.md
+++ b/governance/truth-and-sync-boundary.md
@@ -129,6 +129,11 @@ Loom 当前只允许以下同步：
 - 明确报出 drift
 - 通过专门 sync 入口修复
 
+当前执行面上：
+
+- drift 审计由 `reconciliation audit` 承接
+- control-plane 对齐由后续专门 sync 入口承接
+
 不允许：
 
 - 静默选择其中一边

--- a/harness/README.md
+++ b/harness/README.md
@@ -27,6 +27,8 @@
   - 定义 Loom 与宿主 branch / PR / git worktree 生命周期的边界
 - [host-issue-binding.md](./host-issue-binding.md)
   - 定义 Loom 消费 `active issue` 与 branch / git worktree / PR / merge commit 的绑定合同
+- [reconciliation-audit.md](./reconciliation-audit.md)
+  - 定义 Loom 发现 absorbed-but-open / parent drift / project drift 的审计合同
 - [recovery-model.md](./recovery-model.md)
   - 定义唯一恢复主入口、`checkpoint`、`resume`、`handoff` 与每轮回写合同
 - [review-execution.md](./review-execution.md)

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -23,6 +23,7 @@
 | `recovery writeback` | `python3 tools/loom_flow.py recovery writeback --target <repo> [--item <id>] ...` | 当前 fact-chain + recovery authored 字段 | `pass` / `block` | 只写 recovery 主入口，再同步状态面 |
 | `work item authoring` | `python3 tools/loom_flow.py work-item create|update --target <repo> --item <id> ... [--activate]` | init-result locator + work item static fields | `pass` / `block` | `--activate` 只切当前 locator，不隐式写动态状态 |
 | `host lifecycle boundary` | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | fact-chain + purity + 当前 branch/worktree 观测 | `pass` / `block` | 明确 workspace 由 Loom 管，branch/PR/worktree 由宿主管 |
+| `reconciliation audit` | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | issue tree + PR merge事实 + Project 状态 | `pass` / `warn` / `fix-needed` / `block` | 只报出 drift，不修改 GitHub 控制面 |
 | `merge-ready` | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | fact-chain + state-check + runtime evidence + build checkpoint + merge checkpoint | `pass` / `block` / `fallback` | 只输出统一放行摘要，不替代宿主平台 merge |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
 | `retire` | `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]` -> `workspace cleanup` -> `workspace retire` | purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录 |
@@ -36,6 +37,9 @@
 - CLI
   - 负责读取、校验、回写与输出稳定 JSON 语义
   - 不替代 reviewer 的语义判断
+- `reconciliation audit`
+  - 负责把 GitHub drift 显式化
+  - 不替代后续 sync
 - gate (`loom_check` / CI)
   - 负责复用同一 CLI 入口做机械阻断
   - 不维护第二套检查口径

--- a/harness/reconciliation-audit.md
+++ b/harness/reconciliation-audit.md
@@ -1,0 +1,64 @@
+# Reconciliation Audit
+
+本文件定义 Loom 当前 `reconciliation audit` 的最小执行合同。
+
+本文件当前承接：
+
+- `#177`
+
+## 1. 能力定位
+
+`reconciliation audit` 用来回答三件事：
+
+- merged PR 是否已经吸收了仍然 open 的 issue
+- parent issue 是否仍与 child 的真实状态一致
+- issue / PR / project 的控制面状态是否已经漂移
+
+它只读 GitHub 控制面真相并输出审计结论，不做任何写回。
+
+## 2. 稳定入口
+
+- `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]`
+
+## 3. 稳定 findings
+
+第一版固定三类 finding：
+
+- `absorbed_but_open`
+  - merged PR 已进入主干，但 issue 仍 open
+- `parent_drift`
+  - parent issue 的开关状态与 child 的真实剩余缺口不一致
+- `project_drift`
+  - issue / PR 的 Project 状态与当前控制面结论不一致
+
+每条 finding 至少表达：
+
+- `kind`
+- `severity`
+- `subject`
+- `evidence`
+- `recommended_action`
+
+## 4. 结果语义
+
+`reconciliation audit` 只允许以下结果：
+
+- `pass`
+  - 没有 drift finding
+- `warn`
+  - 只有低严重度观察结论
+- `fix-needed`
+  - 已发现必须同步但尚未阻断的 drift
+- `block`
+  - 已发现不能继续视为 closeout-ready 的 drift，或必需输入缺失
+
+## 5. 边界约束
+
+- 本入口只生成审计结论，不执行 GitHub 修改
+- issue tree 关系通过 GitHub GraphQL 读取，不回写到仓内 docs
+- `absorbed` 的宿主证明继续由 [host-issue-binding.md](./host-issue-binding.md) 承接
+- 修复 drift 的正式入口由后续 reconciliation sync 承接，本文件不提前定义写路径
+
+## 6. 一句话结论
+
+Loom 先用 `reconciliation audit` 明确报出 absorbed-but-open、parent drift 和 project drift，再决定是否允许后续 closeout 或进入专门 sync。

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -220,6 +220,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     closeout.add_argument("--comment", help="Optional closeout comment for issue sync")
     closeout.add_argument("--skip-gate", action="store_true", help="Skip local loom_check execution during closeout")
 
+    reconciliation = subparsers.add_parser("reconciliation", help="Audit Loom GitHub drift before closeout reconciliation")
+    reconciliation.add_argument("operation", choices=("audit",))
+    reconciliation.add_argument("--target", required=True, help="Target repository root")
+    reconciliation.add_argument("--issue", type=int, help="GitHub issue number to audit")
+    reconciliation.add_argument("--pr", type=int, help="GitHub pull request number to audit")
+    reconciliation.add_argument("--project", type=int, help="GitHub project number to audit")
+    reconciliation.add_argument("--owner", help="GitHub owner; auto-detected from origin when omitted")
+    reconciliation.add_argument("--repo", dest="repo_name", help="GitHub repository name; auto-detected from origin when omitted")
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("pre-review", "review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -1862,6 +1871,346 @@ def set_project_item_done(root: Path, project_id: str, item_id: str, status_fiel
     return []
 
 
+def issue_tree_payload(root: Path, owner: str, repo_name: str, issue_number: int) -> tuple[dict[str, Any] | None, list[str]]:
+    query = """
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    issue(number:$number) {
+      id
+      number
+      title
+      state
+      url
+      parent {
+        id
+        number
+        title
+        state
+        url
+        subIssues(first:50) {
+          nodes {
+            id
+            number
+            title
+            state
+            url
+          }
+        }
+      }
+      subIssues(first:50) {
+        nodes {
+          id
+          number
+          title
+          state
+          url
+        }
+      }
+    }
+  }
+}
+"""
+    data, errors = gh_graphql(root, query, {"owner": owner, "name": repo_name, "number": issue_number})
+    if errors or data is None:
+        return None, errors
+    repository = data.get("repository")
+    if not isinstance(repository, dict):
+        return None, ["issue tree graphql payload is missing `repository`"]
+    issue = repository.get("issue")
+    if not isinstance(issue, dict):
+        return None, [f"issue #{issue_number} is missing from GraphQL payload"]
+    return issue, []
+
+
+def contains_merged_commit(root: Path, merge_commit_sha: str) -> bool:
+    run_git(root, ["fetch", "origin", "main"])
+    contains = run_git(root, ["merge-base", "--is-ancestor", merge_commit_sha, "origin/main"])
+    return contains is not None and contains.returncode == 0
+
+
+def make_reconciliation_finding(
+    *,
+    kind: str,
+    severity: str,
+    subject: str,
+    evidence: dict[str, Any],
+    recommended_action: str,
+) -> dict[str, Any]:
+    return {
+        "kind": kind,
+        "severity": severity,
+        "subject": subject,
+        "evidence": evidence,
+        "recommended_action": recommended_action,
+    }
+
+
+def reconciliation_result(findings: list[dict[str, Any]]) -> str:
+    if not findings:
+        return "pass"
+    rank = {"warn": 1, "fix-needed": 2, "block": 3}
+    highest = max(rank.get(str(finding.get("severity")), 0) for finding in findings)
+    if highest == 3:
+        return "block"
+    if highest == 2:
+        return "fix-needed"
+    return "warn"
+
+
+def reconciliation_audit_payload(
+    *,
+    target_root: Path,
+    issue_number: int | None,
+    pr_number: int | None,
+    project_number: int | None,
+    owner: str,
+    repo_name: str,
+) -> tuple[dict[str, Any], list[str]]:
+    missing_inputs: list[str] = []
+    findings: list[dict[str, Any]] = []
+
+    if issue_number is None and pr_number is None and project_number is None:
+        missing_inputs.append("issue/pr/project")
+
+    issue_payload: dict[str, Any] | None = None
+    issue_id: str | None = None
+    parent_payload: dict[str, Any] | None = None
+    if issue_number is not None:
+        issue_payload, issue_errors = issue_tree_payload(target_root, owner, repo_name, issue_number)
+        if issue_errors:
+            missing_inputs.extend(f"issue: {message}" for message in issue_errors)
+        elif issue_payload is not None:
+            raw_issue_id = issue_payload.get("id")
+            if isinstance(raw_issue_id, str) and raw_issue_id:
+                issue_id = raw_issue_id
+            parent = issue_payload.get("parent")
+            if isinstance(parent, dict):
+                parent_payload = parent
+
+    pr_payload: dict[str, Any] | None = None
+    merge_commit_sha: str | None = None
+    merge_commit_in_main = False
+    if pr_number is not None:
+        pr_payload, pr_errors = gh_json(
+            target_root,
+            [
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                f"{owner}/{repo_name}",
+                "--json",
+                "number,state,isDraft,mergedAt,mergeCommit,url,title",
+            ],
+        )
+        if pr_errors:
+            missing_inputs.extend(f"pr: {message}" for message in pr_errors)
+        elif pr_payload is not None:
+            merge_commit = pr_payload.get("mergeCommit")
+            if isinstance(merge_commit, dict):
+                oid = merge_commit.get("oid")
+                if isinstance(oid, str) and oid:
+                    merge_commit_sha = oid
+                    merge_commit_in_main = contains_merged_commit(target_root, merge_commit_sha)
+
+    absorbed_issue = False
+    if issue_payload is not None and pr_payload is not None:
+        if issue_payload.get("state") == "OPEN" and pr_payload.get("state") == "MERGED" and merge_commit_sha and merge_commit_in_main:
+            absorbed_issue = True
+            findings.append(
+                make_reconciliation_finding(
+                    kind="absorbed_but_open",
+                    severity="fix-needed",
+                    subject=f"issue #{issue_number}",
+                    evidence={
+                        "issue_state": issue_payload.get("state"),
+                        "pr_number": pr_number,
+                        "pr_state": pr_payload.get("state"),
+                        "merge_commit": merge_commit_sha,
+                        "merge_commit_in_main": merge_commit_in_main,
+                    },
+                    recommended_action="close the absorbed issue or run reconciliation sync after reviewing the evidence.",
+                )
+            )
+
+    parent_scope: dict[str, Any] | None = None
+    if parent_payload is not None:
+        parent_scope = parent_payload
+    elif isinstance(issue_payload, dict):
+        sub_issues = issue_payload.get("subIssues")
+        if isinstance(sub_issues, dict) and isinstance(sub_issues.get("nodes"), list) and sub_issues.get("nodes"):
+            parent_scope = issue_payload
+
+    if parent_scope is not None:
+        raw_children = parent_scope.get("subIssues")
+        child_nodes = raw_children.get("nodes") if isinstance(raw_children, dict) else None
+        unresolved_children: list[dict[str, Any]] = []
+        resolved_children: list[dict[str, Any]] = []
+        if isinstance(child_nodes, list):
+            for child in child_nodes:
+                if not isinstance(child, dict):
+                    continue
+                child_number = child.get("number")
+                child_state = child.get("state")
+                if child_state == "CLOSED":
+                    resolved_children.append(child)
+                    continue
+                if child_number == issue_number and absorbed_issue:
+                    resolved_children.append(child)
+                    continue
+                unresolved_children.append(child)
+        parent_number = parent_scope.get("number")
+        parent_state = parent_scope.get("state")
+        if parent_state == "CLOSED" and unresolved_children:
+            findings.append(
+                make_reconciliation_finding(
+                    kind="parent_drift",
+                    severity="block",
+                    subject=f"parent issue #{parent_number}",
+                    evidence={
+                        "parent_state": parent_state,
+                        "unresolved_children": [
+                            {"number": child.get("number"), "state": child.get("state"), "title": child.get("title")}
+                            for child in unresolved_children
+                        ],
+                    },
+                    recommended_action="reopen the parent issue or finish the unresolved child issues before treating the parent as closed out.",
+                )
+            )
+        elif parent_state == "OPEN" and child_nodes and not unresolved_children:
+            findings.append(
+                make_reconciliation_finding(
+                    kind="parent_drift",
+                    severity="fix-needed",
+                    subject=f"parent issue #{parent_number}",
+                    evidence={
+                        "parent_state": parent_state,
+                        "resolved_children": [
+                            {"number": child.get("number"), "state": child.get("state"), "title": child.get("title")}
+                            for child in resolved_children
+                        ],
+                    },
+                    recommended_action="reconcile the parent issue because all child gaps are already closed or absorbed.",
+                )
+            )
+
+    project_payload: dict[str, Any] | None = None
+    project_drift_details: list[dict[str, Any]] = []
+    if project_number is not None:
+        project_context, project_errors = project_status_context(target_root, owner, project_number)
+        if project_errors:
+            missing_inputs.extend(f"project: {message}" for message in project_errors)
+        else:
+            items = project_context["items"]
+            issue_item = find_project_item(items, issue_number, "issue") if issue_number is not None else None
+            if issue_item is None and issue_id is not None and issue_number is not None:
+                issue_item, issue_item_errors = project_item_for_issue(target_root, issue_id, project_number)
+                if issue_item_errors:
+                    missing_inputs.extend(f"project: {message}" for message in issue_item_errors)
+            pr_item = find_project_item(items, pr_number, "pr") if pr_number is not None else None
+            project_payload = {
+                "number": project_number,
+                "project_id": project_context["project_id"],
+                "status_field_id": project_context["status_field_id"],
+                "done_option_id": project_context["done_option_id"],
+                "issue_item": issue_item,
+                "pr_item": pr_item,
+            }
+
+            if issue_number is not None:
+                expected_done = issue_payload is not None and (issue_payload.get("state") == "CLOSED" or absorbed_issue)
+                if issue_item is None:
+                    project_drift_details.append(
+                        {
+                            "subject": f"issue #{issue_number}",
+                            "reason": "issue is missing from project",
+                            "expected_done": expected_done,
+                        }
+                    )
+                else:
+                    status = issue_item.get("status")
+                    if expected_done and status != "Done":
+                        project_drift_details.append(
+                            {
+                                "subject": f"issue #{issue_number}",
+                                "reason": "issue project status is not Done",
+                                "expected_done": True,
+                                "actual_status": status,
+                            }
+                        )
+                    if not expected_done and status == "Done":
+                        project_drift_details.append(
+                            {
+                                "subject": f"issue #{issue_number}",
+                                "reason": "issue project status is Done while the issue still has an open gap",
+                                "expected_done": False,
+                                "actual_status": status,
+                            }
+                        )
+
+            if pr_number is not None:
+                expected_done = pr_payload is not None and pr_payload.get("state") == "MERGED"
+                if pr_item is not None:
+                    status = pr_item.get("status")
+                    if expected_done and status != "Done":
+                        project_drift_details.append(
+                            {
+                                "subject": f"pr #{pr_number}",
+                                "reason": "pr project status is not Done",
+                                "expected_done": True,
+                                "actual_status": status,
+                            }
+                        )
+                    if not expected_done and status == "Done":
+                        project_drift_details.append(
+                            {
+                                "subject": f"pr #{pr_number}",
+                                "reason": "pr project status is Done while the PR is not merged",
+                                "expected_done": False,
+                                "actual_status": status,
+                            }
+                        )
+
+    if project_drift_details:
+        findings.append(
+            make_reconciliation_finding(
+                kind="project_drift",
+                severity="fix-needed",
+                subject=f"project {project_number}",
+                evidence={"drifts": project_drift_details},
+                recommended_action="align the project items with the audited issue/PR state before closeout.",
+            )
+        )
+
+    if missing_inputs:
+        result = "block"
+        summary = "reconciliation audit could not complete because required GitHub inputs were missing."
+    else:
+        result = reconciliation_result(findings)
+        summary = (
+            "reconciliation audit found no absorbed-but-open, parent-drift, or project-drift findings."
+            if result == "pass"
+            else "reconciliation audit found GitHub drift that must be reviewed before closeout."
+        )
+    return (
+        {
+            "command": "reconciliation",
+            "operation": "audit",
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": None if result == "pass" else "manual-reconciliation",
+            "repo": {"owner": owner, "name": repo_name},
+            "issue": issue_payload,
+            "parent": parent_payload,
+            "pr": pr_payload,
+            "project": project_payload,
+            "findings": findings,
+        },
+        [],
+    )
+
+
 def closeout_payload(
     *,
     target_root: Path,
@@ -2094,6 +2443,48 @@ def handle_closeout(args: argparse.Namespace) -> int:
         refreshed_payload["missing_inputs"] = list(dict.fromkeys(sync_missing + list(refreshed_payload.get("missing_inputs", []))))
         refreshed_payload["fallback_to"] = "merge"
     return emit(refreshed_payload)
+
+
+def handle_reconciliation(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    owner = args.owner
+    repo_name = args.repo_name
+    if not owner or not repo_name:
+        detected_owner, detected_repo = detect_github_repo(target_root)
+        owner = owner or detected_owner
+        repo_name = repo_name or detected_repo
+    if not owner or not repo_name:
+        return emit(
+            {
+                "command": "reconciliation",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "reconciliation could not determine the GitHub repository.",
+                "missing_inputs": ["owner/repo"],
+                "fallback_to": "manual-reconciliation",
+            }
+        )
+
+    payload, errors = reconciliation_audit_payload(
+        target_root=target_root,
+        issue_number=args.issue,
+        pr_number=args.pr,
+        project_number=args.project,
+        owner=owner,
+        repo_name=repo_name,
+    )
+    if errors:
+        return emit(
+            {
+                "command": "reconciliation",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "reconciliation command hit an unexpected internal error.",
+                "missing_inputs": errors,
+                "fallback_to": "manual-reconciliation",
+            }
+        )
+    return emit(payload)
 
 
 def handle_review(args: argparse.Namespace) -> int:
@@ -2981,6 +3372,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_host_lifecycle(args)
     if args.command == "closeout":
         return handle_closeout(args)
+    if args.command == "reconciliation":
+        return handle_reconciliation(args)
     if args.command == "flow":
         return handle_flow(args)
     if args.command == "checkpoint":


### PR DESCRIPTION
## Summary
- 新增 reconciliation audit CLI，审计 absorbed-but-open、parent drift、project drift
- 新增 harness 审计合同主文件并补齐入口兼容文档
- 保持 read-only，不接 sync、不接 gate

## Validation
- `python3 tools/loom_flow.py reconciliation audit --target /Users/mc/dev/Loom-wt-177-closeout-audit --issue 131 --pr 138 --project 5`
- `python3 tools/loom_flow.py reconciliation audit --target /Users/mc/dev/Loom-wt-177-closeout-audit --issue 177`
- `make loom-check`

Closes #177