### PR TITLE
docs: 收敛 #167 宿主动作合同与结果语义

### DIFF
--- a/adoption/execution-entry-compatibility.md
+++ b/adoption/execution-entry-compatibility.md
@@ -15,7 +15,7 @@
 | 日常读取与检查 | `loom_flow fact-chain/runtime-evidence/state-check` | 输出保持 JSON 结果语义（`result/summary/missing_inputs/fallback_to`） |
 | checkpoint 执行 | `loom_flow checkpoint admission/build/merge` | 三阶段语义与回退关系保持不变 |
 | 现场与纯度治理 | `loom_flow workspace <create/locate/cleanup/retire>` + `purity-check` | 生命周期动作与失败语义保持不变 |
-| 宿主边界与 closeout | `loom_flow host-lifecycle` + `closeout check|sync` | Loom 明确边界与控制面对齐，但不接管宿主 branch/PR/worktree 生命周期；`closeout` 仍保持原有收口控制面职责 |
+| 宿主动作与 closeout | [../harness/host-action-contract.md](../harness/host-action-contract.md) + `loom_flow host-lifecycle` + `reconciliation audit|sync` + `closeout check|sync` | 新增统一主落点，不改变现有 CLI；Loom 冻结 host-facing actions 的结果与去向，但不接管宿主 branch/PR/worktree 生命周期 |
 | drift 审计与 sync | `loom_flow reconciliation audit|sync` | `audit` 只生成 absorbed-but-open / parent drift / project drift；`sync` 只消费这些 finding 做机械写回，不扩展为新的 gate/验证入口 |
 | 高频组合入口 | `loom_flow flow pre-review/review/resume/handoff/merge-ready` | 聚合入口扩张不破坏单命令入口，统一保持 JSON 结果语义 |
 | 场景 skills | `loom-adopt/resume/pre-review/review/handoff/retire/merge-ready` | 场景 skill 只做入口编排，不新增第二套事实真相源 |
@@ -26,6 +26,7 @@
 - 新增聚合入口（如 `flow pre-review`、`flow merge-ready`）不替换单命令入口
 - 新增 authored 入口（如 `review record`、`recovery writeback`、`work-item create|update`）不把只读 flow 变成隐式写入
 - 新增场景 skill 入口不替代 `loom-init` 的 root 身份，只补显式入口与隐式路由
+- 新增 [../harness/host-action-contract.md](../harness/host-action-contract.md) 只收口既有 host-facing actions 的合同，不新增 umbrella CLI，也不改写既有命令输出结构
 - `governance_surface` 只允许扩充 locator 或职责说明，不允许更名、拆成并行字段或复制实时 authored 状态
 - gate 与 verify 始终复用同一 CLI，不维护第二套检查命令
 
@@ -58,6 +59,7 @@
 - 前 1-9 步提供“该进入哪个入口/可继续执行/需阻断/是否应回退”的统一判断
 - `loom-init`、`loom-adopt`、`loom-resume` 对外公开的治理读面保持同一字段名 `governance_surface`
 - merge 阶段可按状态返回 `fallback`，而不是伪装成通过
+- host-facing actions 继续复用既有命令，但 `fallback` 只保留给 Loom 内部 checkpoint / merge control；closeout 与 reconciliation 不把 drift 伪装成 `fallback`
 - 操作流既可拆分执行，也可通过聚合入口执行高频路径
 
 ## 4. 验证结论
@@ -71,6 +73,7 @@
 - `flow resume/pre-review/review/handoff/merge-ready`：均可返回稳定 JSON 结果
 - `review record`、`recovery writeback`、`work-item create|update`：可显式回写 authored 结果而不引入第二真相
 - `checkpoint merge` 在当前样本阶段按预期返回 `fallback`
+- `host-action-contract` 把 `host-lifecycle`、`reconciliation`、`closeout` 的结果与 `fallback_to` 收到唯一主落点，而不改写既有 CLI 入口
 - `reconciliation audit` 会把 GitHub drift 显式化，但不提前执行 sync
 - `reconciliation sync` 必须先消费同范围 audit；若出现任一 `block` finding，则返回 `block` 且不写控制面
 - `reconciliation sync --dry-run` 只输出计划，不伪装成已经完成 closeout

