### PR TITLE
feat: 收敛 #179 closeout gate fail-closed 接线

### DIFF
--- a/harness/automation-frontload.md
+++ b/harness/automation-frontload.md
@@ -97,6 +97,9 @@ Loom 仓库当前通过以下入口承接最小 core 前置检查：
 
 GitHub Actions 工作流会复用同一入口，而不是维护第二套命令。
 
+对于控制面 drift，自动化前置必须显式暴露同范围 `reconciliation audit` 结果，不能把 `warn` / `fix-needed` / `block` 静默吞掉后继续走 closeout。
+closeout 需要控制面对齐时，顺序必须是先处理 `fix-needed` / `block` drift，再继续 closeout；`warn` 必须保留在输出中，但不默认升级为阻断。
+
 对于 Loom 自身仓库，默认 gate 不应退化成单一 job 的自证通过路径。
 最小执行面至少应把以下检查拆成可单独读取的失败面：
 

--- a/harness/closeout-gate.md
+++ b/harness/closeout-gate.md
@@ -11,6 +11,7 @@ closeout gate 用来回答两件事：
 
 ## 2. 稳定入口
 
+- `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]`
 - `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]`
 - `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]`
 - `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]`
@@ -20,6 +21,7 @@ closeout gate 用来回答两件事：
 `closeout check` 至少读取：
 
 - 本地 gate 结果
+- 同范围 `reconciliation audit` 结果
 - issue 状态
 - PR 是否已 merged
 - 事项对应实现是否已达到 `absorbed`
@@ -27,6 +29,13 @@ closeout gate 用来回答两件事：
 - project 中对应 issue 的状态
 
 若这些事实不一致，结果必须返回 `block`。
+
+`closeout check` 内部消费 `reconciliation audit` 时，阻断纪律如下：
+
+- `pass`：允许继续读取 merge / main / project 等 closeout 事实
+- `warn`：必须显式挂到 closeout 输出，但不默认阻断
+- `fix-needed`：必须返回 `block`；先经 `reconciliation sync` 完成机械对齐，再重新执行 closeout check
+- `block`：必须返回 `block`；先消除硬冲突或缺失事实，且在 audit 重新达标前禁止任何 closeout sync 写入
 
 这里的 `absorbed` 只表示 host merge 后可证明的实现吸收结论，不等于 `closed_out`。
 因此，`closeout check` 至少要能区分：
@@ -37,7 +46,7 @@ closeout gate 用来回答两件事：
 
 ## 4. `sync` 最小动作
 
-本阶段的正式写路径是 `reconciliation sync`。它只做控制面对齐动作：
+本阶段的正式写路径是 `reconciliation sync`。`closeout sync` 不单独跳过这一步；它只在同范围 reconciliation 已达可同步条件后继续消费 closeout 结论。`reconciliation sync` 只做控制面对齐动作：
 
 - 先消费同范围的 `reconciliation audit` 结果，再生成可执行 sync 计划
 - 在条件满足时关闭 issue
@@ -50,7 +59,7 @@ closeout gate 用来回答两件事：
 - `--dry-run` 只输出基于 audit 的计划，不修改 GitHub 控制面
 - `--comment-file` 与 `--comment` 二选一，只为当前 issue closeout comment 提供正文来源
 
-`closeout sync` 仍保持既有 closeout 控制面对齐入口；`#179` 再把 `reconciliation audit/sync` 正式接进 gate 与 closeout。
+`closeout sync` 仍保持 closeout 控制面对齐入口，但不得绕过已显式暴露的 reconciliation 结果。
 
 若 parent issue 通过 child issue 的 `closed_out` / `absorbed` 结果完成自身 closeout 判断，`sync` 只负责把这一已成立结论写回控制面，不替代 parent 对剩余缺口的判断。
 
@@ -66,4 +75,4 @@ closeout gate 用来回答两件事：
 - 不在 Loom 内核里固化 GitHub UI、按钮或 ruleset 细节
 - 不把 project 中不存在的 PR item 强行当作阻断
 - 不让 closeout sync 绕过 gate 或 merge 事实
-- 不把 reconciliation sync 扩展成 `#179` gate 接入或 `#162` 验证自动化
+- 不把 reconciliation sync 扩展成新的对象模型或自动化宿主产品

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -28,7 +28,7 @@
 | `merge-ready` | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | fact-chain + state-check + runtime evidence + build checkpoint + merge checkpoint | `pass` / `block` / `fallback` | 只输出统一放行摘要，不替代宿主平台 merge |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
 | `retire` | `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]` -> `workspace cleanup` -> `workspace retire` | purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录 |
