### PR TITLE
feat: 收敛 #178 reconciliation sync 入口

### DIFF
--- a/adoption/execution-entry-compatibility.md
+++ b/adoption/execution-entry-compatibility.md
@@ -15,8 +15,8 @@
 | 日常读取与检查 | `loom_flow fact-chain/runtime-evidence/state-check` | 输出保持 JSON 结果语义（`result/summary/missing_inputs/fallback_to`） |
 | checkpoint 执行 | `loom_flow checkpoint admission/build/merge` | 三阶段语义与回退关系保持不变 |
 | 现场与纯度治理 | `loom_flow workspace <create/locate/cleanup/retire>` + `purity-check` | 生命周期动作与失败语义保持不变 |
-| 宿主边界与 closeout | `loom_flow host-lifecycle` + `closeout check|sync` | Loom 明确边界与控制面对齐，但不接管宿主 branch/PR/worktree 生命周期 |
-| drift 审计 | `loom_flow reconciliation audit` | 只生成 absorbed-but-open / parent drift / project drift 审计结论，不直接修改 GitHub 控制面 |
+| 宿主边界与 closeout | `loom_flow host-lifecycle` + `closeout check|sync` | Loom 明确边界与控制面对齐，但不接管宿主 branch/PR/worktree 生命周期；`closeout` 仍保持原有收口控制面职责 |
+| drift 审计与 sync | `loom_flow reconciliation audit|sync` | `audit` 只生成 absorbed-but-open / parent drift / project drift；`sync` 只消费这些 finding 做机械写回，不扩展为新的 gate/验证入口 |
 | 高频组合入口 | `loom_flow flow pre-review/review/resume/handoff/merge-ready` | 聚合入口扩张不破坏单命令入口，统一保持 JSON 结果语义 |
 | 场景 skills | `loom-adopt/resume/pre-review/review/handoff/retire/merge-ready` | 场景 skill 只做入口编排，不新增第二套事实真相源 |
 
@@ -50,7 +50,8 @@
 15. `loom_flow workspace locate/cleanup/retire`
 16. `loom_flow host-lifecycle`
 17. `loom_flow reconciliation audit`
-18. `loom_flow closeout check`
+18. `loom_flow reconciliation sync --dry-run`
+19. `loom_flow closeout check`
 
 预期：
 
@@ -71,5 +72,7 @@
 - `review record`、`recovery writeback`、`work-item create|update`：可显式回写 authored 结果而不引入第二真相
 - `checkpoint merge` 在当前样本阶段按预期返回 `fallback`
 - `reconciliation audit` 会把 GitHub drift 显式化，但不提前执行 sync
+- `reconciliation sync` 必须先消费同范围 audit；若出现任一 `block` finding，则返回 `block` 且不写控制面
+- `reconciliation sync --dry-run` 只输出计划，不伪装成已经完成 closeout
 
 因此，下游仓库可以按 root skill 或显式场景 skill 消费完整执行内核，不再依赖手工拼接散落流程说明。

--- a/adoption/upstream-delivery-surface.md
+++ b/adoption/upstream-delivery-surface.md
@@ -11,14 +11,14 @@
 - `governance/`
   - 核心原则、审查模型、成熟度与关闭语义
 - `harness/`
-  - 核心执行合同、恢复模型、状态面、纯度、宿主生命周期边界、closeout gate 与自动化前置
+  - 核心执行合同、恢复模型、状态面、纯度、宿主生命周期边界、closeout gate、reconciliation sync 写回约束与自动化前置
 - `templates/`
   - 最小正式规约模板与最小 PR 模板
 - `skills/`
   - 稳定入口合同、`loom-init` root 路由、7 个场景 skills、`registry.json`、`upgrade-contract.json` 与 `route-matrix.md`
 - `adoption/`
   - 稳定 adoption 路径、经验回流、验证记录合同、版本化与升级路径
-  - 执行入口兼容说明、7 个场景 skill 验证记录与完整执行内核复验记录
+  - 执行入口兼容说明、reconciliation audit/sync 兼容边界、7 个场景 skill 验证记录与完整执行内核复验记录
 - 发布说明
   - `docs/complete-kernel-release.md`
 

--- a/harness/closeout-gate.md
+++ b/harness/closeout-gate.md
@@ -13,6 +13,7 @@ closeout gate 用来回答两件事：
 
 - `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]`
 - `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]`
+- `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]`
 
 ## 3. `check` 最小检查面
 
@@ -36,10 +37,20 @@ closeout gate 用来回答两件事：
 
 ## 4. `sync` 最小动作
 