--- a/adoption/upstream-delivery-surface.md
+++ b/adoption/upstream-delivery-surface.md
@@ -11,7 +11,7 @@
 - `governance/`
   - 核心原则、审查模型、成熟度与关闭语义
 - `harness/`
-  - 核心执行合同、恢复模型、状态面、纯度、宿主生命周期边界、closeout gate、reconciliation sync 写回约束与自动化前置
+  - 核心执行合同、恢复模型、状态面、纯度、[宿主动作主合同](../harness/host-action-contract.md)、宿主生命周期边界、closeout gate、reconciliation sync 写回约束与自动化前置
 - `templates/`
   - 最小正式规约模板与最小 PR 模板
 - `skills/`

--- a/adoption/validation-host-lifecycle-and-closeout.md
+++ b/adoption/validation-host-lifecycle-and-closeout.md
@@ -1,6 +1,6 @@
 # Validation: Host Lifecycle Boundary And Closeout Gate
 
-本文记录 `#133` / `#135` / `#162` 的最小复验。
+本文记录 `#133` / `#135` / `#162` / `#167` 的最小复验。
 
 ## 样本
 
@@ -24,21 +24,25 @@ python3 tools/loom_check.py
 - `host-lifecycle`
   - 明确 `workspace` 由 Loom 执行层承接
   - 明确 branch / PR / git worktree 继续由宿主平台承接
+  - 在事实链可读时返回 `pass`，不把宿主边界缺口伪装成顶层 `fallback`
   - 不再把 branch purity / PR purity 留成无去向的 report-only 结论
 - `closeout check`
   - 能同时读取 gate、issue、PR、project、`origin/main`
   - 对 `#131` / `#138` 返回 `pass`
   - 在输出中挂回同范围 `reconciliation audit` payload
+  - 普通 closeout 缺口继续指向 `merge`；`fix-needed` drift 指向 `reconciliation-sync`；`block` drift 指向 `manual-reconciliation`
 - `closeout sync`
   - 在状态已一致时保持幂等
   - 若 `reconciliation` 仍是 `fix-needed` / `block`，会拒绝继续 closeout 写入
+  - 只返回 `pass` / `block`，不额外发明新的 host action 结果词表
 - `reconciliation audit`
   - 对干净样本返回 `pass`
   - 负样本类型稳定收敛为 `absorbed_but_open`、`parent_drift`、`project_drift`
+  - `warn` / `fix-needed` / `block` 继续只停留在 audit 这一层，不被 closeout 改写成 `fallback`
 - `reconciliation sync --dry-run`
   - 只输出计划动作，不伪装成已经完成控制面对齐
 - `loom_check`
-  - 已纳入 `host-lifecycle`、`reconciliation audit`、`closeout` 消费边界的 CLI 契约验证
+  - 已纳入 `host-action-contract`、`host-lifecycle`、`reconciliation audit`、`closeout` 消费边界的 CLI 契约验证
   - 用合成负样本固定验证以下 fail-closed 纪律：
     - `closeout-fix-needed-fail-open`
     - `closeout-block-fallback-drift`
@@ -59,3 +63,5 @@ python3 tools/loom_check.py
 ## 结论
 
 Loom 现在已经把“执行现场抽象”和“宿主 Git/GitHub 对象生命周期”明确分层，同时把 post-merge 的 closeout 检查链路收敛成稳定命令。`#162` 进一步把负向 closeout 验证写入版本控制，证明 `fix-needed` / `block` drift 不会再被 fail-open 地放过，而 `warn` 仍保持显式展示但不默认阻断。
+
+`#167` 则把既有 `host-lifecycle`、`merge-ready`、`reconciliation`、`closeout` 收敛到 [../harness/host-action-contract.md](../harness/host-action-contract.md) 这一唯一主落点，冻结 host-facing actions 的结果与 `fallback_to` 纪律，而不新增新的宿主入口。

