### PR TITLE
feat: 收敛 #152 review rebuttal 与 disposition 合同

### DIFF
--- a/adoption/validation-review-and-authoring.md
+++ b/adoption/validation-review-and-authoring.md
@@ -26,14 +26,24 @@ python3 tools/loom_flow.py work-item update --target <temp-copy> --item NEXT-000
 cat > <temp-copy>/.loom/review-findings.json <<'JSON'
 [
   {
+    "id": "block-1",
     "summary": "Formal review has not approved the item yet.",
-    "severity": "fix-needed",
-    "disposition": "blocking_issue"
+    "severity": "block",
+    "rebuttal": null,
+    "disposition": {
+      "status": "rejected",
+      "summary": "The missing approval signal still blocks the review."
+    }
   },
   {
+    "id": "warn-1",
     "summary": "Re-run formal review after the missing approval signal is resolved.",
     "severity": "warn",
-    "disposition": "follow_up"
+    "rebuttal": "The follow-up review will be recorded after the blocking item is cleared.",
+    "disposition": {
+      "status": "deferred",
+      "summary": "This follow-up remains open until the next formal review."
+    }
   }
 ]
 JSON
@@ -53,7 +63,8 @@ python3 tools/loom_flow.py review record --target <temp-copy> --item NEXT-0001 -
   - 只写静态字段；`--activate` 才切换当前 locator truth
 - `review record`
   - 能在单一 `review_entry` 中写出 merge checkpoint 可机械消费的正式 review 结论
-  - `findings` 成为权威数组，`blocking_issues` / `follow_ups` 只保留兼容投影
+  - `findings` 成为权威数组，逐条承接 `id`、`severity`、`rebuttal`、`disposition`
+  - `blocking_issues` / `follow_ups` 只保留兼容投影
 - `loom_check`
   - 已把 `flow review`、`review read|record`、`recovery writeback`、`work-item create|update` 纳入 gate
 

--- a/adoption/validation-review-and-authoring.md
+++ b/adoption/validation-review-and-authoring.md
@@ -23,7 +23,21 @@ python3 tools/loom_check.py
 python3 tools/loom_flow.py recovery writeback --target <temp-copy> --item INIT-0001 --current-stop "Bootstrap review has started." --next-step "Record the first formal review conclusion." --latest-validation-summary "Bootstrap artifacts verified and ready for semantic review."
 python3 tools/loom_flow.py work-item create --target <temp-copy> --item NEXT-0001 --goal "Validate work item authoring" --scope "Limit changes to `.loom/` artifacts for this temp check" --execution-path execution/support --workspace-entry . --validation-entry "python3 .loom/bin/loom_init.py verify --target ." --closing-condition "The authored work item can be activated and read mechanically." --init-recovery --activate
 python3 tools/loom_flow.py work-item update --target <temp-copy> --item NEXT-0001 --scope "Keep the temp authoring check constrained to `.loom/` files"
