### PR TITLE
feat: 暴露 repo_interface 稳定读面

### DIFF
--- a/adoption/execution-entry-compatibility.md
+++ b/adoption/execution-entry-compatibility.md
@@ -11,7 +11,7 @@
 | 层级 | 稳定入口 | 兼容承诺 |
 | --- | --- | --- |
 | root 入口与基础验证 | `loom_init bootstrap/verify/fact-chain/route` | `loom-init` 继续作为唯一 root entry，路由能力不替代底层 CLI |
-| 初始化与恢复公共治理读面 | `loom-init` 输出合同 + `loom-adopt` / `loom-resume` 场景合同 | `governance_surface` 作为稳定公共字段存在，场景 skill 只能复用或摘要，不新增第二套治理真相 |
+| 初始化与恢复公共治理读面 | `loom-init` 输出合同 + `loom-adopt` / `loom-resume` 场景合同 | `governance_surface` 作为稳定公共字段存在；其中 `repo_interface` 只承接 `repo companion` locator 与机读 requirements/gates，场景 skill 只能复用或摘要，不新增第二套治理真相 |
 | 日常读取与检查 | `loom_flow fact-chain/runtime-evidence/state-check` | 输出保持 JSON 结果语义（`result/summary/missing_inputs/fallback_to`） |
 | checkpoint 执行 | `loom_flow checkpoint admission/build/merge` | 三阶段语义与回退关系保持不变 |
 | 现场与纯度治理 | `loom_flow workspace <create/locate/cleanup/retire>` + `purity-check` | 生命周期动作与失败语义保持不变 |
@@ -27,7 +27,7 @@
 - 新增 authored 入口（如 `review record`、`recovery writeback`、`work-item create|update`）不把只读 flow 变成隐式写入
 - 新增场景 skill 入口不替代 `loom-init` 的 root 身份，只补显式入口与隐式路由
 - 新增 [../harness/host-action-contract.md](../harness/host-action-contract.md) 只收口既有 host-facing actions 的合同，不新增 umbrella CLI，也不改写既有命令输出结构
-- `governance_surface` 只允许扩充 locator 或职责说明，不允许更名、拆成并行字段或复制实时 authored 状态
+- `governance_surface` 只允许扩充 locator 或职责说明，不允许更名、拆成并行字段或复制实时 authored 状态；`repo_interface` 只允许承接 `repo companion` 的 locator、requirements 与 specialized gates 机读摘要
 - gate 与 verify 始终复用同一 CLI，不维护第二套检查命令
 
 ## 3. 可复验操作流
@@ -58,6 +58,7 @@
 
 - 前 1-9 步提供“该进入哪个入口/可继续执行/需阻断/是否应回退”的统一判断
 - `loom-init`、`loom-adopt`、`loom-resume` 对外公开的治理读面保持同一字段名 `governance_surface`
+- `governance_surface.repo_interface` 只区分 `absent | companion_docs_only | incomplete | present` 四类机读状态，不把旧式 companion docs 伪装成稳定 repo interface
 - merge 阶段可按状态返回 `fallback`，而不是伪装成通过
 - host-facing actions 继续复用既有命令，但 `fallback` 只保留给 Loom 内部 checkpoint / merge control；closeout 与 reconciliation 不把 drift 伪装成 `fallback`
 - 操作流既可拆分执行，也可通过聚合入口执行高频路径

--- a/skills/loom-init/references/output-contract.md
+++ b/skills/loom-init/references/output-contract.md
@@ -28,7 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
-- 接入方式是根级重写还是 `companion docs`
+- 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
 ### 3. 暂不引入
@@ -81,6 +81,14 @@
     - `branch_protection`
     - `required_checks`
     - `pr_reviews`
+  - `repo_interface`
+    - `availability`
+    - `manifest`
+    - `companion_entry`
+    - `repo_specific_requirements`
+    - `specialized_gates`
+    - `summary`
+    - `missing_inputs`
   - `summary`
   - `missing_inputs`
 
@@ -137,6 +145,7 @@
   - `validation_entry`
   - `review_merge_surface`
   - `github_control_plane`
+  - `repo_interface`
   - `summary`
   - `missing_inputs`
 - `carrier_summary` 的 6 个子项固定为：