--- a/harness/README.md
+++ b/harness/README.md
@@ -23,6 +23,8 @@
   - 定义执行现场的隔离、定位与 clean state 要求
 - `workspace-lifecycle.md`
   - 定义 `create`、`locate`、`cleanup`、`retire` 与 `purity-check` 的生命周期合同
+- [host-action-contract.md](./host-action-contract.md)
+  - 定义现有 host-facing actions 的统一结果、`fallback_to` 与 ownership 合同
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 定义 Loom 与宿主 branch / PR / git worktree 生命周期的边界
 - [host-issue-binding.md](./host-issue-binding.md)
@@ -45,7 +47,7 @@
   - 定义现场职责纯度、分支纯度与范围控制边界
 
 这些文件共同表达的不是零散脚本集合，而是从 work item / fact-chain 到 review / merge / closeout 的统一编排链路。
-当 Loom 需要调用 GitHub、CI、review engine、`git worktree` 或其他宿主能力时，也应通过这里定义的责任边界进入，而不是在外部再复制一套真相。
+当 Loom 需要调用 GitHub、CI、review engine、`git worktree` 或其他宿主能力时，也应先通过 [host-action-contract.md](./host-action-contract.md) 收口结果与去向，再由各专题文件承接细节，而不是在外部再复制一套真相。
 
 ## 目录约束
 

--- a/harness/closeout-gate.md
+++ b/harness/closeout-gate.md
@@ -2,6 +2,8 @@
 
 本文件定义 Loom 当前最小 closeout 执行链路。
 
+宿主动作统一结果词表与 `fallback_to` 纪律见 [host-action-contract.md](./host-action-contract.md)。本文件只承接 closeout 专有的 fail-closed 顺序与同步边界。
+
 ## 1. 能力定位
 
 closeout gate 用来回答两件事：
@@ -29,6 +31,17 @@ closeout gate 用来回答两件事：
 - project 中对应 issue 的状态
 
 若这些事实不一致，结果必须返回 `block`。
+
+`closeout check` 只允许返回 `pass` 或 `block`：
+
+- 普通 closeout 缺口
+  - 返回 `block`，并把 `fallback_to` 指向 `merge`
+- reconciliation 返回 `fix-needed`
+  - 返回 `block`，并把 `fallback_to` 指向 `reconciliation-sync`
+- reconciliation 返回 `block`
+  - 返回 `block`，并把 `fallback_to` 指向 `manual-reconciliation`
+
+`closeout` 不把 drift 或控制面缺口伪装成顶层 `fallback` 结果。
 
 `closeout check` 内部消费 `reconciliation audit` 时，阻断纪律如下：
 
@@ -60,6 +73,8 @@ closeout gate 用来回答两件事：
 - `--comment-file` 与 `--comment` 二选一，只为当前 issue closeout comment 提供正文来源
 
 `closeout sync` 仍保持 closeout 控制面对齐入口，但不得绕过已显式暴露的 reconciliation 结果。
+
+`closeout sync` 也只允许返回 `pass` 或 `block`。若同步前置不满足，或同步后仍无法把控制面对齐，必须继续显式指向 `reconciliation-sync`、`manual-reconciliation` 或 `merge`，而不是产出新的 host action 结果词表。
 
 若 parent issue 通过 child issue 的 `closed_out` / `absorbed` 结果完成自身 closeout 判断，`sync` 只负责把这一已成立结论写回控制面，不替代 parent 对剩余缺口的判断。
 

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -8,6 +8,8 @@
 - 每个入口读取哪类输入
 - 哪些动作属于“执行入口”，哪些属于“放行入口”
 
+宿主动作的统一结果词表与 `fallback_to` 纪律见 [host-action-contract.md](./host-action-contract.md)；本文件只保留矩阵视图。
+
 ## 1. 入口矩阵
 
 | 动作 | 首选入口 | 读取基线 | 结果形态 | 备注 |