-python3 tools/loom_flow.py review record --target <temp-copy> --item NEXT-0001 --decision fallback --kind code_review --summary "Formal review has not approved the item yet." --reviewer loom-check --fallback-to admission
+cat > <temp-copy>/.loom/review-findings.json <<'JSON'
+[
+  {
+    "summary": "Formal review has not approved the item yet.",
+    "severity": "fix-needed",
+    "disposition": "blocking_issue"
+  },
+  {
+    "summary": "Re-run formal review after the missing approval signal is resolved.",
+    "severity": "warn",
+    "disposition": "follow_up"
+  }
+]
+JSON
+python3 tools/loom_flow.py review record --target <temp-copy> --item NEXT-0001 --decision fallback --kind code_review --summary "Formal review has not approved the item yet." --reviewer loom-check --fallback-to admission --findings-file .loom/review-findings.json
 ```
 
 ## 结果
@@ -38,7 +52,8 @@ python3 tools/loom_flow.py review record --target <temp-copy> --item NEXT-0001 -
 - `work-item create/update`
   - 只写静态字段；`--activate` 才切换当前 locator truth
 - `review record`
-  - 能写出 merge checkpoint 可机械消费的正式 review 结论
+  - 能在单一 `review_entry` 中写出 merge checkpoint 可机械消费的正式 review 结论
+  - `findings` 成为权威数组，`blocking_issues` / `follow_ups` 只保留兼容投影
 - `loom_check`
   - 已把 `flow review`、`review read|record`、`recovery writeback`、`work-item create|update` 纳入 gate
 

--- a/adoption/validation-review-and-authoring.md
+++ b/adoption/validation-review-and-authoring.md
@@ -68,6 +68,19 @@ python3 tools/loom_flow.py review record --target <temp-copy> --item NEXT-0001 -
 - `loom_check`
   - 已把 `flow review`、`review read|record`、`recovery writeback`、`work-item create|update` 纳入 gate
 
+## 对齐复核
+
+- `host action`
+  - 主定义继续落在 [../harness/host-action-contract.md](../harness/host-action-contract.md)
+- `review record`
+  - 主定义继续落在 [../harness/review-execution.md](../harness/review-execution.md)
+- `rebuttal` / `disposition`
+  - 只进入 review record 的权威 `findings` 数组，不迁移到 PR comments、closeout 或 reconciliation
+- `review comments` / `guardian output`
+  - 继续只作为 evidence，不升级为 authored truth
+- `closeout` / `reconciliation sync`
+  - 继续只承接 host control-plane drift 与 sync，不承接 review rebuttal 真相
+
 ## 结论
 
 `pre-review -> review -> merge-ready -> merge checkpoint` 已形成明确分层；同时 recovery writeback 与 work item authoring 也已有稳定脚本面，不再只停留在规则层。

--- a/governance/host-object-taxonomy.md
+++ b/governance/host-object-taxonomy.md
@@ -103,7 +103,7 @@ Loom 当前固定四类对象：
 例如：
 
 - `review record`
-  - 是真相对象
+  - 是真相对象，内部承接正式 review 的 findings / disposition contract
 - `review comments`
   - 是证据对象
 
@@ -118,7 +118,7 @@ Loom 当前固定以下命名规则：
 - issue activation
   - 只表示宿主 issue 已进入当前执行，不等于 `work-item --activate`
 - `review record`
-  - 只表示正式 review 真相
+  - 只表示正式 review 真相，包含同一载体内的 findings / disposition authored 字段
 - `PR`
   - 只表示宿主实现载体
 - `merge-ready`

--- a/governance/host-object-taxonomy.md
+++ b/governance/host-object-taxonomy.md
@@ -103,7 +103,7 @@ Loom 当前固定四类对象：
 例如：
 
 - `review record`
-  - 是真相对象，内部承接正式 review 的 findings / disposition contract
+  - 是真相对象，内部承接正式 review 的 findings / rebuttal / disposition contract
 - `review comments`
   - 是证据对象
 
@@ -118,7 +118,7 @@ Loom 当前固定以下命名规则：
 - issue activation
   - 只表示宿主 issue 已进入当前执行，不等于 `work-item --activate`
 - `review record`
-  - 只表示正式 review 真相，包含同一载体内的 findings / disposition authored 字段
+  - 只表示正式 review 真相，包含同一载体内的 findings / rebuttal / disposition authored 字段
 - `PR`
   - 只表示宿主实现载体
 - `merge-ready`

--- a/governance/truth-and-sync-boundary.md
+++ b/governance/truth-and-sync-boundary.md
@@ -50,7 +50,7 @@ Loom 当前固定四层：
 - recovery 主入口
   - 现在停在哪、下一步是什么、有什么阻断
 - review record
-  - 正式 review 给出的结论、权威 findings 与 disposition 是什么
+  - 正式 review 给出的结论、权威 findings、rebuttal 与 disposition 是什么
 
 ## 4. Host Control Truth
 

--- a/governance/truth-and-sync-boundary.md
+++ b/governance/truth-and-sync-boundary.md
@@ -50,7 +50,7 @@ Loom 当前固定四层：
 - recovery 主入口
   - 现在停在哪、下一步是什么、有什么阻断
 - review record
-  - 正式 review 给出的结论是什么
+  - 正式 review 给出的结论、权威 findings 与 disposition 是什么
 
 ## 4. Host Control Truth
 
@@ -99,6 +99,8 @@ Loom 当前固定四层：
 
 - review 结论
   - 回写到 review record
+- review findings / disposition
+  - 仍回写到同一 review record，不新增第二 authored truth object 或状态机
 - 动态停点与下一步
   - 回写到 recovery 主入口
 

--- a/harness/merge-checkpoint.md
+++ b/harness/merge-checkpoint.md
@@ -50,6 +50,7 @@ merge checkpoint 是执行侧的最终放行层。
   - 只能从恢复主入口读取
 - 正式 review 结论
   - 只能从 `work item.review_entry` 指向的 review record 读取
+  - 其中 `findings` 是 review/disposition 的权威字段；`blocking_issues` / `follow_ups` 只作兼容投影
 - 状态面
   - 只允许作为派生汇总读面，不得替代上述主真相
 
@@ -84,6 +85,7 @@ merge checkpoint 只允许输出以下三类结果：
 ## 5. 边界约束
 
 - merge checkpoint 消费 reviewer、自动检查和运行证据的结果，不重新发明第二套审查体系
+- merge checkpoint 只消费单一 review record，不为 findings / disposition 再引入第二 authored artifact
 - merge checkpoint 只回答“是否可进入 host merge”，进入主干后的 issue / project / main 收口由 [closeout-gate.md](./closeout-gate.md) 承接
 - merge checkpoint 不负责定义成熟度、关闭语义或事项是否值得做；这些属于 `governance/`
 - merge checkpoint 不得补读另一份 authored 状态摘要来替代恢复主入口

--- a/harness/review-execution.md
+++ b/harness/review-execution.md
@@ -24,6 +24,12 @@ Loom 把 review 分成三层：
 - `python3 tools/loom_flow.py flow review --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py review record --target <repo> [--item <id>] --decision <allow|block|fallback> --kind <general_review|code_review|spec_review> --summary <text> --reviewer <id>`
 
+其中：
+
+- `review record` 仍只写入单一 `review_entry` 指向的 JSON
+- 结构化审查结论可通过 `--findings-file <path>` 写入同一 review record
+- `--blocking-issue` / `--follow-up` 只保留兼容 authored 入口，不得与 `--findings-file` 混用
+
 ## 3. review record 最小字段
 
 review record 至少应包含：
@@ -36,10 +42,19 @@ review record 至少应包含：
 - `summary`
 - `reviewer`
 - `fallback_to`
+- `findings`
 - `blocking_issues`
 - `follow_ups`
 
 模板见 [../templates/review-record.md](../templates/review-record.md)。
+
+其中：
+
+- `findings` 是正式审查结论的权威数组
+- 每条 finding 至少应包含 `summary`、`severity`、`disposition`
+- `severity` 当前稳定值为 `warn`、`fix-needed`、`block`
+- `disposition` 当前稳定值为 `blocking_issue`、`follow_up`
+- `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 
 ## 4. 与 merge checkpoint 的边界
 