@@ -148,6 +157,13 @@
   - `plan_path`
 - `carrier_summary` 每个子项固定为 `{status, locator, source}`，`status` 只允许 `present | missing | planned`
 - `github_control_plane` 缺失时允许用 `unknown`，但不得猜测
+- `repo_interface` 只允许承接 `repo companion` 的 locator 和机读 requirements / gates 摘要，不得复制 authored state
+- `repo_interface.availability` 只允许：
+  - `absent`
+  - `companion_docs_only`
+  - `incomplete`
+  - `present`
+- `repo_interface.manifest`、`repo_interface.companion_entry`、`repo_interface.repo_specific_requirements`、`repo_interface.specialized_gates` 固定为 `{status, locator, source}`
 
 禁止事项：
 
@@ -155,6 +171,7 @@
 - 改名或拆出并行的治理读面字段
 - 在 `governance_surface` 中并行复制实时停点、下一步、阻断项或验证摘要
 - 用 `governance_surface` 覆盖 `work item`、恢复入口、PR 或规则文档的 authored 事实
+- 把 `repo_interface` 变成第二套 review / recovery / closeout authored state
 
 ### 6. 验证与收口
 

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -29,6 +29,14 @@ PLANNED_LOCATORS = {
     "plan_path": ".loom/specs/INIT-0001/plan.md",
 }
 
+REPO_INTERFACE_SURFACES = ("review", "merge_ready", "closeout")
+REPO_INTERFACE_AVAILABILITY = {"absent", "companion_docs_only", "incomplete", "present"}
+REPO_INTERFACE_MANIFEST_SCHEMA = "loom-repo-companion-manifest/v1"
+REPO_INTERFACE_SCHEMA = "loom-repo-interface/v1"
+REPO_INTERFACE_ENFORCEMENT = {"blocking", "advisory"}
+REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
+REPO_INTERFACE_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
+
 
 def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(args, cwd=cwd, check=False, capture_output=True, text=True)
