### PR TITLE
feat: 收口 installed-skills pre-merge chain 验收

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -28,6 +28,7 @@
 - 场景 skill `loom-handoff` 验证：[validation-skill-loom-handoff.md](./validation-skill-loom-handoff.md)
 - 场景 skill `loom-retire` 验证：[validation-skill-loom-retire.md](./validation-skill-loom-retire.md)
 - 场景 skill `loom-merge-ready` 验证：[validation-skill-loom-merge-ready.md](./validation-skill-loom-merge-ready.md)
+- installed-skills pre-merge 链验收：[validation-installed-skills-pre-merge-chain.md](./validation-installed-skills-pre-merge-chain.md)
 - 事实链消费验证：[validation-fact-chain-mail-listener.md](./validation-fact-chain-mail-listener.md)
 - checkpoint 链路复验：[validation-checkpoints-hotcp.md](./validation-checkpoints-hotcp.md)
 - 运行时证据复验：[validation-runtime-evidence-hotcp.md](./validation-runtime-evidence-hotcp.md)
@@ -43,6 +44,7 @@ Issue -> 验证 / 回写索引：
 - `#168` -> [validation-main-path-new-project.md](./validation-main-path-new-project.md)
 - `#170` -> [validation-existing-repo-execution-sync.md](./validation-existing-repo-execution-sync.md)
 - `#180` -> [validation-retrofit-143-tree.md](./validation-retrofit-143-tree.md)
+- `#209` -> [validation-installed-skills-pre-merge-chain.md](./validation-installed-skills-pre-merge-chain.md)
 - `#169` -> [landing-map.md](./landing-map.md); [upstream-delivery-surface.md](./upstream-delivery-surface.md); [versioning-and-upgrades.md](./versioning-and-upgrades.md); [../docs/complete-kernel-release.md](../docs/complete-kernel-release.md)
 
 当前目录对应的主要 `EXT-*` 条目：

--- a/adoption/validation-installed-skills-pre-merge-chain.md
+++ b/adoption/validation-installed-skills-pre-merge-chain.md
@@ -1,0 +1,78 @@
+# Validation: Installed-Skills Pre-Merge Chain
+
+本文记录 `#209` 的 installed-skills pre-merge 验收。
+
+## 样本
+
+- `installed-skills 安装根`
+  - 临时目录中只复制 `skills/`
+- `target repo 验证现场`
+  - 当前 Loom 仓库快照的临时副本
+  - 不复用源工作树
+- `repo-local 源码现场`
+  - 只用于开发回归与 `make loom-check`
+  - 不计入 `#209` 验收结论
+
+## 正向链
+
+在 installed-skills 安装根中执行：
+
+```bash
+python3 loom-init/scripts/loom-init.py bootstrap --target <target-repo> --write --force --verify --install-pr-template
+git -C <target-repo> add .
+git -C <target-repo> commit -m "bootstrap baseline for #209"
+
+python3 loom-init/scripts/loom-init.py route --target <target-repo> --task "请接手当前事项并恢复上下文后继续推进"
+python3 loom-resume/scripts/loom-resume.py flow resume --target <target-repo> --item INIT-0001
+
+python3 loom-init/scripts/loom-init.py route --target <target-repo> --task "请在进入 review 前做统一检查"
+python3 loom-pre-review/scripts/loom-pre-review.py flow pre-review --target <target-repo> --item INIT-0001
+
+python3 loom-init/scripts/loom-init.py route --target <target-repo> --task "请对当前事项做正式 review 并给出审查结论"
+python3 loom-review/scripts/loom-review.py flow review --target <target-repo> --item INIT-0001
+python3 loom-review/scripts/loom-review.py review record --target <target-repo> --item INIT-0001 --decision allow --kind code_review --summary "Installed pre-merge chain is ready for merge checkpoint consumption." --reviewer loom-check
+python3 shared/scripts/loom_flow.py recovery writeback --target <target-repo> --item INIT-0001 --current-checkpoint "merge checkpoint" --current-stop "Installed review completed and merge-ready validation is next." --next-step "Run merge-ready and checkpoint merge from installed skills." --latest-validation-summary "<resume latest_validation_summary>"
+git -C <target-repo> add .loom/reviews/INIT-0001.json .loom/progress/INIT-0001.md .loom/status/current.md
+git -C <target-repo> commit -m "author installed pre-merge carriers for #209"
+
+python3 loom-init/scripts/loom-init.py route --target <target-repo> --task "请做 merge-ready 最终放行前预检并确认是否可以合并"
+python3 loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <target-repo> --item INIT-0001
+python3 shared/scripts/loom_flow.py checkpoint merge --target <target-repo> --item INIT-0001
+```
+
+结果：
+
+- `route(resume|pre-review|review|merge-ready)` 全部命中对应 installed skill
+- `flow resume` / `flow pre-review` / `flow review` / `flow merge-ready` 全部 `pass`
+- `review record` 以 `allow` 写入单一 `review_entry`
+- `checkpoint merge = pass`
+- 允许 review 之后只新增 Loom 自身的 `review_entry`、recovery、status carriers 提交；否则仍视为 stale
+
+## Fail-Closed 负样本
+
+### 1. 安装态 layout 漂移
+
+- 删除 installed `install-layout.json`
+- 期望：
+  - `loom-init route` 直接 `block`
+  - `loom-pre-review flow pre-review` 直接 `block`
+
+### 2. review 基线缺失
+
+- 将 recovery `Current Checkpoint` 降回 `admission checkpoint`
+- 期望：
+  - `flow review` 返回 `fallback`
+  - `flow merge-ready` 返回 `fallback` 或 `block`
+
+### 3. merge-ready 条件漂移
+
+- 在 allow review 和 merge carriers 提交之后，再提交非 Loom carrier 改动
+- 期望：
+  - `checkpoint merge` 明确 `block`
+  - 原因保留为 review stale / reviewed head drift，而不是伪装成 `pass`
+
+## 结论
+
+- `#209` 的 installed-skills pre-merge 链已经可在隔离安装根和隔离 target repo 上完整复验
+- 正向链必须包含显式 authored 推进：`review record` 与 `recovery writeback`
+- 本记录只覆盖 pre-merge readiness，不宣称 `#210` 的 host merge 后 closeout 已完成