@@ -52,9 +67,11 @@ review record 至少应包含：
 - `decision: allow` 才算 review 已通过
 - `decision: block` 返回 `block`
 - `decision: fallback` 按 `fallback_to` 返回 `fallback`
+- 如需读取阻断或后续事项，只能优先消费同一 review record 内的 `findings`
 
 ## 5. 非目标
 
 - 不把 review 结论写回 recovery entry 或 status surface
 - 不让 PR 模板充当正式 review 真相
 - 不让 merge-ready 替代正式 review
+- 不为 rebuttal / disposition 再创建第二份 review artifact 或新状态机

--- a/harness/review-execution.md
+++ b/harness/review-execution.md
@@ -51,9 +51,10 @@ review record 至少应包含：
 其中：
 
 - `findings` 是正式审查结论的权威数组
-- 每条 finding 至少应包含 `summary`、`severity`、`disposition`
-- `severity` 当前稳定值为 `warn`、`fix-needed`、`block`
-- `disposition` 当前稳定值为 `blocking_issue`、`follow_up`
+- 每条 finding 至少应包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`
+- `severity` 当前稳定值为 `warn`、`block`
+- `rebuttal` 当前稳定值为 `null` 或非空字符串
+- `disposition` 当前稳定值为 `null` 或对象；对象内的 `status` 只允许 `accepted`、`rejected`、`deferred`
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 
 ## 4. 与 merge checkpoint 的边界

--- a/skills/loom-review/SKILL.md
+++ b/skills/loom-review/SKILL.md
@@ -33,6 +33,12 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `python3 tools/loom_flow.py flow review --target <repo> [--item <id>]`
 - `python3 tools/loom_flow.py review record --target <repo> [--item <id>] --decision <allow|block|fallback> --kind <general_review|code_review|spec_review> --summary <text> --reviewer <id>`
 
+补充约束：
+
+- 若需要写入结构化 findings / disposition，使用 `--findings-file <path>`
+- `--blocking-issue` / `--follow-up` 仅保留兼容 authored 入口，不得与 `--findings-file` 混用
+- 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
+
 这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review record` 把审查结论写成可消费载体。
 
 ## 3. 固定编排
@@ -60,6 +66,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - review 机械基线结果
 - build checkpoint 是否允许进入正式审查
 - review artifact 的定位与已记录结论
+- review record 中的权威 findings / disposition 摘要
 - 审查结论（`allow` / `block` / `fallback`）
 - 若当前不能继续，应回退到哪里
 
@@ -71,6 +78,7 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - 审查执行严格以 `flow review` 为前置，而不是绕过预检
 - 输出 JSON 与 review record 都能直接支撑 merge checkpoint 消费
 - skill 不创建第二 authored 真相源，不替代 merge-ready 聚合
+- review/disposition contract 只扩展 review record 内部字段，不新增第二 artifact 或新状态机
 
 输入信号与输出合同见：
 

--- a/skills/loom-review/contract.json
+++ b/skills/loom-review/contract.json
@@ -3,7 +3,7 @@
   "role": "scenario/review",
   "contract_version": "1.2.0",
   "display_name": "Loom Review",