@@ -163,6 +171,244 @@ def detect_repository_mode(root: Path, loom_state: str, scenario_override: str |
 
 def carrier_entry(status: str, locator: str, source: str) -> dict[str, str]:
     return {"status": status, "locator": locator, "source": source}
+
+
+def has_legacy_companion_docs(root: Path) -> bool:
+    companion_dir = root / ".loom" / "companion"
+    if not companion_dir.exists() or not companion_dir.is_dir():
+        return False
+    for path in companion_dir.iterdir():
+        if path.name in {"manifest.json", "repo-interface.json"}:
+            continue
+        if path.suffix.lower() == ".md":
+            return True
+    return False
+
+
+def relative_locator_from_value(root: Path, raw_locator: object) -> str | None:
+    if not isinstance(raw_locator, str):
+        return None
+    locator = raw_locator.strip()
+    if not locator:
+        return None
+    locator_path = Path(locator)
+    if locator_path.is_absolute():
+        try:
+            return str(locator_path.relative_to(root))
+        except ValueError:
+            return str(locator_path)
+    return str(locator_path)
+
+
+def resolve_locator(root: Path, raw_locator: object) -> tuple[str | None, Path | None]:
+    locator = relative_locator_from_value(root, raw_locator)
+    if locator is None:
+        return None, None
+    return locator, (root / locator).resolve()
+
+
+def locator_status_entry(
+    *,
+    root: Path,
+    raw_locator: object,
+    source: str,
+) -> tuple[dict[str, str], str | None]:
+    locator, target = resolve_locator(root, raw_locator)
+    if locator is None or target is None:
+        return carrier_entry("missing", "unknown", source), f"{source} is missing a valid locator"
+    if not target.exists():
+        return carrier_entry("missing", locator, source), f"{source} points to missing path `{locator}`"
+    return carrier_entry("present", locator, source), None
+
+
+def validate_repo_specific_requirement(
+    *,
+    root: Path,
+    surface: str,
+    entry: object,
+    index: int,
+) -> list[str]:
+    prefix = f"repo_interface.{surface}[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    missing_inputs: list[str] = []
+    for field in ("id", "summary", "locator", "enforcement"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(f"{prefix} missing `{field}`")
+    enforcement = entry.get("enforcement")
+    if enforcement not in REPO_INTERFACE_ENFORCEMENT:
+        missing_inputs.append(f"{prefix} enforcement must be `blocking` or `advisory`")
+    locator, target = resolve_locator(root, entry.get("locator"))
+    if locator is None or target is None:
+        missing_inputs.append(f"{prefix} locator must be a non-empty string")
+    elif not target.exists():
+        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
+    return missing_inputs
+
+
+def validate_specialized_gate(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> list[str]:
+    prefix = f"specialized_gates[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    missing_inputs: list[str] = []
+    for field in ("id", "summary", "locator"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(f"{prefix} missing `{field}`")
+    locator, target = resolve_locator(root, entry.get("locator"))
+    if locator is None or target is None:
+        missing_inputs.append(f"{prefix} locator must be a non-empty string")
+    elif not target.exists():
+        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
+    return missing_inputs
+
+
+def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
+    companion_dir = root / ".loom" / "companion"
+    manifest_path = companion_dir / "manifest.json"
+    repo_interface_path = companion_dir / "repo-interface.json"
+
+    repo_interface_surface: dict[str, Any] = {
+        "availability": "absent",
+        "manifest": carrier_entry("missing", ".loom/companion/manifest.json", "companion manifest"),
+        "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
+        "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
+        "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "summary": "no repo companion interface is declared for this repository.",
+        "missing_inputs": [],
+    }
+    missing_inputs: list[str] = []
+
+    if not manifest_path.exists():
+        if has_legacy_companion_docs(root):
+            repo_interface_surface["availability"] = "companion_docs_only"
+            repo_interface_surface["summary"] = (
+                "legacy companion docs are present, but no machine-readable repo companion manifest is declared."
+            )
+        return repo_interface_surface, missing_inputs
+
+    repo_interface_surface["manifest"] = carrier_entry(
+        "present",
+        ".loom/companion/manifest.json",
+        "repository scan",
+    )
+    manifest = safe_read_json(manifest_path)
+    if manifest is None:
+        missing_inputs.append("repo companion manifest is unreadable")
+        repo_interface_surface["availability"] = "incomplete"
+        repo_interface_surface["summary"] = "repo companion manifest exists, but the machine-readable interface is incomplete."
+        repo_interface_surface["missing_inputs"] = missing_inputs
+        return repo_interface_surface, missing_inputs
+
+    if manifest.get("schema_version") != REPO_INTERFACE_MANIFEST_SCHEMA:
+        missing_inputs.append(
+            f"repo companion manifest schema must be `{REPO_INTERFACE_MANIFEST_SCHEMA}`"
+        )
+    extra_manifest_keys = sorted(set(manifest.keys()) - REPO_INTERFACE_MANIFEST_KEYS)
+    if extra_manifest_keys:
+        missing_inputs.append(
+            "repo companion manifest must stay locator-only: "
+            + ", ".join(extra_manifest_keys)
+        )
+
+    companion_entry, companion_error = locator_status_entry(
+        root=root,
+        raw_locator=manifest.get("companion_entry"),
+        source="repo companion manifest.companion_entry",
+    )
+    repo_interface_surface["companion_entry"] = companion_entry
+    if companion_error:
+        missing_inputs.append(companion_error)
+
+    manifest_repo_interface, manifest_repo_interface_error = locator_status_entry(
+        root=root,
+        raw_locator=manifest.get("repo_interface"),
+        source="repo companion manifest.repo_interface",
+    )
+    repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
+    repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    if manifest_repo_interface_error:
+        missing_inputs.append(manifest_repo_interface_error)
+
+    repo_interface_locator, repo_interface_target = resolve_locator(root, manifest.get("repo_interface"))
+    if repo_interface_surface["repo_specific_requirements"]["status"] != "present":
+        if repo_interface_path.exists() and manifest_repo_interface_error:
+            missing_inputs.append("repo companion manifest must point `repo_interface` to `.loom/companion/repo-interface.json`")
+    else:
+        interface_payload = safe_read_json(repo_interface_target or repo_interface_path)
+        if interface_payload is None:
+            missing_inputs.append("repo companion interface is unreadable")
+        else:
+            if interface_payload.get("schema_version") != REPO_INTERFACE_SCHEMA:
+                missing_inputs.append(f"repo companion interface schema must be `{REPO_INTERFACE_SCHEMA}`")
+            extra_interface_keys = sorted(set(interface_payload.keys()) - REPO_INTERFACE_KEYS)
+            if extra_interface_keys:
+                missing_inputs.append(
+                    "repo companion interface contains unexpected top-level fields: "
+                    + ", ".join(extra_interface_keys)
+                )
+            interface_companion_entry, interface_companion_error = locator_status_entry(
+                root=root,
+                raw_locator=interface_payload.get("companion_entry"),
+                source="repo companion interface.companion_entry",
+            )
+            if interface_companion_entry["status"] == "present":
+                repo_interface_surface["companion_entry"] = interface_companion_entry
+            if interface_companion_error:
+                missing_inputs.append(interface_companion_error)
+
+            requirements = interface_payload.get("repo_specific_requirements")
+            if not isinstance(requirements, dict):
+                missing_inputs.append("repo companion interface must include `repo_specific_requirements`")
+            else:
+                for surface in REPO_INTERFACE_SURFACES:
+                    entries = requirements.get(surface)
+                    if not isinstance(entries, list):
+                        missing_inputs.append(
+                            f"repo companion interface surface `{surface}` must be a list"
+                        )
+                        continue
+                    for index, entry in enumerate(entries):
+                        missing_inputs.extend(
+                            validate_repo_specific_requirement(
+                                root=root,
+                                surface=surface,
+                                entry=entry,
+                                index=index,
+                            )
+                        )
+
+            specialized_gates = interface_payload.get("specialized_gates")
+            if not isinstance(specialized_gates, list):
+                missing_inputs.append("repo companion interface must include `specialized_gates` as a list")
+            else:
+                for index, entry in enumerate(specialized_gates):
+                    missing_inputs.extend(
+                        validate_specialized_gate(
+                            root=root,
+                            entry=entry,
+                            index=index,
+                        )
+                    )
+
+    if missing_inputs:
+        repo_interface_surface["availability"] = "incomplete"
+        repo_interface_surface["summary"] = (
+            "repo companion manifest exists, but the machine-readable interface is incomplete."
+        )
+    else:
+        repo_interface_surface["availability"] = "present"
+        repo_interface_surface["summary"] = (
+            "repo companion manifest and machine-readable repo interface are readable."
+        )
+    repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
 def first_match(directory: Path, suffix: str, root: Path) -> str:
@@ -307,6 +553,7 @@ def build_governance_surface(
     execution_entry = detect_execution_entry(root, loom_state, bootstrap_mode=bootstrap_mode)
     validation_entry = detect_validation_entry(loom_state, bootstrap_mode=bootstrap_mode)
     review_merge_surface = detect_review_merge_surface(root, loom_state, bootstrap_mode=bootstrap_mode)
+    repo_interface, repo_interface_missing = detect_repo_interface(root)
 
     missing_inputs: list[str] = []
     if bootstrap_mode and repository_mode == "new":
@@ -317,6 +564,8 @@ def build_governance_surface(
         if not present_carriers:
             missing_inputs.append("no stable Loom carriers are readable yet")
         missing_inputs.extend(github_missing)
+        if repo_interface["availability"] == "incomplete":
+            missing_inputs.extend(repo_interface_missing)
         control_plane_ready = github_control_plane["default_branch"] != "unknown"
         carrier_ready = bool(present_carriers)
         summary = (
@@ -333,6 +582,7 @@ def build_governance_surface(
         "validation_entry": validation_entry,
         "review_merge_surface": review_merge_surface,
         "github_control_plane": github_control_plane,
+        "repo_interface": repo_interface,
         "summary": summary,
         "missing_inputs": list(dict.fromkeys(missing_inputs)),
     }


### PR DESCRIPTION
## Problem
`#199` 冻结边界后，还需要把稳定的 `repo_interface` 读面挂进 `governance_surface` 与 `loom-init` 输出合同，避免后续 flow 自造 companion 解析逻辑。

## Scope
- 扩展 `skills/shared/scripts/governance_surface.py`
- 更新 `skills/loom-init/references/output-contract.md`
- 更新 `adoption/execution-entry-compatibility.md` 中的公共治理读面兼容承诺

## Validation
- `python3 -m py_compile skills/shared/scripts/governance_surface.py`
- 最终栈验证见顶层收口 PR

## Risks And Follow-ups
- `loom_flow` 对 `repo_specific_requirements` 的消费留在后续 `#201`

## Related Work
- Part of #198
- Refs #200
- Stacked on #215