--- a/harness/merge-checkpoint.md
+++ b/harness/merge-checkpoint.md
@@ -77,6 +77,7 @@ merge checkpoint 只允许输出以下三类结果：
   - 回到 [status-surface.md](./status-surface.md) 与实际验证入口
 - 缺 formal review、review stale 或 reviewer 明确要求回退
   - 回到 [review-execution.md](./review-execution.md) 或 `build checkpoint`
+  - 若 review 之后只提交了 `review_entry`、recovery 主入口或状态面这类 Loom carrier 更新，不应误判成 stale
 - 缺停点、下一步、风险或回滚边界
   - 回到 [recovery-model.md](./recovery-model.md)
 - head 已超出批准范围或事项边界失真

--- a/harness/review-execution.md
+++ b/harness/review-execution.md
@@ -64,6 +64,8 @@ review record 至少应包含：
 - 读取 `work item.review_entry`
 - 校验 `item_id` 是否匹配当前事项
 - 校验 `reviewed_head` 是否仍匹配当前 `HEAD`
+  - 若 `HEAD` 在 review 之后只新增了 Loom 自身的 review / recovery / status carriers 提交，允许继续消费
+  - 一旦 `HEAD` 还包含其他路径漂移，仍按 review stale 处理
 - 校验 `reviewed_validation_summary` 是否仍匹配当前 recovery 的 `latest_validation_summary`
 - `decision: allow` 才算 review 已通过
 - `decision: block` 返回 `block`

--- a/skills/shared/references/harness/merge-checkpoint.md
+++ b/skills/shared/references/harness/merge-checkpoint.md
@@ -77,6 +77,7 @@ merge checkpoint 只允许输出以下三类结果：
   - 回到 [status-surface.md](./status-surface.md) 与实际验证入口
 - 缺 formal review、review stale 或 reviewer 明确要求回退
   - 回到 [review-execution.md](./review-execution.md) 或 `build checkpoint`
+  - 若 review 之后只提交了 `review_entry`、recovery 主入口或状态面这类 Loom carrier 更新，不应误判成 stale
 - 缺停点、下一步、风险或回滚边界
   - 回到 [recovery-model.md](./recovery-model.md)
 - head 已超出批准范围或事项边界失真

--- a/skills/shared/references/harness/review-execution.md
+++ b/skills/shared/references/harness/review-execution.md
@@ -64,6 +64,8 @@ review record 至少应包含：
 - 读取 `work item.review_entry`
 - 校验 `item_id` 是否匹配当前事项
 - 校验 `reviewed_head` 是否仍匹配当前 `HEAD`
+  - 若 `HEAD` 在 review 之后只新增了 Loom 自身的 review / recovery / status carriers 提交，允许继续消费
+  - 一旦 `HEAD` 还包含其他路径漂移，仍按 review stale 处理
 - 校验 `reviewed_validation_summary` 是否仍匹配当前 recovery 的 `latest_validation_summary`
 - `decision: allow` 才算 review 已通过
 - `decision: block` 返回 `block`