-  "description": "Run the formal semantic review layer on top of pre-review and return findings plus a review verdict without replacing merge-ready.",
+  "description": "Run the formal semantic review layer on top of pre-review and return authoritative review findings plus a verdict without replacing merge-ready.",
   "root_entry": false,
   "entrypoint": {
     "skill_markdown": "SKILL.md",

--- a/skills/loom-review/references/output-contract.md
+++ b/skills/loom-review/references/output-contract.md
@@ -21,8 +21,15 @@
 - `build_checkpoint`
   - build checkpoint 的结果、摘要、缺失输入与回退语义
 - `review`
-  - 正式 review artifact 的定位与已记录结论
+  - 唯一 `review_entry` review record 的定位、已记录结论，以及权威 findings / disposition 摘要
 - `current_checkpoint`
   - 当前 recovery checkpoint 的原始值与归一化值
+
+`review` 段至少应让执行者读出：
+
+- 读取的是哪一个 `review_entry`
+- review record 中的 `decision`
+- review record 中的权威 `findings`
+- `blocking_issues` / `follow_ups` 只是兼容字段，而不是第二份审查工件
 
 这个 skill 负责正式 review 执行层，不替代 `loom-pre-review` 的机械预检，也不替代 `loom-merge-ready` 的 merge 前聚合放行判断。

--- a/skills/loom-review/references/output-contract.md
+++ b/skills/loom-review/references/output-contract.md
@@ -30,6 +30,7 @@
 - 读取的是哪一个 `review_entry`
 - review record 中的 `decision`
 - review record 中的权威 `findings`
+- 每条 finding 的 `id`、`severity`、`rebuttal` 与 `disposition`
 - `blocking_issues` / `follow_ups` 只是兼容字段，而不是第二份审查工件
 
 这个 skill 负责正式 review 执行层，不替代 `loom-pre-review` 的机械预检，也不替代 `loom-merge-ready` 的 merge 前聚合放行判断。

--- a/templates/review-record.md
+++ b/templates/review-record.md
@@ -10,6 +10,7 @@
 - `summary`
 - `reviewer`
 - `fallback_to`
+- `findings`
 - `blocking_issues`
 - `follow_ups`
 
@@ -23,4 +24,8 @@
 
 - `fallback_to` 只在 `decision: fallback` 时使用
 - `reviewed_head` 与 `reviewed_validation_summary` 必须对应本次审查基线
+- `findings` 是权威 findings / disposition 数组；每条至少包含 `summary`、`severity`、`disposition`
+- `severity` 当前稳定值为 `warn`、`fix-needed`、`block`
+- `disposition` 当前稳定值为 `blocking_issue`、`follow_up`
+- `blocking_issues` / `follow_ups` 仅作为兼容字段保留，默认从 `findings` 投影，不应被当作独立 authored 真相
 - review record 是 merge checkpoint 的正式输入之一，不得只留在会话或 PR 评论里

--- a/templates/review-record.md
+++ b/templates/review-record.md
@@ -24,8 +24,9 @@
 
 - `fallback_to` 只在 `decision: fallback` 时使用
 - `reviewed_head` 与 `reviewed_validation_summary` 必须对应本次审查基线
-- `findings` 是权威 findings / disposition 数组；每条至少包含 `summary`、`severity`、`disposition`
-- `severity` 当前稳定值为 `warn`、`fix-needed`、`block`
-- `disposition` 当前稳定值为 `blocking_issue`、`follow_up`
+- `findings` 是权威 findings / rebuttal / disposition 数组；每条至少包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`
+- `severity` 当前稳定值为 `warn`、`block`
+- `rebuttal` 当前稳定值为 `null` 或非空字符串
+- `disposition` 当前稳定值为 `null` 或对象；对象内的 `status` 只允许 `accepted`、`rejected`、`deferred`
 - `blocking_issues` / `follow_ups` 仅作为兼容字段保留，默认从 `findings` 投影，不应被当作独立 authored 真相
 - review record 是 merge checkpoint 的正式输入之一，不得只留在会话或 PR 评论里

--- a/tools/loom_check.py
+++ b/tools/loom_check.py
@@ -191,6 +191,9 @@ GOVERNANCE_SURFACE_CONTRACT_SKILLS = {
     "loom-resume",
 }
 
+REVIEW_FINDING_SEVERITIES = {"warn", "fix-needed", "block"}
+REVIEW_FINDING_DISPOSITIONS = {"blocking_issue", "follow_up"}
+
 
 def repo_root_from_argv(argv: list[str]) -> Path:
     if len(argv) > 2:
@@ -578,6 +581,37 @@ def require_closeout_reconciliation_contract(
             failures.append(Failure(category, f"{context} must block when reconciliation returns `block`"))
         if fallback_to != "manual-reconciliation":
             failures.append(Failure(category, f"{context} must point blocked reconciliation drift to `manual-reconciliation`"))
+
+
+def require_review_record_contract(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include a review record object"))
+        return
+    findings = payload.get("findings")
+    if not isinstance(findings, list):
+        failures.append(Failure(category, f"{context} must include review `findings` as a list"))
+        return
+    for list_field in ("blocking_issues", "follow_ups"):
+        if not isinstance(payload.get(list_field), list):
+            failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    for finding in findings:
+        if not isinstance(finding, dict):
+            failures.append(Failure(category, f"{context} review findings must be JSON objects"))
+            continue
+        if not isinstance(finding.get("summary"), str) or not finding.get("summary"):
+            failures.append(Failure(category, f"{context} review findings must include non-empty `summary`"))
+        if finding.get("severity") not in REVIEW_FINDING_SEVERITIES:
+            failures.append(Failure(category, f"{context} review finding severity must stay within the stable contract"))
+        if finding.get("disposition") not in REVIEW_FINDING_DISPOSITIONS:
+            failures.append(
+                Failure(category, f"{context} review finding disposition must stay within the stable contract")
+            )
 
 
 def check_skill_manifests(root: Path) -> list[Failure]:
@@ -1343,6 +1377,14 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow review` must run fact-chain, state-check, runtime-evidence, checkpoint-build, and review-entry in order",
                     )
                 )
+            review = payload.get("review")
+            if isinstance(review, dict):
+                require_review_record_contract(
+                    failures,
+                    category="daily-execution-cli",
+                    context="`flow review` review.record",
+                    payload=review.get("record"),
+                )
         if label == "review-read":
             if payload.get("command") != "review":
                 failures.append(Failure("daily-execution-cli", "`review read` must report `command: review`"))
@@ -1353,6 +1395,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`review read` must include a `review` object"))
             elif not isinstance(review.get("record"), dict):
                 failures.append(Failure("daily-execution-cli", "`review read` must include `review.record`"))