@@ -23,12 +25,12 @@
 | `recovery writeback` | `python3 tools/loom_flow.py recovery writeback --target <repo> [--item <id>] ...` | 当前 fact-chain + recovery authored 字段 | `pass` / `block` | 只写 recovery 主入口，再同步状态面 |
 | `work item authoring` | `python3 tools/loom_flow.py work-item create|update --target <repo> --item <id> ... [--activate]` | init-result locator + work item static fields | `pass` / `block` | `--activate` 只切当前 locator，不隐式写动态状态 |
 | `host lifecycle boundary` | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | fact-chain + purity + 当前 branch/worktree 观测 | `pass` / `block` | 明确 workspace 由 Loom 管，branch/PR/worktree 由宿主管 |
-| `reconciliation audit` | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | issue tree + PR merge事实 + Project 状态 | `pass` / `warn` / `fix-needed` / `block` | 只报出 drift，不修改 GitHub 控制面 |
-| `reconciliation sync` | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 同范围 reconciliation audit + issue/PR/project 控制面 | `pass` / `block` | 只修机械可证明的 `fix-needed` drift；`block` 零写入，`warn` 仅保留提示 |
-| `merge-ready` | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | fact-chain + state-check + runtime evidence + build checkpoint + merge checkpoint | `pass` / `block` / `fallback` | 只输出统一放行摘要，不替代宿主平台 merge |
+| `reconciliation audit` | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | issue tree + PR merge事实 + Project 状态 | `pass` / `warn` / `fix-needed` / `block` | 只报出 drift，不修改 GitHub 控制面；非 `pass` 的去向由 [host-action-contract.md](./host-action-contract.md) 统一定义 |
+| `reconciliation sync` | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 同范围 reconciliation audit + issue/PR/project 控制面 | `pass` / `block` | 只修机械可证明的 `fix-needed` drift；`block` 零写入，`warn` 仅保留提示，不提升成第二套 closeout 语义 |
+| `merge-ready` | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | fact-chain + state-check + runtime evidence + build checkpoint + merge checkpoint | `pass` / `block` / `fallback` | 只输出统一放行摘要，不替代宿主平台 merge；`fallback_to` 只能回到 Loom 内部 checkpoint |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
 | `retire` | `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]` -> `workspace cleanup` -> `workspace retire` | purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录 |
-| `closeout` | `python3 tools/loom_flow.py closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | loom_check + 同范围 reconciliation audit/sync + issue/PR/project/main | `pass` / `block` | closeout 负责消费 reconciliation 结果；`fix-needed` / `block` 必须先停下并处理，`warn` 只显式展示 |
+| `closeout` | `python3 tools/loom_flow.py closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | loom_check + 同范围 reconciliation audit/sync + issue/PR/project/main | `pass` / `block` | closeout 负责消费 reconciliation 结果；`fix-needed` / `block` 必须先停下并处理，`warn` 只显式展示，且不得伪装成 `fallback` |
 
 ## 2. 分层边界
 