-| `closeout` | `python3 tools/loom_flow.py closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | loom_check + issue/PR/project/main | `pass` / `block` | 仍是 closeout 控制面对齐入口；`#179` 再接入 reconciliation 结果 |
+| `closeout` | `python3 tools/loom_flow.py closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | loom_check + 同范围 reconciliation audit/sync + issue/PR/project/main | `pass` / `block` | closeout 负责消费 reconciliation 结果；`fix-needed` / `block` 必须先停下并处理，`warn` 只显式展示 |
 
 ## 2. 分层边界
 
@@ -44,6 +44,9 @@
 - `reconciliation sync`
   - 必须先消费同范围 `reconciliation audit`
   - 不绕过 `block` finding，不伪造实现完成
+- `closeout`
+  - 负责把 reconciliation 结果接入 closeout 判定与控制面对齐
+  - 不另写新的 reconciliation 主合同，也不绕过先处理 `fix-needed` / `block` 再 closeout 的顺序
 - gate (`loom_check` / CI)
   - 负责复用同一 CLI 入口做机械阻断
   - 不维护第二套检查口径

--- a/tools/loom_check.py
+++ b/tools/loom_check.py
@@ -65,6 +65,7 @@ CORE_DOCS = (
     "harness/workspace-model.md",
     "harness/workspace-lifecycle.md",
     "harness/host-lifecycle-boundary.md",
+    "harness/reconciliation-audit.md",
     "harness/recovery-model.md",
     "harness/review-execution.md",
     "harness/status-surface.md",
@@ -389,6 +390,81 @@ def require_governance_surface(
     governance_surface = payload.get("governance_surface")
     if not isinstance(governance_surface, dict):
         failures.append(Failure(category, f"{context} must include `governance_surface` as an object"))
+
+
+def require_reconciliation_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `reconciliation` as an object"))
+        return
+    if payload.get("command") != "reconciliation":
+        failures.append(Failure(category, f"{context} must report `command: reconciliation`"))
+    if payload.get("operation") != "audit":
+        failures.append(Failure(category, f"{context} must report `operation: audit`"))
+    if payload.get("result") not in {"pass", "warn", "fix-needed", "block"}:
+        failures.append(Failure(category, f"{context} returned an unknown reconciliation result"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include a non-empty reconciliation `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include reconciliation `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "manual-reconciliation"}:
+        failures.append(Failure(category, f"{context} reconciliation fallback must be `null` or `manual-reconciliation`"))
+    findings = payload.get("findings")
+    if not isinstance(findings, list):
+        failures.append(Failure(category, f"{context} must include reconciliation `findings` as a list"))
+        return
+    for finding in findings:
+        if not isinstance(finding, dict):
+            failures.append(Failure(category, f"{context} reconciliation findings must be JSON objects"))
+            continue
+        if finding.get("kind") not in {"absorbed_but_open", "parent_drift", "project_drift"}:
+            failures.append(Failure(category, f"{context} reconciliation finding kind must stay within the stable contract"))
+        if finding.get("severity") not in {"warn", "fix-needed", "block"}:
+            failures.append(Failure(category, f"{context} reconciliation finding severity must stay within the stable contract"))
+        if not isinstance(finding.get("subject"), str) or not finding.get("subject"):
+            failures.append(Failure(category, f"{context} reconciliation findings must include non-empty `subject`"))
+        if not isinstance(finding.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} reconciliation findings must include `evidence`"))
+        if not isinstance(finding.get("recommended_action"), str) or not finding.get("recommended_action"):
+            failures.append(Failure(category, f"{context} reconciliation findings must include non-empty `recommended_action`"))
+
+
+def require_closeout_reconciliation_contract(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: dict[str, object],
+) -> None:
+    reconciliation = payload.get("reconciliation")
+    if reconciliation is None:
+        return
+    require_reconciliation_payload(
+        failures,
+        category=category,
+        context=f"{context} reconciliation",
+        payload=reconciliation,
+    )
+    if not isinstance(reconciliation, dict):
+        return
+    reconciliation_result = reconciliation.get("result")
+    closeout_result = payload.get("result")
+    fallback_to = payload.get("fallback_to")
+    if reconciliation_result == "fix-needed":
+        if closeout_result != "block":
+            failures.append(Failure(category, f"{context} must block when reconciliation returns `fix-needed`"))
+        if fallback_to != "reconciliation-sync":
+            failures.append(Failure(category, f"{context} must point `fix-needed` reconciliation drift to `reconciliation-sync`"))
+    if reconciliation_result == "block":
+        if closeout_result != "block":
+            failures.append(Failure(category, f"{context} must block when reconciliation returns `block`"))
+        if fallback_to != "manual-reconciliation":
+            failures.append(Failure(category, f"{context} must point blocked reconciliation drift to `manual-reconciliation`"))
 
 
 def check_skill_manifests(root: Path) -> list[Failure]:
@@ -977,6 +1053,11 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             {"pass"},
         ),
         (
+            "reconciliation-audit",
+            ["python3", "tools/loom_flow.py", "reconciliation", "audit", "--target", "."],
+            {"block"},
+        ),
+        (
             "purity",
             ["python3", "tools/loom_flow.py", "purity-check", "--target", "examples/new-project", "--item", "INIT-0001"],
             {"pass"},
@@ -1185,6 +1266,23 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", f"`{label}` must include `repo.owner`"))
                 if not isinstance(repo.get("name"), str) or not repo.get("name"):
                     failures.append(Failure("daily-execution-cli", f"`{label}` must include `repo.name`"))
+            require_closeout_reconciliation_contract(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload,
+            )
+        if label == "reconciliation-audit":
+            if payload.get("command") != "reconciliation":
+                failures.append(Failure("daily-execution-cli", "`reconciliation audit` must report `command: reconciliation`"))
+            if payload.get("operation") != "audit":
+                failures.append(Failure("daily-execution-cli", "`reconciliation audit` must report `operation: audit`"))
+            require_reconciliation_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`reconciliation audit`",
+                payload=payload,
+            )
         if label == "flow-merge-ready":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must report `command: flow`"))
@@ -1491,6 +1589,121 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         f"`state-check` negative sample must block, got `{state_payload.get('result')}`",
                     )
                 )
+
+    fail_closed_payloads = [
+        (
+            "closeout-fix-needed-fail-open",
+            {
+                "result": "pass",
+                "fallback_to": None,
+                "reconciliation": {
+                    "command": "reconciliation",
+                    "operation": "audit",
+                    "result": "fix-needed",
+                    "summary": "fix-needed",
+                    "missing_inputs": [],
+                    "fallback_to": "manual-reconciliation",
+                    "findings": [
+                        {
+                            "kind": "absorbed_but_open",
+                            "severity": "fix-needed",
+                            "subject": "issue #177",
+                            "evidence": {},
+                            "recommended_action": "run reconciliation sync",
+                        }
+                    ],
+                },
+            },
+        ),
+        (
+            "closeout-block-fallback-drift",
+            {
+                "result": "block",
+                "fallback_to": "merge",
+                "reconciliation": {
+                    "command": "reconciliation",
+                    "operation": "audit",
+                    "result": "block",
+                    "summary": "block",
+                    "missing_inputs": ["issue/pr/project"],
+                    "fallback_to": "manual-reconciliation",
+                    "findings": [
+                        {
+                            "kind": "parent_drift",
+                            "severity": "block",
+                            "subject": "parent issue #148",
+                            "evidence": {},
+                            "recommended_action": "manual reconciliation",
+                        }
+                    ],
+                },
+            },
+        ),
+        (
+            "closeout-malformed-reconciliation",
+            {
+                "result": "pass",
+                "fallback_to": None,
+                "reconciliation": {
+                    "command": "reconciliation",
+                    "operation": "audit",
+                    "summary": "broken",
+                    "missing_inputs": "bad",
+                    "findings": "bad",
+                },
+            },
+        ),
+    ]
+    for label, payload in fail_closed_payloads:
+        sample_failures: list[Failure] = []
+        require_closeout_reconciliation_contract(
+            sample_failures,
+            category="daily-execution-cli",
+            context=f"`{label}`",
+            payload=payload,
+        )
+        if not sample_failures:
+            failures.append(
+                Failure(
+                    "daily-execution-cli",
+                    f"`{label}` synthetic payload must fail closeout reconciliation validation",
+                )
+            )
+
+    warn_payload_failures: list[Failure] = []
+    require_closeout_reconciliation_contract(
+        warn_payload_failures,
+        category="daily-execution-cli",
+        context="`closeout-warn-does-not-block`",
+        payload={
+            "result": "pass",
+            "fallback_to": None,
+            "reconciliation": {
+                "command": "reconciliation",
+                "operation": "audit",
+                "result": "warn",
+                "summary": "warn",
+                "missing_inputs": [],
+                "fallback_to": "manual-reconciliation",
+                "findings": [
+                    {
+                        "kind": "project_drift",
+                        "severity": "warn",
+                        "subject": "project 5",
+                        "evidence": {},
+                        "recommended_action": "review warning",
+                    }
+                ],
+            },
+        },
+    )
+    if warn_payload_failures:
+        failures.append(
+            Failure(
+                "daily-execution-cli",
+                "`closeout-warn-does-not-block` synthetic payload must allow non-blocking reconciliation warnings",
+            )
+        )
 
     return failures
 

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -2363,6 +2363,19 @@ def reconciliation_sync_plan(audit_payload: dict[str, Any]) -> tuple[list[dict[s
     return plan, skipped_actions
 
 
+def closeout_reconciliation_result(
+    audit_payload: dict[str, Any] | None,
+) -> tuple[str | None, str | None]:
+    if not isinstance(audit_payload, dict):
+        return None, None
+    result = audit_payload.get("result")
+    if result == "fix-needed":
+        return "reconciliation-sync", "closeout requires reconciliation sync before it can pass."
+    if result == "block":
+        return "manual-reconciliation", "closeout requires manual reconciliation because the audit itself is blocked."
+    return None, None
+
+
 def closeout_payload(
     *,
     target_root: Path,
@@ -2382,6 +2395,27 @@ def closeout_payload(
         gate["stdout"] = gate_result.stdout.strip()
         if gate_result.returncode != 0:
             missing_inputs.append("loom_check")
+
+    reconciliation_payload: dict[str, Any] | None = None
+    closeout_fallback: str | None = None
+    closeout_summary_override: str | None = None
+    if issue_number is not None or pr_number is not None or project_number is not None:
+        reconciliation_payload, reconciliation_errors = reconciliation_audit_payload(
+            target_root=target_root,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            project_number=project_number,
+            owner=owner,
+            repo_name=repo_name,
+        )
+        if reconciliation_errors:
+            missing_inputs.extend(f"reconciliation: {message}" for message in reconciliation_errors)
+        else:
+            closeout_fallback, closeout_summary_override = closeout_reconciliation_result(reconciliation_payload)
+            if closeout_fallback == "reconciliation-sync":
+                missing_inputs.append("reconciliation audit requires sync")
+            if closeout_fallback == "manual-reconciliation":
+                missing_inputs.append("reconciliation audit is blocked")
 
     issue_payload: dict[str, Any] | None = None
     issue_id: str | None = None
@@ -2462,23 +2496,31 @@ def closeout_payload(
         missing_inputs.append("issue is not closed")
 
     result = "pass" if not missing_inputs else "block"
+    summary = (
+        "closeout state is consistent across gate, GitHub issue/PR, project, and main."
+        if result == "pass"
+        else "closeout state is not yet consistent across gate, GitHub issue/PR, project, and main."
+    )
+    fallback_to = None if result == "pass" else "merge"
+    if result == "block" and closeout_summary_override is not None:
+        summary = closeout_summary_override
+        fallback_to = closeout_fallback
+    elif result == "pass" and isinstance(reconciliation_payload, dict) and reconciliation_payload.get("result") == "warn":
+        summary = "closeout state is consistent, but reconciliation audit reported non-blocking warnings that still need review."
     return (
         {
             "command": "closeout",
             "operation": "check",
             "result": result,
-            "summary": (
-                "closeout state is consistent across gate, GitHub issue/PR, project, and main."
-                if result == "pass"
-                else "closeout state is not yet consistent across gate, GitHub issue/PR, project, and main."
-            ),
+            "summary": summary,
             "missing_inputs": missing_inputs,
-            "fallback_to": None if result == "pass" else "merge",
+            "fallback_to": fallback_to,
             "repo": {"owner": owner, "name": repo_name},
             "gate": gate,
             "issue": issue_payload,
             "pr": pr_payload,
             "project": project_payload,
+            **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
     )
@@ -2527,6 +2569,24 @@ def handle_closeout(args: argparse.Namespace) -> int:
 
     if args.operation == "check":
         return emit(payload)
+
+    reconciliation = payload.get("reconciliation")
+    if isinstance(reconciliation, dict):
+        reconciliation_result = reconciliation.get("result")
+        if reconciliation_result in {"fix-needed", "block"}:
+            return emit(
+                {
+                    **payload,
+                    "operation": "sync",
+                    "result": "block",
+                    "summary": (
+                        "closeout sync is blocked until reconciliation sync repairs the audited drift."
+                        if reconciliation_result == "fix-needed"
+                        else "closeout sync is blocked because reconciliation audit could not complete."
+                    ),
+                    "fallback_to": "reconciliation-sync" if reconciliation_result == "fix-needed" else "manual-reconciliation",
+                }
+            )
 
     sync_missing: list[str] = []
     if args.issue is not None:


### PR DESCRIPTION
## Summary

- 让 `closeout check` 正式消费同范围 `reconciliation audit`，对 `fix-needed/block` fail-closed
- 让 `closeout sync` 在 drift 未处理前拒绝继续，避免绕过 reconciliation
- 为 `loom_check` 增加 reconciliation 合同检查与 fail-closed 负样本

## Validation

- `python3 tools/loom_flow.py closeout check --target /Users/mc/dev/Loom-wt-179-audit-gate --issue 131 --pr 138 --project 5 --skip-gate`
- `python3 tools/loom_flow.py closeout check --target /Users/mc/dev/Loom-wt-179-audit-gate --skip-gate`
- `python3 tools/loom_flow.py closeout sync --target /Users/mc/dev/Loom-wt-179-audit-gate --skip-gate`
- `make loom-check`

Refs #179