+            else:
+                require_review_record_contract(
+                    failures,
+                    category="daily-execution-cli",
+                    context="`review read` review.record",
+                    payload=review.get("record"),
+                )
         if label == "host-lifecycle":
             if payload.get("command") != "host-lifecycle":
                 failures.append(Failure("daily-execution-cli", "`host-lifecycle` must report `command: host-lifecycle`"))
@@ -1621,6 +1670,29 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         elif payload.get("result") != "pass":
             failures.append(Failure("daily-execution-cli", "`work-item update` must pass on a clean temp copy"))
 
+        findings_path = authoring_target / ".loom" / "review-findings.json"
+        findings_path.parent.mkdir(parents=True, exist_ok=True)
+        findings_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "summary": "Formal review has not approved the item yet.",
+                        "severity": "fix-needed",
+                        "disposition": "blocking_issue",
+                    },
+                    {
+                        "summary": "Re-run formal review after the missing approval signal is resolved.",
+                        "severity": "warn",
+                        "disposition": "follow_up",
+                    },
+                ],
+                ensure_ascii=False,
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
         payload, error = load_command_json(
             root,
             [
@@ -1642,12 +1714,23 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 "loom-check",
                 "--fallback-to",
                 "admission",
+                "--findings-file",
+                ".loom/review-findings.json",
             ],
         )
         if error:
             failures.append(Failure("daily-execution-cli", f"`review record` failed: {error}"))
         elif payload.get("result") != "pass":
             failures.append(Failure("daily-execution-cli", "`review record` must pass for an authored fallback decision"))
+        else:
+            review = payload.get("review")
+            if isinstance(review, dict):
+                require_review_record_contract(
+                    failures,
+                    category="daily-execution-cli",
+                    context="`review record` review.record",
+                    payload=review.get("record"),
+                )
 
     if shutil.which("git") is not None:
         with tempfile.TemporaryDirectory(prefix="loom-check-purity-") as tmp:

--- a/tools/loom_check.py
+++ b/tools/loom_check.py
@@ -191,8 +191,8 @@ GOVERNANCE_SURFACE_CONTRACT_SKILLS = {
     "loom-resume",
 }
 