-`closeout sync` 只做控制面对齐动作：
+本阶段的正式写路径是 `reconciliation sync`。它只做控制面对齐动作：
 
+- 先消费同范围的 `reconciliation audit` 结果，再生成可执行 sync 计划
 - 在条件满足时关闭 issue
 - 在 project 中把对应 item 状态设为 `Done`
+
+约束：
+
+- 若 `reconciliation audit` 出现任一 `block` finding，`sync` 必须直接返回 `block`，且不做任何写入
+- `sync` 只允许对 `fix-needed` finding 做机械修复；`warn` 仅保留提示，不触发写入
+- `--dry-run` 只输出基于 audit 的计划，不修改 GitHub 控制面
+- `--comment-file` 与 `--comment` 二选一，只为当前 issue closeout comment 提供正文来源
+
+`closeout sync` 仍保持既有 closeout 控制面对齐入口；`#179` 再把 `reconciliation audit/sync` 正式接进 gate 与 closeout。
 
 若 parent issue 通过 child issue 的 `closed_out` / `absorbed` 结果完成自身 closeout 判断，`sync` 只负责把这一已成立结论写回控制面，不替代 parent 对剩余缺口的判断。
 
@@ -55,3 +66,4 @@ closeout gate 用来回答两件事：
 - 不在 Loom 内核里固化 GitHub UI、按钮或 ruleset 细节
 - 不把 project 中不存在的 PR item 强行当作阻断
 - 不让 closeout sync 绕过 gate 或 merge 事实
+- 不把 reconciliation sync 扩展成 `#179` gate 接入或 `#162` 验证自动化

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -24,10 +24,11 @@
 | `work item authoring` | `python3 tools/loom_flow.py work-item create|update --target <repo> --item <id> ... [--activate]` | init-result locator + work item static fields | `pass` / `block` | `--activate` 只切当前 locator，不隐式写动态状态 |
 | `host lifecycle boundary` | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | fact-chain + purity + 当前 branch/worktree 观测 | `pass` / `block` | 明确 workspace 由 Loom 管，branch/PR/worktree 由宿主管 |
 | `reconciliation audit` | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | issue tree + PR merge事实 + Project 状态 | `pass` / `warn` / `fix-needed` / `block` | 只报出 drift，不修改 GitHub 控制面 |
+| `reconciliation sync` | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 同范围 reconciliation audit + issue/PR/project 控制面 | `pass` / `block` | 只修机械可证明的 `fix-needed` drift；`block` 零写入，`warn` 仅保留提示 |
 | `merge-ready` | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | fact-chain + state-check + runtime evidence + build checkpoint + merge checkpoint | `pass` / `block` / `fallback` | 只输出统一放行摘要，不替代宿主平台 merge |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
 | `retire` | `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]` -> `workspace cleanup` -> `workspace retire` | purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录 |
-| `closeout` | `python3 tools/loom_flow.py closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | loom_check + issue/PR/project/main | `pass` / `block` | 只对齐 closeout 控制面，不替代 merge |
+| `closeout` | `python3 tools/loom_flow.py closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | loom_check + issue/PR/project/main | `pass` / `block` | 仍是 closeout 控制面对齐入口；`#179` 再接入 reconciliation 结果 |
 
 ## 2. 分层边界
 
@@ -40,6 +41,9 @@
 - `reconciliation audit`
   - 负责把 GitHub drift 显式化
   - 不替代后续 sync
+- `reconciliation sync`
+  - 必须先消费同范围 `reconciliation audit`
+  - 不绕过 `block` finding，不伪造实现完成
 - gate (`loom_check` / CI)
   - 负责复用同一 CLI 入口做机械阻断
   - 不维护第二套检查口径

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -221,13 +221,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     closeout.add_argument("--skip-gate", action="store_true", help="Skip local loom_check execution during closeout")
 
     reconciliation = subparsers.add_parser("reconciliation", help="Audit Loom GitHub drift before closeout reconciliation")
-    reconciliation.add_argument("operation", choices=("audit",))
+    reconciliation.add_argument("operation", choices=("audit", "sync"))
     reconciliation.add_argument("--target", required=True, help="Target repository root")
     reconciliation.add_argument("--issue", type=int, help="GitHub issue number to audit")
     reconciliation.add_argument("--pr", type=int, help="GitHub pull request number to audit")
     reconciliation.add_argument("--project", type=int, help="GitHub project number to audit")
     reconciliation.add_argument("--owner", help="GitHub owner; auto-detected from origin when omitted")
     reconciliation.add_argument("--repo", dest="repo_name", help="GitHub repository name; auto-detected from origin when omitted")