--- a/skills/shared/references/templates/review-record.md
+++ b/skills/shared/references/templates/review-record.md
@@ -24,6 +24,7 @@
 
 - `fallback_to` 只在 `decision: fallback` 时使用
 - `reviewed_head` 与 `reviewed_validation_summary` 必须对应本次审查基线
+- merge checkpoint 允许 review 之后只新增 Loom 自身的 `review_entry` / recovery / status carriers 提交；除此之外的 `HEAD` 漂移仍视为 stale
 - `findings` 是权威 findings / rebuttal / disposition 数组；每条至少包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`
 - `severity` 当前稳定值为 `warn`、`block`
 - `rebuttal` 当前稳定值为 `null` 或非空字符串

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -91,6 +91,7 @@ CORE_DOCS = (
     "adoption/validation-devskills.md",
     "adoption/validation-hotcp.md",
     "adoption/validation-review-and-authoring.md",
+    "adoption/validation-installed-skills-pre-merge-chain.md",
     "adoption/validation-host-lifecycle-and-closeout.md",
     "adoption/validation-fact-chain-mail-listener.md",
     "adoption/validation-checkpoints-hotcp.md",
@@ -687,6 +688,47 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_route_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_skill: str,
+    expected_mode: str,
+    expected_runtime_scene: str | None = None,
+    expected_runtime_carrier: str | None = None,
+    allowed_results: set[str] | None = None,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "route":
+        failures.append(Failure(category, f"{context} must report `command: route`"))
+    if payload.get("result") not in (allowed_results or {"pass"}):
+        failures.append(Failure(category, f"{context} result must stay within the stable contract"))
+    if payload.get("selected_skill") != expected_skill:
+        failures.append(Failure(category, f"{context} must select `{expected_skill}`"))
+    if payload.get("mode") != expected_mode:
+        failures.append(Failure(category, f"{context} must report `mode: {expected_mode}`"))
+    if not isinstance(payload.get("matched_signals"), list):
+        failures.append(Failure(category, f"{context} must include `matched_signals`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {"loom-init", "refresh-install", "rebootstrap-runtime", "manual-runtime-reconciliation", None}:
+        failures.append(Failure(category, f"{context} fallback must stay within the stable contract"))
+    if expected_runtime_scene is not None or expected_runtime_carrier is not None:
+        require_runtime_state_payload(
+            failures,
+            category=category,
+            context=context,
+            payload=payload.get("runtime_state"),
+            expected_scene=expected_runtime_scene,
+            expected_carrier=expected_runtime_carrier,
+            allowed_results={"pass", "block"},
+        )
 
 
 def check_skill_manifests(root: Path) -> list[Failure]:
@@ -2142,6 +2184,588 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             failures.append(Failure("daily-execution-cli", f"`bootstrapped runtime-state` manifest drift failed unexpectedly: {error}"))
         elif payload.get("result") != "block":
             failures.append(Failure("daily-execution-cli", "`bootstrapped runtime-state` must block when the bootstrap manifest drifts"))
+
+    if shutil.which("git") is not None:
+        with tempfile.TemporaryDirectory(prefix="loom-check-installed-pre-merge-") as tmp:
+            tmp_root = Path(tmp)
+            install_root = tmp_root / "installed" / "skills"
+            source_snapshot = tmp_root / "source-snapshot"
+            positive_target = tmp_root / "positive-target"
+            review_fallback_target = tmp_root / "review-fallback-target"
+            shutil.copytree(root / "skills", install_root)
+            shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+            def prepare_target(target: Path) -> tuple[str | None, list[str]]:
+                errors: list[str] = []
+                shutil.copytree(source_snapshot, target)
+                for args in (
+                    ["git", "init"],
+                    ["git", "config", "user.email", "loom-check@example.com"],
+                    ["git", "config", "user.name", "loom-check"],
+                ):
+                    result = run_command(root, args, cwd=target)
+                    if result.returncode != 0:
+                        detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                        errors.append(detail)
+                        return None, errors
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-init" / "scripts" / "loom-init.py"),
+                        "bootstrap",
+                        "--target",
+                        str(target),
+                        "--write",
+                        "--force",
+                        "--verify",
+                        "--install-pr-template",
+                    ],
+                )
+                if error:
+                    errors.append(error)
+                    return None, errors
+                verification = payload.get("verification")
+                if not isinstance(verification, dict) or verification.get("ok") is not True:
+                    errors.append("installed bootstrap must verify successfully before the pre-merge chain starts")
+                    return None, errors
+
+                git_add = run_command(root, ["git", "add", "."], cwd=target)
+                if git_add.returncode != 0:
+                    detail = git_add.stderr.strip() or git_add.stdout.strip() or "git add failed"
+                    errors.append(detail)
+                    return None, errors
+                git_commit = run_command(root, ["git", "commit", "-m", "bootstrap baseline for #209"], cwd=target)
+                if git_commit.returncode != 0:
+                    detail = git_commit.stderr.strip() or git_commit.stdout.strip() or "git commit failed"
+                    errors.append(detail)
+                    return None, errors
+
+                resume_payload, resume_error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-resume" / "scripts" / "loom-resume.py"),
+                        "flow",
+                        "resume",
+                        "--target",
+                        str(target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if resume_error:
+                    errors.append(resume_error)
+                    return None, errors
+                recovery = resume_payload.get("recovery")
+                if not isinstance(recovery, dict):
+                    errors.append("resume payload must include `recovery`")
+                    return None, errors
+                summary = recovery.get("latest_validation_summary")
+                if not isinstance(summary, str) or not summary:
+                    errors.append("resume payload must expose a non-empty `latest_validation_summary`")
+                    return None, errors
+                return summary, errors
+
+            positive_summary, positive_setup_errors = prepare_target(positive_target)
+            if positive_setup_errors:
+                failures.append(
+                    Failure(
+                        "daily-execution-cli",
+                        f"`installed pre-merge chain` setup failed: {'; '.join(positive_setup_errors)}",
+                    )
+                )
+            else:
+                task_signals = {
+                    "resume": "请接手当前事项并恢复上下文后继续推进",
+                    "pre-review": "请在进入 review 前做统一检查",
+                    "review": "请对当前事项做正式 review 并给出审查结论",
+                    "merge-ready": "请做 merge-ready 最终放行前预检并确认是否可以合并",
+                }
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-init" / "scripts" / "loom-init.py"),
+                        "route",
+                        "--target",
+                        str(positive_target),
+                        "--task",
+                        task_signals["resume"],
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed route resume` failed: {error}"))
+                else:
+                    require_route_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed route resume`",
+                        payload=payload,
+                        expected_skill="loom-resume",
+                        expected_mode="implicit",
+                        expected_runtime_scene="installed-runtime",
+                        expected_runtime_carrier="installed-skills-root",
+                    )
+
+                resume_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-resume" / "scripts" / "loom-resume.py"),
+                        "flow",
+                        "resume",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed flow resume` failed: {error}"))
+                elif resume_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed flow resume` must pass for the positive chain"))
+                else:
+                    require_runtime_state_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed flow resume`",
+                        payload=resume_payload.get("runtime_state"),
+                        expected_scene="installed-runtime",
+                        expected_carrier="installed-skills-root",
+                        allowed_results={"pass"},
+                    )
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-init" / "scripts" / "loom-init.py"),
+                        "route",
+                        "--target",
+                        str(positive_target),
+                        "--task",
+                        task_signals["pre-review"],
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed route pre-review` failed: {error}"))
+                else:
+                    require_route_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed route pre-review`",
+                        payload=payload,
+                        expected_skill="loom-pre-review",
+                        expected_mode="implicit",
+                        expected_runtime_scene="installed-runtime",
+                        expected_runtime_carrier="installed-skills-root",
+                    )
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-pre-review" / "scripts" / "loom-pre-review.py"),
+                        "flow",
+                        "pre-review",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed flow pre-review` failed: {error}"))
+                elif payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed flow pre-review` must pass for the positive chain"))
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-init" / "scripts" / "loom-init.py"),
+                        "route",
+                        "--target",
+                        str(positive_target),
+                        "--task",
+                        task_signals["review"],
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed route review` failed: {error}"))
+                else:
+                    require_route_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed route review`",
+                        payload=payload,
+                        expected_skill="loom-review",
+                        expected_mode="implicit",
+                        expected_runtime_scene="installed-runtime",
+                        expected_runtime_carrier="installed-skills-root",
+                    )
+
+                review_flow_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-review" / "scripts" / "loom-review.py"),
+                        "flow",
+                        "review",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed flow review` failed: {error}"))
+                elif review_flow_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed flow review` must pass for the positive chain"))
+                else:
+                    review = review_flow_payload.get("review")
+                    if isinstance(review, dict):
+                        require_review_record_contract(
+                            failures,
+                            category="daily-execution-cli",
+                            context="`installed flow review` review.record",
+                            payload=review.get("record"),
+                        )
+
+                review_record_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-review" / "scripts" / "loom-review.py"),
+                        "review",
+                        "record",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--decision",
+                        "allow",
+                        "--kind",
+                        "code_review",
+                        "--summary",
+                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        "--reviewer",
+                        "loom-check",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review record allow` failed: {error}"))
+                elif review_record_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review record allow` must pass"))
+                else:
+                    review = review_record_payload.get("review")
+                    if isinstance(review, dict):
+                        require_review_record_contract(
+                            failures,
+                            category="daily-execution-cli",
+                            context="`installed review record allow` review.record",
+                            payload=review.get("record"),
+                        )
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "recovery",
+                        "writeback",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--current-checkpoint",
+                        "merge checkpoint",
+                        "--current-stop",
+                        "Installed review completed and merge-ready validation is next.",
+                        "--next-step",
+                        "Run merge-ready and checkpoint merge from installed skills.",
+                        "--latest-validation-summary",
+                        positive_summary,
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed recovery writeback for merge` failed: {error}"))
+                elif payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed recovery writeback for merge` must pass"))
+
+                git_add = run_command(
+                    root,
+                    [
+                        "git",
+                        "add",
+                        ".loom/progress/INIT-0001.md",
+                        ".loom/status/current.md",
+                        ".loom/reviews/INIT-0001.json",
+                    ],
+                    cwd=positive_target,
+                )
+                if git_add.returncode != 0:
+                    detail = git_add.stderr.strip() or git_add.stdout.strip() or "git add failed"
+                    failures.append(Failure("daily-execution-cli", f"`installed pre-merge carrier commit` add failed: {detail}"))
+                else:
+                    git_commit = run_command(
+                        root,
+                        ["git", "commit", "-m", "author installed pre-merge carriers for #209"],
+                        cwd=positive_target,
+                    )
+                    if git_commit.returncode != 0:
+                        detail = git_commit.stderr.strip() or git_commit.stdout.strip() or "git commit failed"
+                        failures.append(Failure("daily-execution-cli", f"`installed pre-merge carrier commit` failed: {detail}"))
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-init" / "scripts" / "loom-init.py"),
+                        "route",
+                        "--target",
+                        str(positive_target),
+                        "--task",
+                        task_signals["merge-ready"],
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed route merge-ready` failed: {error}"))
+                else:
+                    require_route_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed route merge-ready`",
+                        payload=payload,
+                        expected_skill="loom-merge-ready",
+                        expected_mode="implicit",
+                        expected_runtime_scene="installed-runtime",
+                        expected_runtime_carrier="installed-skills-root",
+                    )
+
+                merge_ready_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "loom-merge-ready" / "scripts" / "loom-merge-ready.py"),
+                        "flow",
+                        "merge-ready",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed flow merge-ready` failed: {error}"))
+                elif merge_ready_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed flow merge-ready` must pass for the positive chain"))
+                else:
+                    merge_checkpoint = merge_ready_payload.get("merge_checkpoint")
+                    if not isinstance(merge_checkpoint, dict) or merge_checkpoint.get("result") != "pass":
+                        failures.append(Failure("daily-execution-cli", "`installed flow merge-ready` must expose `merge_checkpoint.result = pass`"))
+
+                checkpoint_merge_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "checkpoint",
+                        "merge",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed checkpoint merge` failed: {error}"))
+                elif checkpoint_merge_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` must pass for the positive chain"))
+
+                broken_install = tmp_root / "broken-install" / "skills"
+                shutil.copytree(root / "skills", broken_install)
+                (broken_install / "install-layout.json").unlink()
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(broken_install / "loom-init" / "scripts" / "loom-init.py"),
+                        "route",
+                        "--target",
+                        str(positive_target),
+                        "--task",
+                        task_signals["resume"],
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed route` missing install-layout failed unexpectedly: {error}"))
+                else:
+                    require_route_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed route` missing install-layout",
+                        payload=payload,
+                        expected_skill="loom-init",
+                        expected_mode="fallback",
+                        expected_runtime_scene="installed-runtime",
+                        expected_runtime_carrier="installed-skills-root",
+                        allowed_results={"block"},
+                    )
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(broken_install / "loom-pre-review" / "scripts" / "loom-pre-review.py"),
+                        "flow",
+                        "pre-review",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed flow pre-review` missing install-layout failed unexpectedly: {error}"))
+                elif payload.get("result") != "block":
+                    failures.append(Failure("daily-execution-cli", "`installed flow pre-review` must block when install-layout is missing"))
+                else:
+                    require_runtime_state_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed flow pre-review` missing install-layout",
+                        payload=payload.get("runtime_state"),
+                        expected_scene="installed-runtime",
+                        expected_carrier="installed-skills-root",
+                        allowed_results={"block"},
+                    )
+
+                review_fallback_summary, review_fallback_errors = prepare_target(review_fallback_target)
+                if review_fallback_errors:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            f"`installed review baseline fallback` setup failed: {'; '.join(review_fallback_errors)}",
+                        )
+                    )
+                else:
+                    payload, error = load_command_json(
+                        root,
+                        [
+                            "python3",
+                            str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                            "recovery",
+                            "writeback",
+                            "--target",
+                            str(review_fallback_target),
+                            "--item",
+                            "INIT-0001",
+                            "--current-checkpoint",
+                            "admission checkpoint",
+                            "--current-stop",
+                            "Installed review baseline is still at admission.",
+                            "--next-step",
+                            "Promote the target repo to build checkpoint before review.",
+                            "--latest-validation-summary",
+                            review_fallback_summary,
+                        ],
+                    )
+                    if error:
+                        failures.append(Failure("daily-execution-cli", f"`installed recovery writeback for admission fallback` failed: {error}"))
+                    elif payload.get("result") != "pass":
+                        failures.append(Failure("daily-execution-cli", "`installed recovery writeback for admission fallback` must pass"))
+
+                    git_add = run_command(
+                        root,
+                        ["git", "add", ".loom/progress/INIT-0001.md", ".loom/status/current.md"],
+                        cwd=review_fallback_target,
+                    )
+                    if git_add.returncode != 0:
+                        detail = git_add.stderr.strip() or git_add.stdout.strip() or "git add failed"
+                        failures.append(Failure("daily-execution-cli", f"`installed review baseline fallback` add failed: {detail}"))
+                    else:
+                        git_commit = run_command(
+                            root,
+                            ["git", "commit", "-m", "lower checkpoint to admission for #209 fallback"],
+                            cwd=review_fallback_target,
+                        )
+                        if git_commit.returncode != 0:
+                            detail = git_commit.stderr.strip() or git_commit.stdout.strip() or "git commit failed"
+                            failures.append(Failure("daily-execution-cli", f"`installed review baseline fallback` commit failed: {detail}"))
+
+                    payload, error = load_command_json(
+                        root,
+                        [
+                            "python3",
+                            str(install_root / "loom-review" / "scripts" / "loom-review.py"),
+                            "flow",
+                            "review",
+                            "--target",
+                            str(review_fallback_target),
+                            "--item",
+                            "INIT-0001",
+                        ],
+                    )
+                    if error:
+                        failures.append(Failure("daily-execution-cli", f"`installed flow review` admission fallback failed: {error}"))
+                    elif payload.get("result") != "fallback" or payload.get("fallback_to") != "admission":
+                        failures.append(Failure("daily-execution-cli", "`installed flow review` must fall back to `admission` when build checkpoint is missing"))
+
+                    payload, error = load_command_json(
+                        root,
+                        [
+                            "python3",
+                            str(install_root / "loom-merge-ready" / "scripts" / "loom-merge-ready.py"),
+                            "flow",
+                            "merge-ready",
+                            "--target",
+                            str(review_fallback_target),
+                            "--item",
+                            "INIT-0001",
+                        ],
+                    )
+                    if error:
+                        failures.append(Failure("daily-execution-cli", f"`installed flow merge-ready` review-baseline fallback failed: {error}"))
+                    elif payload.get("result") not in {"fallback", "block"}:
+                        failures.append(Failure("daily-execution-cli", "`installed flow merge-ready` must fail closed when review baseline is missing"))
+
+                readme_path = positive_target / "README.md"
+                readme_path.write_text(readme_path.read_text(encoding="utf-8") + "\n# review-head-drift\n", encoding="utf-8")
+                git_add = run_command(root, ["git", "add", "README.md"], cwd=positive_target)
+                if git_add.returncode != 0:
+                    detail = git_add.stderr.strip() or git_add.stdout.strip() or "git add failed"
+                    failures.append(Failure("daily-execution-cli", f"`installed merge-ready drift` add failed: {detail}"))
+                else:
+                    git_commit = run_command(
+                        root,
+                        ["git", "commit", "-m", "introduce non-carrier drift after review for #209"],
+                        cwd=positive_target,
+                    )
+                    if git_commit.returncode != 0:
+                        detail = git_commit.stderr.strip() or git_commit.stdout.strip() or "git commit failed"
+                        failures.append(Failure("daily-execution-cli", f"`installed merge-ready drift` commit failed: {detail}"))
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "checkpoint",
+                        "merge",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed checkpoint merge` drift negative failed: {error}"))
+                elif payload.get("result") != "block":
+                    failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` must block when HEAD drifts beyond Loom carriers"))
 
     fail_closed_payloads = [
         (

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -333,6 +333,17 @@ def git_head_sha(root: Path) -> str | None:
     return sha or None
 
 
+def git_changed_paths(root: Path, base: str, head: str) -> tuple[list[str], list[str]]:
+    result = run_git(root, ["diff", "--name-only", "--no-renames", f"{base}..{head}"])
+    if result is None:
+        return [], ["git is unavailable while comparing reviewed HEAD to current HEAD"]
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "git diff failed"
+        return [], [detail]
+    paths = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    return paths, []
+
+
 def git_remote_origin(root: Path) -> str | None:
     result = run_git(root, ["remote", "get-url", "origin"])
     if result is None or result.returncode != 0:
@@ -598,6 +609,14 @@ def read_runtime_evidence(target_root: Path, status_relative: str) -> tuple[dict
 
 def default_review_path(item_id: str) -> str:
     return f".loom/reviews/{item_id}.json"
+
+
+def allowed_post_review_carrier_paths(context: dict[str, Any], review_path: str) -> set[str]:
+    return {
+        review_path,
+        str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
+        str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
+    }
 
 
 def compat_findings_from_lists(
@@ -1372,9 +1391,18 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
             current_head = git_head_sha(context["target_root"])
             reviewed_head = review_record.get("reviewed_head")
             if current_head and reviewed_head != current_head:
-                missing_inputs.append("review artifact was recorded against a different HEAD")
-                if result == "pass":
-                    result = "block"
+                changed_paths, head_errors = git_changed_paths(context["target_root"], reviewed_head, current_head)
+                if head_errors:
+                    missing_inputs.extend([f"review HEAD comparison failed: {detail}" for detail in head_errors])
+                    if result == "pass":
+                        result = "block"
+                else:
+                    allowed_paths = allowed_post_review_carrier_paths(context, review_path)
+                    disallowed_paths = [path for path in changed_paths if path not in allowed_paths]
+                    if disallowed_paths or not changed_paths:
+                        missing_inputs.append("review artifact was recorded against a different HEAD")
+                        if result == "pass":
+                            result = "block"
             if decision == "block":
                 if result == "pass":
                     result = "block"

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -254,6 +254,7 @@ def route_payload(
     missing_inputs: list[str],
     fallback_to: str,
     governance_surface: dict[str, object] | None = None,
+    runtime_state: dict[str, object] | None = None,
 ) -> dict[str, object]:
     payload = {
         "command": "route",
@@ -267,6 +268,8 @@ def route_payload(
     }
     if governance_surface is not None:
         payload["governance_surface"] = governance_surface
+    if runtime_state is not None:
+        payload["runtime_state"] = runtime_state
     return payload
 
 
@@ -1464,6 +1467,26 @@ def route(args: argparse.Namespace) -> int:
         print(f"loom-init: target is not a directory: {target_root}", file=sys.stderr)
         return 2
 
+    runtime_state = runtime_state_payload(target_root)
+    if runtime_state["result"] != "pass":
+        print(
+            json.dumps(
+                route_payload(
+                    result="block",
+                    selected_skill="loom-init",
+                    mode="fallback",
+                    matched_signals=[],
+                    summary="cannot route because the Loom runtime state is inconsistent.",
+                    missing_inputs=list(runtime_state["missing_inputs"]),
+                    fallback_to=runtime_state["fallback_to"] or "loom-init",
+                    runtime_state=runtime_state,
+                ),
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return 1
+
     registry_skill_ids, registry_error = load_registry_skill_ids()
     if registry_error:
         print(
@@ -1476,6 +1499,7 @@ def route(args: argparse.Namespace) -> int:
                     summary=f"cannot route because {registry_error}",
                     missing_inputs=["a valid installed registry"],
                     fallback_to="loom-init",
+                    runtime_state=runtime_state,
                 ),
                 ensure_ascii=False,
                 indent=2,
@@ -1503,6 +1527,7 @@ def route(args: argparse.Namespace) -> int:
                         summary=f"unknown skill `{args.skill}`",
                         missing_inputs=["a known skill id from the installed registry"],
                         fallback_to="loom-init",
+                        runtime_state=runtime_state,
                     ),
                     ensure_ascii=False,
                     indent=2,
@@ -1520,6 +1545,7 @@ def route(args: argparse.Namespace) -> int:
                     missing_inputs=[],
                     fallback_to="loom-init",
                     governance_surface=governance_surface if args.skill in {"loom-adopt", "loom-resume"} else None,
+                    runtime_state=runtime_state,
                 ),
                 ensure_ascii=False,
                 indent=2,
@@ -1541,6 +1567,7 @@ def route(args: argparse.Namespace) -> int:
                         summary=f"route table resolved to unknown registry skill `{selected_skill}`",
                         missing_inputs=["a registry entry aligned with skills/route-matrix.md"],
                         fallback_to="loom-init",
+                        runtime_state=runtime_state,
                     ),
                     ensure_ascii=False,
                     indent=2,
@@ -1558,6 +1585,7 @@ def route(args: argparse.Namespace) -> int:
                     missing_inputs=[],
                     fallback_to="loom-init",
                     governance_surface=governance_surface if selected_skill in {"loom-adopt", "loom-resume"} else None,
+                    runtime_state=runtime_state,
                 ),
                 ensure_ascii=False,
                 indent=2,
@@ -1575,6 +1603,7 @@ def route(args: argparse.Namespace) -> int:
             missing_inputs=["one stable scenario signal such as adopt, resume, pre-review, handoff, retire, or merge-ready"],
             fallback_to="loom-init",
             governance_surface=governance_surface if governance_surface is not None else None,
+            runtime_state=runtime_state,
         )
     else:
         all_matches = sorted({signal for matched in matches.values() for signal in matched})
@@ -1587,6 +1616,7 @@ def route(args: argparse.Namespace) -> int:
             missing_inputs=["a single dominant scenario signal or an explicit --skill"],
             fallback_to="loom-init",
             governance_surface=governance_surface if governance_surface is not None else None,
+            runtime_state=runtime_state,
         )
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     return 0


### PR DESCRIPTION
## Summary
- 收口 `#209` 的 installed-skills pre-merge chain：`route -> resume -> pre-review -> review -> merge-ready`
- 让 installed `loom-init route` 接入 `runtime_state` 并在 runtime/layout 漂移时直接 fail-closed
- 扩展 `loom_check`，在隔离 install root 和隔离 target repo 上跑完整 installed 正向链与负样本
- 修正 `merge checkpoint` 对 review stale 的判定：允许 review 之后只新增 Loom 自身 review/recovery/status carriers 提交，其他 HEAD 漂移仍然 `block`

## What Changed
- `skills/shared/scripts/loom_init.py`
  - `route` 现在携带 `runtime_state`
  - runtime/layout 不一致时，`route` 直接 `block`
- `skills/shared/scripts/loom_flow.py`
  - `merge checkpoint` 现在区分 Loom carrier-only drift 和真正的 stale head
- `skills/shared/scripts/loom_check.py`
  - 新增 installed pre-merge chain 机械验收
  - 正样本跑到 `flow merge-ready = pass` 与 `checkpoint merge = pass`
  - 负样本覆盖：layout 漂移、review baseline 缺失、非 carrier 的 HEAD drift
- 文档与验收记录
  - 新增 `adoption/validation-installed-skills-pre-merge-chain.md`
  - 同步 `adoption/README.md`
  - 更新 review/merge-checkpoint 合同，写明 review 后只允许 Loom carriers 提交继续被 merge checkpoint 消费

## Validation
- `repo-local 源码现场`
  - `python3 tools/loom_check.py`
  - `make loom-check`
- `installed-skills 验证现场`
  - install root 只复制 `skills/`
  - target repo 使用 Loom 仓库隔离副本，不复用源工作树
  - 正向链结果：
    - `route(resume)` -> `loom-resume`
    - `flow resume = pass`
    - `route(pre-review)` -> `loom-pre-review`
    - `flow pre-review = pass`
    - `route(review)` -> `loom-review`
    - `flow review = pass`
    - `review record allow = pass`
    - `route(merge-ready)` -> `loom-merge-ready`
    - `flow merge-ready = pass`
    - `checkpoint merge = pass`
  - 负样本结果：
    - 删除 installed `install-layout.json` 后，`route = block`，`flow pre-review = block`
    - 把 recovery checkpoint 降回 `admission checkpoint` 后，`flow review = fallback`，`flow merge-ready = fallback`
    - allow review 后再提交非 Loom carrier 变更，`checkpoint merge = block`

## Boundary
- 本 PR 只收口 `#209` 的 installed pre-merge readiness
- 不宣称 `#210` 的 post-merge closeout / cleanup 已完成
- `#208` 仍只作为父级消费容器，不在本 PR 内收口

Closes #209