-REVIEW_FINDING_SEVERITIES = {"warn", "fix-needed", "block"}
-REVIEW_FINDING_DISPOSITIONS = {"blocking_issue", "follow_up"}
+REVIEW_FINDING_SEVERITIES = {"warn", "block"}
+REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -604,14 +604,26 @@ def require_review_record_contract(
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
             continue
+        if not isinstance(finding.get("id"), str) or not finding.get("id"):
+            failures.append(Failure(category, f"{context} review findings must include non-empty `id`"))
         if not isinstance(finding.get("summary"), str) or not finding.get("summary"):
             failures.append(Failure(category, f"{context} review findings must include non-empty `summary`"))
         if finding.get("severity") not in REVIEW_FINDING_SEVERITIES:
             failures.append(Failure(category, f"{context} review finding severity must stay within the stable contract"))
-        if finding.get("disposition") not in REVIEW_FINDING_DISPOSITIONS:
+        rebuttal = finding.get("rebuttal")
+        if rebuttal is not None and (not isinstance(rebuttal, str) or not rebuttal):
             failures.append(
-                Failure(category, f"{context} review finding disposition must stay within the stable contract")
+                Failure(category, f"{context} review finding `rebuttal` must be `null` or a non-empty string")
             )
+        disposition = finding.get("disposition")
+        if disposition is not None:
+            if not isinstance(disposition, dict):
+                failures.append(Failure(category, f"{context} review finding disposition must be `null` or an object"))
+                continue
+            if disposition.get("status") not in REVIEW_FINDING_DISPOSITION_STATUSES:
+                failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
+            if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
+                failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
 def check_skill_manifests(root: Path) -> list[Failure]:
@@ -1676,14 +1688,24 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             json.dumps(
                 [
                     {
+                        "id": "compat-block-1",
                         "summary": "Formal review has not approved the item yet.",
-                        "severity": "fix-needed",
-                        "disposition": "blocking_issue",
+                        "severity": "block",
+                        "rebuttal": None,
+                        "disposition": {
+                            "status": "rejected",
+                            "summary": "The finding remains open until the missing approval signal is resolved."
+                        },
                     },
                     {
+                        "id": "compat-warn-1",
                         "summary": "Re-run formal review after the missing approval signal is resolved.",
                         "severity": "warn",
-                        "disposition": "follow_up",
+                        "rebuttal": "A follow-up review will be recorded after the blocking issue is resolved.",
+                        "disposition": {
+                            "status": "deferred",
+                            "summary": "This follow-up stays open until the next formal review."
+                        },
                     },
                 ],
                 ensure_ascii=False,

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -78,8 +78,8 @@ WORK_ITEM_FIELD_LABELS = {
 
 REVIEW_DECISIONS = {"allow", "block", "fallback"}
 REVIEW_KINDS = {"general_review", "code_review", "spec_review"}
-REVIEW_FINDING_SEVERITIES = {"warn", "fix-needed", "block"}
-REVIEW_FINDING_DISPOSITIONS = {"blocking_issue", "follow_up"}
+REVIEW_FINDING_SEVERITIES = {"warn", "block"}
+REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -590,23 +590,33 @@ def compat_findings_from_lists(
     decision: str | None,
     blocking_issues: list[str],
     follow_ups: list[str],
-) -> list[dict[str, str]]:
-    findings: list[dict[str, str]] = []
-    blocking_severity = "block" if decision == "block" else "fix-needed"
-    for summary in blocking_issues:
+) -> list[dict[str, Any]]:
+    del decision
+    findings: list[dict[str, Any]] = []
+    for index, summary in enumerate(blocking_issues, start=1):
         findings.append(
             {
+                "id": f"compat-block-{index}",
                 "summary": summary,
-                "severity": blocking_severity,
-                "disposition": "blocking_issue",
+                "severity": "block",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "rejected",
+                    "summary": "Projected from compatibility `blocking_issues`.",
+                },
             }
         )
-    for summary in follow_ups:
+    for index, summary in enumerate(follow_ups, start=1):
         findings.append(
             {
+                "id": f"compat-follow-up-{index}",
                 "summary": summary,
                 "severity": "warn",
-                "disposition": "follow_up",
+                "rebuttal": None,
+                "disposition": {
+                    "status": "deferred",
+                    "summary": "Projected from compatibility `follow_ups`.",
+                },
             }
         )
     return findings
@@ -619,9 +629,9 @@ def compat_lists_from_findings(findings: list[dict[str, Any]]) -> tuple[list[str
         summary = finding.get("summary")
         if not isinstance(summary, str) or not summary.strip():
             continue
-        if finding.get("disposition") == "blocking_issue":
+        if finding.get("severity") == "block":
             blocking_issues.append(summary.strip())
-        elif finding.get("disposition") == "follow_up":
+        elif finding.get("severity") == "warn":
             follow_ups.append(summary.strip())
     return blocking_issues, follow_ups
 
@@ -637,9 +647,15 @@ def normalize_review_findings(raw_findings: Any, *, relative: str) -> tuple[list
             errors.append(f"review artifact `{relative}` findings[{index}] must be a JSON object")
             continue
         normalized = dict(finding)
+        finding_id = normalized.get("id")
         summary = normalized.get("summary")
         severity = normalized.get("severity")
+        rebuttal = normalized.get("rebuttal")
         disposition = normalized.get("disposition")
+        if not isinstance(finding_id, str) or not finding_id.strip():
+            errors.append(f"review artifact `{relative}` findings[{index}] must include non-empty `id`")
+        else:
+            normalized["id"] = finding_id.strip()
         if not isinstance(summary, str) or not summary.strip():
             errors.append(f"review artifact `{relative}` findings[{index}] must include non-empty `summary`")
         else:
@@ -649,11 +665,32 @@ def normalize_review_findings(raw_findings: Any, *, relative: str) -> tuple[list
                 f"review artifact `{relative}` findings[{index}] severity must be one of "
                 f"{', '.join(sorted(REVIEW_FINDING_SEVERITIES))}"
             )
-        if disposition not in REVIEW_FINDING_DISPOSITIONS:
-            errors.append(
-                f"review artifact `{relative}` findings[{index}] disposition must be one of "
-                f"{', '.join(sorted(REVIEW_FINDING_DISPOSITIONS))}"
-            )
+        if rebuttal is not None:
+            if not isinstance(rebuttal, str) or not rebuttal.strip():
+                errors.append(f"review artifact `{relative}` findings[{index}] `rebuttal` must be null or a non-empty string")
+            else:
+                normalized["rebuttal"] = rebuttal.strip()
+        if disposition is not None:
+            if not isinstance(disposition, dict):
+                errors.append(f"review artifact `{relative}` findings[{index}] `disposition` must be null or an object")
+            else:
+                status = disposition.get("status")
+                disposition_summary = disposition.get("summary")
+                if status not in REVIEW_FINDING_DISPOSITION_STATUSES:
+                    errors.append(
+                        f"review artifact `{relative}` findings[{index}] disposition status must be one of "
+                        f"{', '.join(sorted(REVIEW_FINDING_DISPOSITION_STATUSES))}"
+                    )
+                if not isinstance(disposition_summary, str) or not disposition_summary.strip():
+                    errors.append(
+                        f"review artifact `{relative}` findings[{index}] disposition must include non-empty `summary`"
+                    )
+                else:
+                    normalized["disposition"] = {
+                        **disposition,
+                        "status": status,
+                        "summary": disposition_summary.strip(),
+                    }
         findings.append(normalized)
     return findings, errors
 
@@ -3402,14 +3439,24 @@ def handle_work_item(args: argparse.Namespace) -> int:
                     "fallback_to": "admission",
                     "findings": [
                         {
+                            "id": "scaffolded-block-1",
                             "summary": "Review artifact scaffolded but not yet concluded.",
-                            "severity": "fix-needed",
-                            "disposition": "blocking_issue",
+                            "severity": "block",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "rejected",
+                                "summary": "Scaffold placeholder must be replaced by a real formal review conclusion.",
+                            },
                         },
                         {
+                            "id": "scaffolded-warn-1",
                             "summary": "Record a real review before asking merge checkpoint to consume it.",
                             "severity": "warn",
-                            "disposition": "follow_up",
+                            "rebuttal": None,
+                            "disposition": {
+                                "status": "deferred",
+                                "summary": "This follow-up stays open until a real review is recorded.",
+                            },
                         },
                     ],
                     "blocking_issues": ["Review artifact scaffolded but not yet concluded."],

--- a/tools/loom_flow.py
+++ b/tools/loom_flow.py
@@ -78,6 +78,8 @@ WORK_ITEM_FIELD_LABELS = {
 
 REVIEW_DECISIONS = {"allow", "block", "fallback"}
 REVIEW_KINDS = {"general_review", "code_review", "spec_review"}
+REVIEW_FINDING_SEVERITIES = {"warn", "fix-needed", "block"}
+REVIEW_FINDING_DISPOSITIONS = {"blocking_issue", "follow_up"}
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -158,6 +160,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--summary", help="Stable review conclusion summary")
     review.add_argument("--reviewer", help="Reviewer identity")
     review.add_argument("--fallback-to", choices=("admission", "build", "merge"))
+    review.add_argument("--findings-file", help="Optional findings JSON path relative to the target root")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -582,6 +585,106 @@ def default_review_path(item_id: str) -> str:
     return f".loom/reviews/{item_id}.json"
 
 
+def compat_findings_from_lists(
+    *,
+    decision: str | None,
+    blocking_issues: list[str],
+    follow_ups: list[str],
+) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    blocking_severity = "block" if decision == "block" else "fix-needed"
+    for summary in blocking_issues:
+        findings.append(
+            {
+                "summary": summary,
+                "severity": blocking_severity,
+                "disposition": "blocking_issue",
+            }
+        )
+    for summary in follow_ups:
+        findings.append(
+            {
+                "summary": summary,
+                "severity": "warn",
+                "disposition": "follow_up",
+            }
+        )
+    return findings
+
+
+def compat_lists_from_findings(findings: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    blocking_issues: list[str] = []
+    follow_ups: list[str] = []
+    for finding in findings:
+        summary = finding.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            continue
+        if finding.get("disposition") == "blocking_issue":
+            blocking_issues.append(summary.strip())
+        elif finding.get("disposition") == "follow_up":
+            follow_ups.append(summary.strip())
+    return blocking_issues, follow_ups
+
+
+def normalize_review_findings(raw_findings: Any, *, relative: str) -> tuple[list[dict[str, Any]], list[str]]:
+    if not isinstance(raw_findings, list):
+        return [], [f"review artifact `{relative}` `findings` must be a list"]
+
+    findings: list[dict[str, Any]] = []
+    errors: list[str] = []
+    for index, finding in enumerate(raw_findings, start=1):
+        if not isinstance(finding, dict):
+            errors.append(f"review artifact `{relative}` findings[{index}] must be a JSON object")
+            continue
+        normalized = dict(finding)
+        summary = normalized.get("summary")
+        severity = normalized.get("severity")
+        disposition = normalized.get("disposition")
+        if not isinstance(summary, str) or not summary.strip():
+            errors.append(f"review artifact `{relative}` findings[{index}] must include non-empty `summary`")
+        else:
+            normalized["summary"] = summary.strip()
+        if severity not in REVIEW_FINDING_SEVERITIES:
+            errors.append(
+                f"review artifact `{relative}` findings[{index}] severity must be one of "
+                f"{', '.join(sorted(REVIEW_FINDING_SEVERITIES))}"
+            )
+        if disposition not in REVIEW_FINDING_DISPOSITIONS:
+            errors.append(
+                f"review artifact `{relative}` findings[{index}] disposition must be one of "
+                f"{', '.join(sorted(REVIEW_FINDING_DISPOSITIONS))}"
+            )
+        findings.append(normalized)
+    return findings, errors
+
+
+def target_relative_label(target_root: Path, path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(target_root.resolve()))
+    except ValueError:
+        return str(path.resolve())
+
+
+def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict[str, Any]] | None, list[str]]:
+    findings_path = Path(findings_file).expanduser()
+    if not findings_path.is_absolute():
+        findings_path = (target_root / findings_path).resolve()
+
+    label = target_relative_label(target_root, findings_path)
+    try:
+        payload = json.loads(findings_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [f"invalid findings file `{label}`: {exc}"]
+
+    if isinstance(payload, dict):
+        payload = payload.get("findings")
+
+    findings, errors = normalize_review_findings(payload, relative=label)
+    if errors:
+        return None, errors
+    return findings, []
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -595,6 +698,8 @@ def load_review_record(
         payload = load_json_file(review_path)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         return None, relative, [f"invalid review artifact `{relative}`: {exc}"]
+    if not isinstance(payload, dict):
+        return None, relative, [f"review artifact `{relative}` must be a JSON object"]
     errors: list[str] = []
     for field in ("item_id", "decision", "kind", "summary", "reviewer", "reviewed_head", "reviewed_validation_summary"):
         value = payload.get(field)
@@ -609,11 +714,37 @@ def load_review_record(
     fallback_to = payload.get("fallback_to")
     if fallback_to not in {None, "admission", "build", "merge"}:
         errors.append(f"review artifact `{relative}` fallback_to must be null, admission, build, or merge")
+    compatibility_lists: dict[str, list[str]] = {}
     for list_field in ("blocking_issues", "follow_ups"):
         value = payload.get(list_field)
         if value is not None and not isinstance(value, list):
             errors.append(f"review artifact `{relative}` `{list_field}` must be a list when present")
-    return payload, relative, errors
+            continue
+        entries: list[str] = []
+        for index, entry in enumerate(value or [], start=1):
+            if not isinstance(entry, str) or not entry.strip():
+                errors.append(f"review artifact `{relative}` `{list_field}`[{index}] must be a non-empty string")
+                continue
+            entries.append(entry.strip())
+        compatibility_lists[list_field] = entries
+
+    findings_value = payload.get("findings")
+    if findings_value is None:
+        findings = compat_findings_from_lists(
+            decision=payload.get("decision") if isinstance(payload.get("decision"), str) else None,
+            blocking_issues=compatibility_lists.get("blocking_issues", []),
+            follow_ups=compatibility_lists.get("follow_ups", []),
+        )
+    else:
+        findings, finding_errors = normalize_review_findings(findings_value, relative=relative)
+        errors.extend(finding_errors)
+
+    blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    normalized_payload = dict(payload)
+    normalized_payload["findings"] = findings
+    normalized_payload["blocking_issues"] = blocking_issues
+    normalized_payload["follow_ups"] = follow_ups
+    return normalized_payload, relative, errors
 
 
 def render_work_item(data: dict[str, Any]) -> str:
@@ -2960,6 +3091,18 @@ def handle_review(args: argparse.Namespace) -> int:
             }
         )
 
+    if args.findings_file and (args.blocking_issue or args.follow_up):
+        return emit(
+            {
+                "command": "review",
+                "operation": "record",
+                "result": "block",
+                "summary": "review record must not mix `--findings-file` with compatibility finding flags.",
+                "missing_inputs": ["choose either `--findings-file` or compatibility finding flags"],
+                "fallback_to": "build",
+            }
+        )
+
     build_payload = checkpoint_payload("build", context)
     if args.decision == "allow" and build_payload["result"] != "pass":
         missing = list(build_payload["missing_inputs"])
@@ -2975,6 +3118,31 @@ def handle_review(args: argparse.Namespace) -> int:
             }
         )
 
+    findings: list[dict[str, Any]]
+    findings_errors: list[str] = []
+    if args.findings_file:
+        findings, findings_errors = load_findings_file(target_root, args.findings_file)
+        if findings is None:
+            findings = []
+    else:
+        findings = compat_findings_from_lists(
+            decision=args.decision,
+            blocking_issues=[entry.strip() for entry in args.blocking_issue if entry.strip()],
+            follow_ups=[entry.strip() for entry in args.follow_up if entry.strip()],
+        )
+    if findings_errors:
+        return emit(
+            {
+                "command": "review",
+                "operation": "record",
+                "result": "block",
+                "summary": "review record could not load a valid authoritative findings file.",
+                "missing_inputs": findings_errors,
+                "fallback_to": "build",
+            }
+        )
+
+    blocking_issues, follow_ups = compat_lists_from_findings(findings)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -2985,8 +3153,9 @@ def handle_review(args: argparse.Namespace) -> int:
         "reviewed_head": git_head_sha(target_root) or "unknown",
         "reviewed_validation_summary": context["latest_validation_summary"],
         "fallback_to": args.fallback_to,
-        "blocking_issues": args.blocking_issue,
-        "follow_ups": args.follow_up,
+        "findings": findings,
+        "blocking_issues": blocking_issues,
+        "follow_ups": follow_ups,
         "consumed_inputs": {
             "work_item": str(context["report"]["fact_chain"]["entry_points"]["work_item"]),
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
@@ -3231,6 +3400,18 @@ def handle_work_item(args: argparse.Namespace) -> int:
                     "reviewed_head": git_head_sha(target_root) or "unknown",
                     "reviewed_validation_summary": "No validation recorded yet.",
                     "fallback_to": "admission",
+                    "findings": [
+                        {
+                            "summary": "Review artifact scaffolded but not yet concluded.",
+                            "severity": "fix-needed",
+                            "disposition": "blocking_issue",
+                        },
+                        {
+                            "summary": "Record a real review before asking merge checkpoint to consume it.",
+                            "severity": "warn",
+                            "disposition": "follow_up",
+                        },
+                    ],
                     "blocking_issues": ["Review artifact scaffolded but not yet concluded."],
                     "follow_ups": ["Record a real review before asking merge checkpoint to consume it."],
                 },


### PR DESCRIPTION
## Summary
- 在单一 `review_entry` 下扩展 `review record`，新增权威 `findings` 数组与 `--findings-file`
- 保留 `blocking_issues` / `follow_ups` 作为兼容投影，不新增第二 artifact 或新状态机
- 同步 `loom_check`、`loom-review` 合同与验证记录，并回写 `#167/#152` 术语对齐复核

## Validation
- `python3 -m py_compile tools/loom_flow.py tools/loom_check.py`
- `python3 tools/loom_flow.py review read --target examples/new-project --item INIT-0001`
- 定向临时副本验证：`review record --findings-file` + `review read`
- `python3 tools/loom_check.py .`
- `make loom-check`
- 恢复 demo 跟踪文件后再次执行 `python3 tools/loom_check.py .`

## Alignment Notes
- `host action` 主定义继续落在 `harness/host-action-contract.md`
- `review record` 主定义继续落在 `harness/review-execution.md`
- `rebuttal` / `disposition` 只进入 review record 的权威 `findings`
- `review comments` / `guardian output` 继续只作为 evidence
- `closeout` / `reconciliation sync` 继续只承接 host control-plane drift 与 sync