--- a/harness/host-action-contract.md
+++ b/harness/host-action-contract.md
@@ -1,0 +1,125 @@
+# Host Action Contract
+
+本文件定义 Loom 当前已冻结的宿主动作合同。
+
+本文件当前承接：
+
+- `#167`
+
+它只收口三件事：
+
+- 哪些现有入口属于 Loom 的宿主动作面
+- 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
+- Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
+
+## 1. 能力定位
+
+Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
+
+它是 Loom 对现有 host-facing actions 的统一合同层，用来把以下能力收成同一组结果语义：
+
+- 宿主对象边界读取
+- 宿主 gate / required checks / merge controls 的放行消费
+- post-merge 的 drift 审计与控制面对齐
+
+具体专题落点仍保持拆分：
+
+- 对象 ownership 边界见 [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
+- merge 前放行细节见 [merge-checkpoint.md](./merge-checkpoint.md)
+- 自动检查与 required checks 读面见 [automation-frontload.md](./automation-frontload.md)
+- drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
+- closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
+
+## 2. 覆盖范围
+
+当前冻结的宿主动作只包括现有入口：
+
+| 类别 | 稳定入口 | 宿主写入 | 说明 |
+| --- | --- | --- | --- |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+
+以下内容继续明确排除在 Loom 宿主动作面之外：
+
+- branch create / rename / retire
+- PR create / update / merge / close
+- git worktree create / remove
+- CI 产品实现、required checks 配置界面、merge button 与 ruleset 细节
+
+## 3. 统一输出面
+
+宿主动作沿用 Loom 既有 JSON 输出骨架，不新增第二套结果对象：
+
+- `command`
+- `operation`（若该入口有子动作）
+- `result`
+- `summary`
+- `missing_inputs`
+- `fallback_to`
+
+某些入口会额外带上专题字段，例如：
+
+- `host-lifecycle.objects`
+- `reconciliation.findings`
+- `closeout.reconciliation`
+- `flow merge-ready` / `checkpoint merge` 的放行细节
+
+这些专题字段可以扩展，但不得绕过本文件定义的结果纪律。
+
+## 4. 结果与 `fallback_to` 纪律
+
+宿主动作当前冻结以下结果集合：
+
+| 入口 | 允许结果 | `fallback_to` 纪律 |
+| --- | --- | --- |
+| `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
+| `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
+| `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
+| `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
+| `closeout sync` | `pass` / `block` | 不得绕过 reconciliation；若同步前置未满足或同步后仍未对齐，指向 `reconciliation-sync` 或 `manual-reconciliation`；其他 closeout 缺口继续指向 `merge` |
+
+补充纪律：
+
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
+- `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
+- `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
+- 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
+
+## 5. Ownership Boundary
+
+Loom 当前承接：
+
+- workspace execution semantics
+- required checks / validation / review / risk rollback 的放行消费
+- 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
+- closeout 前后的控制面对齐判断
+
+宿主平台当前承接：
+
+- branch / PR / git worktree 的真实生命周期动作
+- 实际 merge / close / status UI 与策略
+- CI 产品实现与 required checks 配置机制
+
+因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
+
+## 6. 专题文件分工
+
+- [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
+  - 只定义 workspace、branch、PR、git worktree 的 ownership boundary
+- [merge-checkpoint.md](./merge-checkpoint.md)
+  - 只定义 merge control 的执行侧放行输入、结果与回退承接
+- [automation-frontload.md](./automation-frontload.md)
+  - 只定义适合前置机械化的 checks surface
+- [reconciliation-audit.md](./reconciliation-audit.md)
+  - 只定义 drift finding taxonomy 与 audit 结果语义
+- [closeout-gate.md](./closeout-gate.md)
+  - 只定义 closeout check / sync 的最小链路与 fail-closed 顺序
+
+这些文件共同表达一条统一宿主动作链路，但本文件是结果词表、`fallback_to` 与 ownership 收口的唯一主落点。

--- a/harness/host-lifecycle-boundary.md
+++ b/harness/host-lifecycle-boundary.md
@@ -2,6 +2,8 @@
 
 本文件定义 Loom 与宿主平台在 `workspace`、branch、PR、git worktree 之间的生命周期边界。
 
+宿主动作入口、结果词表与 `fallback_to` 纪律的统一主落点见 [host-action-contract.md](./host-action-contract.md)。
+
 稳定命名与对象分类见 [../governance/host-object-taxonomy.md](../governance/host-object-taxonomy.md)。
 `active issue` 与 branch / `git worktree` / PR / merge commit 的绑定消费见 [host-issue-binding.md](./host-issue-binding.md)。
 
@@ -37,12 +39,13 @@ Loom 当前不提供以下原生命令：
 
 这些动作继续留给 Git / GitHub 或其他宿主平台。
 
-## 4. 稳定入口
+## 4. 边界读取入口
 
 - `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py workspace create|locate|cleanup|retire --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]`
-- `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]`
+
+更广的 host-facing actions，例如 `checkpoint merge`、`flow merge-ready`、`reconciliation audit|sync`、`closeout check|sync`，统一由 [host-action-contract.md](./host-action-contract.md) 索引。
 
 ## 5. 边界约束
 
@@ -50,3 +53,4 @@ Loom 当前不提供以下原生命令：
 - `workspace` 是执行现场抽象，不等于 git worktree
 - Loom 只消费 `active issue` 与宿主对象的绑定，不在这里主定义 `active issue`
 - 宿主对象的 UI、命名、按钮与策略不进入 Loom 默认内核
+- `host-lifecycle` 正常只读边界，不把宿主动作缺口伪装成 `fallback`；回退纪律由 [host-action-contract.md](./host-action-contract.md) 统一承接

--- a/tools/loom_check.py
+++ b/tools/loom_check.py
@@ -64,6 +64,7 @@ CORE_DOCS = (
     "harness/checkpoint-model.md",
     "harness/workspace-model.md",
     "harness/workspace-lifecycle.md",
+    "harness/host-action-contract.md",
     "harness/host-lifecycle-boundary.md",
     "harness/reconciliation-audit.md",
     "harness/recovery-model.md",
@@ -390,6 +391,118 @@ def require_governance_surface(
     governance_surface = payload.get("governance_surface")
     if not isinstance(governance_surface, dict):
         failures.append(Failure(category, f"{context} must include `governance_surface` as an object"))
+        return
+
+    required_keys = (
+        "repository_mode",
+        "loom_state",
+        "carrier_summary",
+        "execution_entry",
+        "validation_entry",
+        "review_merge_surface",
+        "github_control_plane",
+        "summary",
+        "missing_inputs",
+    )
+    for key in required_keys:
+        if key not in governance_surface:
+            failures.append(Failure(category, f"{context} governance_surface must include `{key}`"))
+
+    for key in ("repository_mode", "loom_state", "execution_entry", "validation_entry", "summary"):
+        if key in governance_surface and (not isinstance(governance_surface.get(key), str) or not governance_surface.get(key)):
+            failures.append(Failure(category, f"{context} governance_surface `{key}` must be a non-empty string"))
+
+    missing_inputs = governance_surface.get("missing_inputs")
+    if missing_inputs is not None and not isinstance(missing_inputs, list):
+        failures.append(Failure(category, f"{context} governance_surface `missing_inputs` must be a list"))
+
+    carrier_summary = governance_surface.get("carrier_summary")
+    if not isinstance(carrier_summary, dict):
+        failures.append(Failure(category, f"{context} governance_surface must include `carrier_summary`"))
+    else:
+        required_carriers = ("work_item", "recovery", "review", "status_surface", "spec_path", "plan_path")
+        for carrier in required_carriers:
+            entry = carrier_summary.get(carrier)
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} governance_surface carrier `{carrier}` must be an object"))
+                continue
+            if entry.get("status") not in {"present", "missing", "planned"}:
+                failures.append(
+                    Failure(category, f"{context} governance_surface carrier `{carrier}` status must stay within the stable contract")
+                )
+            for field in ("locator", "source"):
+                value = entry.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(
+                        Failure(category, f"{context} governance_surface carrier `{carrier}` must include non-empty `{field}`")
+                    )
+
+    for key in ("review_merge_surface", "github_control_plane"):
+        value = governance_surface.get(key)
+        if value is not None and not isinstance(value, dict):
+            failures.append(Failure(category, f"{context} governance_surface `{key}` must be an object"))
+
+
+def require_host_lifecycle_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: dict[str, object],
+) -> None:
+    if payload.get("result") not in {"pass", "block"}:
+        failures.append(Failure(category, f"{context} must return `pass` or `block`"))
+    if payload.get("fallback_to") not in {None, "admission"}:
+        failures.append(Failure(category, f"{context} fallback must be `null` or `admission`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include a non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+
+    objects = payload.get("objects")
+    if not isinstance(objects, dict):
+        failures.append(Failure(category, f"{context} must include `objects`"))
+        return
+
+    workspace = objects.get("workspace")
+    branch = objects.get("branch")
+    pr = objects.get("pr")
+    worktree = objects.get("worktree")
+    for key, value in (("workspace", workspace), ("branch", branch), ("pr", pr), ("worktree", worktree)):
+        if not isinstance(value, dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    if not isinstance(workspace, dict) or not isinstance(branch, dict) or not isinstance(pr, dict) or not isinstance(worktree, dict):
+        return
+
+    if workspace.get("ownership") != "loom":
+        failures.append(Failure(category, f"{context} workspace ownership must stay `loom`"))
+    for field in ("entry", "path", "lifecycle_entry"):
+        value = workspace.get(field)
+        if not isinstance(value, str) or not value:
+            failures.append(Failure(category, f"{context} workspace must include non-empty `{field}`"))
+
+    if branch.get("ownership") != "host":
+        failures.append(Failure(category, f"{context} branch ownership must stay `host`"))
+    if branch.get("purity_status") not in {"report_only", "host_managed_without_local_branch"}:
+        failures.append(Failure(category, f"{context} branch purity_status must stay within the stable contract"))
+    if not isinstance(branch.get("next_action"), str) or not branch.get("next_action"):
+        failures.append(Failure(category, f"{context} branch must include non-empty `next_action`"))
+
+    if pr.get("ownership") != "host":
+        failures.append(Failure(category, f"{context} PR ownership must stay `host`"))
+    if pr.get("purity_status") != "report_only":
+        failures.append(Failure(category, f"{context} PR purity_status must stay `report_only`"))
+    if not isinstance(pr.get("next_action"), str) or not pr.get("next_action"):
+        failures.append(Failure(category, f"{context} PR must include non-empty `next_action`"))
+
+    if worktree.get("ownership") != "host":
+        failures.append(Failure(category, f"{context} worktree ownership must stay `host`"))
+    if worktree.get("status") != "host_managed":
+        failures.append(Failure(category, f"{context} worktree status must stay `host_managed`"))
+    for field in ("cwd_within_repo", "next_action"):
+        value = worktree.get(field)
+        if not isinstance(value, str) or not value:
+            failures.append(Failure(category, f"{context} worktree must include non-empty `{field}`"))
 
 
 def require_reconciliation_payload(
@@ -1243,13 +1356,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         if label == "host-lifecycle":
             if payload.get("command") != "host-lifecycle":
                 failures.append(Failure("daily-execution-cli", "`host-lifecycle` must report `command: host-lifecycle`"))
-            objects = payload.get("objects")
-            if not isinstance(objects, dict):
-                failures.append(Failure("daily-execution-cli", "`host-lifecycle` must include `objects`"))
-            else:
-                for key in ("workspace", "branch", "pr", "worktree"):
-                    if not isinstance(objects.get(key), dict):
-                        failures.append(Failure("daily-execution-cli", f"`host-lifecycle` must include `{key}`"))
+            require_host_lifecycle_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`host-lifecycle`",
+                payload=payload,
+            )
         if label in {"closeout-check", "closeout-sync"}:
             if payload.get("command") != "closeout":
                 failures.append(Failure("daily-execution-cli", f"`{label}` must report `command: closeout`"))


### PR DESCRIPTION
## Summary
- 新增 `harness/host-action-contract.md`，统一收口现有 host-facing actions 的范围、结果词表与 `fallback_to` 纪律
- 对齐 `host-lifecycle`、`merge-ready`、`reconciliation`、`closeout` 的文档与 gate 消费边界
- 不新增新的宿主动作总 CLI，不把 GitHub / `gh` 变成 Loom 内核自动化产品

## Validation
- `python3 tools/loom_flow.py host-lifecycle --target examples/new-project --item INIT-0001`
- `python3 tools/loom_flow.py flow merge-ready --target examples/new-project --item INIT-0001`
- `python3 tools/loom_flow.py reconciliation audit --target .`
- `python3 tools/loom_flow.py reconciliation sync --target . --dry-run`
- `python3 tools/loom_flow.py closeout check --target . --skip-gate`
- `python3 tools/loom_check.py`
- `make loom-check`

## Alignment Notes
- `review record` 继续留在 repo execution truth，不进入 host action 主合同
- `closeout` / `reconciliation` 只承接 host control-plane drift 与 sync，不承接 review rebuttal 真相