+    reconciliation.add_argument("--comment", help="Optional closeout comment for issue sync")
+    reconciliation.add_argument("--comment-file", help="Read closeout comment body from a file")
+    reconciliation.add_argument("--dry-run", action="store_true", help="Preview reconciliation sync actions without writing GitHub state")
 
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("pre-review", "review", "resume", "handoff", "merge-ready"))
@@ -328,6 +331,15 @@ def detect_github_repo(root: Path) -> tuple[str | None, str | None]:
     if not match:
         return None, None
     return match.group("owner"), match.group("repo")
+
+
+def read_text_file(path_str: str) -> tuple[str | None, list[str]]:
+    path = Path(path_str).expanduser()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, [f"failed to read {path}: {exc.strerror or exc}"]
+    return text, []
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
@@ -2211,6 +2223,146 @@ def reconciliation_audit_payload(
     )
 
 
+def reconciliation_sync_plan(audit_payload: dict[str, Any]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    plan: list[dict[str, Any]] = []
+    skipped_actions: list[dict[str, Any]] = []
+    findings = audit_payload.get("findings")
+    if not isinstance(findings, list):
+        return plan, skipped_actions
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        severity = finding.get("severity")
+        kind = finding.get("kind")
+        subject = finding.get("subject")
+        evidence = finding.get("evidence")
+        if severity != "fix-needed":
+            continue
+        if kind == "absorbed_but_open":
+            plan.append(
+                {
+                    "kind": kind,
+                    "subject": subject,
+                    "action": "close_issue",
+                    "issue_number": audit_payload.get("issue", {}).get("number"),
+                }
+            )
+            continue
+        if kind == "project_drift":
+            project = audit_payload.get("project")
+            if not isinstance(project, dict):
+                skipped_actions.append(
+                    {
+                        "kind": kind,
+                        "subject": subject,
+                        "action": "set_project_status",
+                        "reason": "project_drift is missing project context",
+                    }
+                )
+                continue
+            drifts = evidence.get("drifts") if isinstance(evidence, dict) else None
+            if not isinstance(drifts, list):
+                skipped_actions.append(
+                    {
+                        "kind": kind,
+                        "subject": subject,
+                        "action": "set_project_status",
+                        "reason": "project_drift is missing drift details",
+                    }
+                )
+                continue
+            for drift in drifts:
+                if not isinstance(drift, dict):
+                    continue
+                drift_subject = drift.get("subject")
+                reason = str(drift.get("reason", ""))
+                expected_done = drift.get("expected_done")
+                if expected_done is not True:
+                    skipped_actions.append(
+                        {
+                            "kind": kind,
+                            "subject": drift_subject,
+                            "action": "set_project_status",
+                            "reason": f"requires manual reconciliation: {reason}",
+                        }
+                    )
+                    continue
+                item_key = None
+                if isinstance(drift_subject, str) and drift_subject.startswith("issue #"):
+                    item_key = "issue_item"
+                elif isinstance(drift_subject, str) and drift_subject.startswith("pr #"):
+                    item_key = "pr_item"
+                item = project.get(item_key) if item_key else None
+                if not isinstance(item, dict):
+                    skipped_actions.append(
+                        {
+                            "kind": kind,
+                            "subject": drift_subject,
+                            "action": "set_project_status",
+                            "reason": "cannot be synced because the project item is missing",
+                        }
+                    )
+                    continue
+                item_id = item.get("id")
+                project_id = project.get("project_id")
+                status_field_id = project.get("status_field_id")
+                done_option_id = project.get("done_option_id")
+                if not all(isinstance(value, str) and value for value in (item_id, project_id, status_field_id, done_option_id)):
+                    skipped_actions.append(
+                        {
+                            "kind": kind,
+                            "subject": drift_subject,
+                            "action": "set_project_status",
+                            "reason": "is missing project status identifiers",
+                        }
+                    )
+                    continue
+                plan.append(
+                    {
+                        "kind": kind,
+                        "subject": drift_subject,
+                        "action": "set_project_done",
+                        "project_number": project.get("number"),
+                        "project_id": project_id,
+                        "item_id": item_id,
+                        "status_field_id": status_field_id,
+                        "done_option_id": done_option_id,
+                    }
+                )
+            continue
+        if kind == "parent_drift":
+            parent = audit_payload.get("parent")
+            parent_number = parent.get("number") if isinstance(parent, dict) else None
+            if parent_number is None:
+                skipped_actions.append(
+                    {
+                        "kind": kind,
+                        "subject": subject,
+                        "action": "close_issue",
+                        "reason": "parent_drift is missing parent issue context",
+                    }
+                )
+                continue
+            plan.append(
+                {
+                    "kind": kind,
+                    "subject": subject,
+                    "action": "close_issue",
+                    "issue_number": parent_number,
+                }
+            )
+            continue
+        skipped_actions.append(
+            {
+                "kind": kind,
+                "subject": subject,
+                "action": "unsupported",
+                "reason": f"unsupported reconciliation finding `{kind}`",
+            }
+        )
+    return plan, skipped_actions
+
+
 def closeout_payload(
     *,
     target_root: Path,
@@ -2437,6 +2589,7 @@ def handle_closeout(args: argparse.Namespace) -> int:
     if errors:
         sync_missing.extend(errors)
     refreshed_payload["operation"] = "sync"
+
     if sync_missing:
         refreshed_payload["result"] = "block"
         refreshed_payload["summary"] = "closeout sync could not fully align GitHub control-plane state."
@@ -2465,6 +2618,33 @@ def handle_reconciliation(args: argparse.Namespace) -> int:
             }
         )
 
+    if args.comment and args.comment_file:
+        return emit(
+            {
+                "command": "reconciliation",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "reconciliation sync accepts either --comment or --comment-file, not both.",
+                "missing_inputs": ["choose one comment source"],
+                "fallback_to": "manual-reconciliation",
+            }
+        )
+
+    comment_body = args.comment
+    if args.comment_file:
+        comment_body, comment_errors = read_text_file(args.comment_file)
+        if comment_errors:
+            return emit(
+                {
+                    "command": "reconciliation",
+                    "operation": args.operation,
+                    "result": "block",
+                    "summary": "reconciliation sync could not read the requested comment file.",
+                    "missing_inputs": comment_errors,
+                    "fallback_to": "manual-reconciliation",
+                }
+            )
+
     payload, errors = reconciliation_audit_payload(
         target_root=target_root,
         issue_number=args.issue,
@@ -2484,7 +2664,179 @@ def handle_reconciliation(args: argparse.Namespace) -> int:
                 "fallback_to": "manual-reconciliation",
             }
         )
-    return emit(payload)
+    if args.operation == "audit":
+        return emit(payload)
+
+    if payload.get("result") == "block":
+        return emit(
+            {
+                **payload,
+                "operation": "sync",
+                "summary": "reconciliation sync stopped because audit returned block findings or missing inputs.",
+                "applied_actions": [],
+                "skipped_actions": [],
+                "remaining_findings": list(payload.get("findings", [])),
+            }
+        )
+
+    applied_actions, skipped_actions = reconciliation_sync_plan(payload)
+    remaining_findings = [
+        finding
+        for finding in payload.get("findings", [])
+        if isinstance(finding, dict) and finding.get("severity") == "warn"
+    ]
+    sync_missing: list[str] = []
+
+    if args.dry_run:
+        dry_run_actions = [{**action, "dry_run": True} for action in applied_actions]
+        has_unresolved_fix_needed = any(
+            isinstance(finding, dict) and finding.get("severity") == "fix-needed"
+            for finding in payload.get("findings", [])
+        ) and bool(skipped_actions)
+        return emit(
+            {
+                **payload,
+                "operation": "sync",
+                "result": "block" if has_unresolved_fix_needed else "pass",
+                "summary": (
+                    "reconciliation sync dry-run produced the planned control-plane actions."
+                    if not has_unresolved_fix_needed
+                    else "reconciliation sync dry-run found fix-needed drift that still requires manual reconciliation."
+                ),
+                "applied_actions": dry_run_actions,
+                "skipped_actions": skipped_actions,
+                "remaining_findings": list(payload.get("findings", [])),
+                "dry_run": True,
+                "fallback_to": None if not has_unresolved_fix_needed else "manual-reconciliation",
+            }
+        )
+
+    executed_actions: list[dict[str, Any]] = []
+    for action in applied_actions:
+        step_kind = action.get("action")
+        subject = action.get("subject")
+        if step_kind == "close_issue":
+            issue_number = action.get("issue_number")
+            if not isinstance(issue_number, int):
+                sync_missing.append(f"{subject} is missing an issue number for reconciliation sync")
+                skipped_actions.append(
+                    {
+                        "kind": action.get("kind"),
+                        "subject": subject,
+                        "action": step_kind,
+                        "reason": "missing issue number for reconciliation sync",
+                    }
+                )
+                continue
+            if comment_body and issue_number == args.issue:
+                comment_result = run_process(
+                    [
+                        "gh",
+                        "issue",
+                        "comment",
+                        str(issue_number),
+                        "--repo",
+                        f"{owner}/{repo_name}",
+                        "--body",
+                        comment_body,
+                    ],
+                    target_root,
+                )
+                if comment_result.returncode != 0:
+                    sync_missing.append(comment_result.stderr.strip() or f"failed to comment on issue #{issue_number}")
+                    skipped_actions.append(
+                        {
+                            "kind": action.get("kind"),
+                            "subject": subject,
+                            "action": step_kind,
+                            "reason": f"failed to comment on issue #{issue_number}",
+                        }
+                    )
+                    continue
+            close_result = run_process(
+                ["gh", "issue", "close", str(issue_number), "--repo", f"{owner}/{repo_name}"],
+                target_root,
+            )
+            if close_result.returncode != 0:
+                sync_missing.append(close_result.stderr.strip() or f"failed to close issue #{issue_number}")
+                skipped_actions.append(
+                    {
+                        "kind": action.get("kind"),
+                        "subject": subject,
+                        "action": step_kind,
+                        "reason": close_result.stderr.strip() or f"failed to close issue #{issue_number}",
+                    }
+                )
+                continue
+            executed_actions.append(action)
+            continue
+        if step_kind == "set_project_done":
+            step_errors = set_project_item_done(
+                target_root,
+                action["project_id"],
+                action["item_id"],
+                action["status_field_id"],
+                action["done_option_id"],
+            )
+            if step_errors:
+                sync_missing.extend(step_errors)
+                skipped_actions.append(
+                    {
+                        "kind": action.get("kind"),
+                        "subject": subject,
+                        "action": step_kind,
+                        "reason": "; ".join(step_errors),
+                    }
+                )
+                continue
+            executed_actions.append(action)
+            continue
+        sync_missing.append(f"{subject} uses unsupported sync action `{step_kind}`")
+        skipped_actions.append(
+            {
+                "kind": action.get("kind"),
+                "subject": subject,
+                "action": step_kind,
+                "reason": f"unsupported sync action `{step_kind}`",
+            }
+        )
+
+    refreshed_payload, refreshed_errors = reconciliation_audit_payload(
+        target_root=target_root,
+        issue_number=args.issue,
+        pr_number=args.pr,
+        project_number=args.project,
+        owner=owner,
+        repo_name=repo_name,
+    )
+    if refreshed_errors:
+        sync_missing.extend(refreshed_errors)
+        refreshed_payload = payload
+    remaining_findings = [finding for finding in refreshed_payload.get("findings", []) if isinstance(finding, dict)]
+    unresolved_fix_needed = any(finding.get("severity") == "fix-needed" for finding in remaining_findings)
+
+    result = "pass"
+    summary = "reconciliation sync aligned the requested GitHub control-plane state."
+    fallback_to = None
+    if sync_missing or unresolved_fix_needed:
+        result = "block"
+        summary = "reconciliation sync could not fully align the requested GitHub control-plane state."
+        fallback_to = "manual-reconciliation"
+
+    return emit(
+        {
+            **refreshed_payload,
+            "operation": "sync",
+            "result": result,
+            "summary": summary,
+            "missing_inputs": list(dict.fromkeys(sync_missing + list(refreshed_payload.get("missing_inputs", [])))),
+            "fallback_to": fallback_to,
+            "applied_actions": executed_actions,
+            "skipped_actions": skipped_actions,
+            "remaining_findings": remaining_findings,
+            "audit": payload,
+        }
+    )
 
 
 def handle_review(args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary

- 新增 `reconciliation sync` 稳定入口，冻结 closeout 之外的写路径合同
- 保持 `closeout sync` 在 `#179` 前不提前接入 reconciliation 语义
- 补齐 reconciliation sync 的兼容面与交付面文档

## Validation

- `python3 tools/loom_flow.py reconciliation sync --help`
- `python3 tools/loom_flow.py reconciliation sync --target /Users/mc/dev/Loom-wt-178-reconciliation-sync --issue 131 --pr 138 --project 5 --dry-run`
- `python3 tools/loom_flow.py reconciliation sync --target /Users/mc/dev/Loom-wt-178-reconciliation-sync --comment x --comment-file /tmp/nope`
- `python3 tools/loom_flow.py closeout sync --target /Users/mc/dev/Loom-wt-178-reconciliation-sync --skip-gate`
- `make loom-check`

Refs #178
