### PR TITLE
docs(skills): 冻结 skills surface benchmark 与交付判断

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ CLI 主要给这些情况使用：
 - [skills/README.md](./skills/README.md)
 - [harness/README.md](./harness/README.md)
 - [skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)
+- [docs/skills-surface-delivery-judgment.md](./docs/skills-surface-delivery-judgment.md)
+- [docs/skills-surface-issue-tree-draft.md](./docs/skills-surface-issue-tree-draft.md)
 - [VISION.md](./VISION.md)
 - [docs/complete-kernel-release.md](./docs/complete-kernel-release.md)
 - [adoption/versioning-and-upgrades.md](./adoption/versioning-and-upgrades.md)

--- a/adoption/README.md
+++ b/adoption/README.md
@@ -24,6 +24,7 @@
 - `repo companion` 接口状态验证：[validation-repo-companion-interface.md](./validation-repo-companion-interface.md)
 - 小型既有仓库的默认 retrofit 策略：[lightweight-retrofit-default.md](./lightweight-retrofit-default.md)
 - 暂不固化、待继续验证的候选模式：[candidate-patterns.md](./candidate-patterns.md)
+- 外部优秀 `SKILLS` 仓库设计清单与 Loom gap analysis：[skills-repo-design-checklist.md](./skills-repo-design-checklist.md)
 - 初始化 `SKILL` 模拟验证：[demo-init-validation.md](./demo-init-validation.md)
 - 真实 adoption 验证记录合同：[validation-record-contract.md](./validation-record-contract.md)
 - 经验回流机制：[experience-feedback-loop.md](./experience-feedback-loop.md)
@@ -58,6 +59,7 @@ Issue -> 验证 / 回写索引：
 - `#180` -> [validation-retrofit-143-tree.md](./validation-retrofit-143-tree.md)
 - `#209` -> [validation-installed-skills-pre-merge-chain.md](./validation-installed-skills-pre-merge-chain.md)
 - `#210` -> [validation-installed-skills-post-merge-closeout.md](./validation-installed-skills-post-merge-closeout.md)
+- `#223` -> [skills-repo-design-checklist.md](./skills-repo-design-checklist.md); [../docs/skills-surface-delivery-judgment.md](../docs/skills-surface-delivery-judgment.md); [../docs/skills-surface-issue-tree-draft.md](../docs/skills-surface-issue-tree-draft.md)
 - `#169` -> [landing-map.md](./landing-map.md); [upstream-delivery-surface.md](./upstream-delivery-surface.md); [versioning-and-upgrades.md](./versioning-and-upgrades.md); [../docs/complete-kernel-release.md](../docs/complete-kernel-release.md)
 
 当前目录对应的主要 `EXT-*` 条目：

--- a/adoption/skills-repo-design-checklist.md
+++ b/adoption/skills-repo-design-checklist.md
@@ -1,0 +1,663 @@
+# SKILLS Repo Benchmark And Loom Gap Analysis
+
+本文把三个外部样本仓库作为 benchmark，完整评估“一个优秀 `SKILLS` 仓库”在产品面、分发面、shared 层、runtime、验证与升级面上应该长成什么样，并据此修正 Loom 的 gap analysis。
+
+讨论范围刻意收窄为：
+
+- 只评价“作为一个可分发和可消费的 `SKILLS` 仓库”是否优秀
+- 不评价 Loom 的治理理念、checkpoint 设计或 harness 目标本身是否成立
+- 不把单一仓库的局部实现直接提升为 Loom 默认规则
+
+## 1. 调研方法
+
+本次不再只看 `README` 和 `SKILL.md`，而是按以下六个面完整读取样本：
+
+1. 产品面
+   - 用户先看到什么
+   - 技能是如何被命名和组织的
+2. 安装 / 分发面
+   - plugin / marketplace / npm / symlink / bootstrap / package / manifest
+3. 技能单元与 shared 层
+   - `SKILL.md`、references、scripts、assets、shared skill、meta-skill
+4. runtime / tooling 面
+   - skill 实际依附什么执行面
+   - 真相源落在 skill、CLI、plugin 还是脚本层
+5. 测试 / 验证面
+   - 是否验证技能触发、显式调用、集成行为、安装后行为、回归
+6. 版本 / 升级 / 兼容面
+   - version truth、升级路径、兼容界面、同步面宽度
+
+## 2. 样本与一手材料
+
+### 2.1 `anthropics/skills`
+
+- 仓库入口
+  - [README](https://raw.githubusercontent.com/anthropics/skills/main/README.md)
+- 分发与分组
+  - [.claude-plugin/marketplace.json](https://raw.githubusercontent.com/anthropics/skills/main/.claude-plugin/marketplace.json)
+- 模板与规范
+  - [template/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/template/SKILL.md)
+  - [spec/agent-skills-spec.md](https://raw.githubusercontent.com/anthropics/skills/main/spec/agent-skills-spec.md)
+- 复杂 skill 样本
+  - [skills/pptx/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/pptx/SKILL.md)
+  - [skills/pptx/editing.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/pptx/editing.md)
+  - [skills/pptx/pptxgenjs.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/pptx/pptxgenjs.md)
+- authoring / packaging / eval
+  - [skills/skill-creator/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/SKILL.md)
+  - [skills/skill-creator/scripts/quick_validate.py](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/scripts/quick_validate.py)
+  - [skills/skill-creator/scripts/package_skill.py](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/scripts/package_skill.py)
+
+### 2.2 `obra/superpowers`
+
+- 仓库入口
+  - [README](https://raw.githubusercontent.com/obra/superpowers/main/README.md)
+- 宿主安装与分发
+  - [docs/README.codex.md](https://raw.githubusercontent.com/obra/superpowers/main/docs/README.codex.md)
+  - [.codex/INSTALL.md](https://raw.githubusercontent.com/obra/superpowers/main/.codex/INSTALL.md)
+  - [.opencode/INSTALL.md](https://raw.githubusercontent.com/obra/superpowers/main/.opencode/INSTALL.md)
+  - [.claude-plugin/plugin.json](https://raw.githubusercontent.com/obra/superpowers/main/.claude-plugin/plugin.json)
+  - [.claude-plugin/marketplace.json](https://raw.githubusercontent.com/obra/superpowers/main/.claude-plugin/marketplace.json)
+  - [.cursor-plugin/plugin.json](https://raw.githubusercontent.com/obra/superpowers/main/.cursor-plugin/plugin.json)
+  - [package.json](https://raw.githubusercontent.com/obra/superpowers/main/package.json)
+- bootstrap / root behavior
+  - [hooks/session-start](https://raw.githubusercontent.com/obra/superpowers/main/hooks/session-start)
+  - [hooks/hooks.json](https://raw.githubusercontent.com/obra/superpowers/main/hooks/hooks.json)
+  - [hooks/hooks-cursor.json](https://raw.githubusercontent.com/obra/superpowers/main/hooks/hooks-cursor.json)
+  - [skills/using-superpowers/SKILL.md](https://raw.githubusercontent.com/obra/superpowers/main/skills/using-superpowers/SKILL.md)
+- workflow / meta skills
+  - [skills/brainstorming/SKILL.md](https://raw.githubusercontent.com/obra/superpowers/main/skills/brainstorming/SKILL.md)
+  - [skills/writing-skills/SKILL.md](https://raw.githubusercontent.com/obra/superpowers/main/skills/writing-skills/SKILL.md)
+- 测试
+  - [tests/claude-code/README.md](https://raw.githubusercontent.com/obra/superpowers/main/tests/claude-code/README.md)
+  - [tests/skill-triggering/run-all.sh](https://raw.githubusercontent.com/obra/superpowers/main/tests/skill-triggering/run-all.sh)
+  - [tests/explicit-skill-requests/run-all.sh](https://raw.githubusercontent.com/obra/superpowers/main/tests/explicit-skill-requests/run-all.sh)
+
+### 2.3 `larksuite/cli`
+
+- 仓库入口
+  - [README](https://raw.githubusercontent.com/larksuite/cli/main/README.md)
+- shared / domain skills
+  - [skills/lark-shared/SKILL.md](https://raw.githubusercontent.com/larksuite/cli/main/skills/lark-shared/SKILL.md)
+  - [skills/lark-doc/SKILL.md](https://raw.githubusercontent.com/larksuite/cli/main/skills/lark-doc/SKILL.md)
+- CLI 真相层
+  - [cmd/root.go](https://raw.githubusercontent.com/larksuite/cli/main/cmd/root.go)
+  - [cmd/update/update.go](https://raw.githubusercontent.com/larksuite/cli/main/cmd/update/update.go)
+  - [internal/registry/loader.go](https://raw.githubusercontent.com/larksuite/cli/main/internal/registry/loader.go)
+  - [internal/registry/loader_embedded.go](https://raw.githubusercontent.com/larksuite/cli/main/internal/registry/loader_embedded.go)
+- 版本与升级
+  - [CHANGELOG.md](https://raw.githubusercontent.com/larksuite/cli/main/CHANGELOG.md)
+- E2E 测试
+  - [tests/cli_e2e/README.md](https://raw.githubusercontent.com/larksuite/cli/main/tests/cli_e2e/README.md)
+
+## 3. 样本画像
+
+### 3.1 `anthropics/skills`: 标准 skill 仓库样板
+
+#### 产品面
+
+这是三者里最接近“标准 `SKILLS` 仓库”的一个。仓库 README 把 skill 定义为“folders of instructions, scripts, and resources”，并强调每个 skill 都是 self-contained folder，核心单位就是 `SKILL.md` 加少量 bundled resources。[README](https://raw.githubusercontent.com/anthropics/skills/main/README.md)
+
+它的首层产品心智非常窄：
+
+- skill 是一个目录
+- 目录里必须有 `SKILL.md`
+- 其他内容只是可选的 scripts / references / assets
+
+这套定义在模板和 `skill-creator` 中是自洽的。[template/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/template/SKILL.md) [skills/skill-creator/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/SKILL.md)
+
+#### 安装 / 分发面
+
+仓库确实有分发层，但它非常薄：
+
+- Claude Code 用 `.claude-plugin/marketplace.json` 把 skills 分组为 `document-skills`、`example-skills`、`claude-api`
+- 用户入口仍然是 `/plugin marketplace add` 和 `/plugin install`
+- 分发分组存在，但不会反向变成每个 skill 的第一层用户心智
+
+Anthropic 还提供 `.skill` 打包脚本，但它被放在 `skill-creator` 内部，作为 authoring / distribution tooling，不是整个仓库的对外主叙事。[.claude-plugin/marketplace.json](https://raw.githubusercontent.com/anthropics/skills/main/.claude-plugin/marketplace.json) [skills/skill-creator/scripts/package_skill.py](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/scripts/package_skill.py)
+
+#### 技能单元与 shared 层
+
+Anthropic 没有做一个巨大 shared runtime；而是把 skill 尽可能保持为自包含单元：
+
+- `SKILL.md`
+- 按需 `scripts/`
+- 按需 `references/`
+- 按需 `assets/`
+
+`skill-creator` 甚至把这种模式明写成“three-level loading system”：
+
+1. metadata
+2. `SKILL.md` body
+3. bundled resources
+
+这意味着深知识是被允许的，但必须通过 progressive disclosure 下沉，而不是默认挤进首屏。[skills/skill-creator/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/SKILL.md)
+
+#### runtime / tooling 面
+
+Anthropic 的 runtime 逻辑基本是 skill-local 的：
+
+- `pptx` 依赖 skill 自带脚本和本地工具链
+- `docx` / `xlsx` / `pdf` 同样如此
+- 没有一个对所有 skill 都强制暴露的 runtime-state vocabulary
+
+也就是说，它允许复杂 runtime 存在，但把复杂性压在具体 skill 的内部执行面，而不是仓库级公开合同面。[skills/pptx/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/pptx/SKILL.md)
+
+#### 测试 / 验证面
+
+Anthropic 的强项不是仓库级 trigger regression，而是 authoring / eval 工具链：
+
+- frontmatter 和结构的轻量验证
+- packaging 校验
+- eval / benchmark / blind comparison / description optimization
+
+这说明它很重视“skill 质量”，但验证层主要服务 skill 作者，而不是形成一个强协议型的安装 / runtime 合同。[skills/skill-creator/scripts/quick_validate.py](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/scripts/quick_validate.py) [skills/skill-creator/SKILL.md](https://raw.githubusercontent.com/anthropics/skills/main/skills/skill-creator/SKILL.md)
+
+#### 版本 / 升级 / 兼容面
+
+Anthropic 几乎没有把 install / update / runtime compatibility 扩成一个公开同步面。它的同步面非常窄：
+
+- marketplace grouping
+- template
+- frontmatter contract
+- package skill tooling
+
+这和 Loom 当前把 `registry/install-layout/upgrade-contract/runtime_state` 都抬到入口层形成鲜明对照。
+
+#### 对 Loom 的直接启发
+
+- 强启发
+  - user-facing 单元必须尽量自包含
+  - 深知识应下沉到 references / scripts / assets
+  - skill 首屏只承担触发和 quick reference，不承担总协议说明
+- 不能直接照搬
+  - Anthropic 没有 Loom 这种 root routing / multi-scene workflow 问题
+  - 它的“无 shared runtime 中心”不能被机械上移为 Loom 默认实现
+
+### 3.2 `superpowers`: 技能驱动的方法论产品
+
+#### 产品面
+
+`superpowers` 不是单纯的 skill 示例仓库，而是一个方法论产品。用户先消费的是 workflow：
+
+- brainstorming
+- using-git-worktrees
+- writing-plans
+- subagent-driven-development
+- test-driven-development
+- requesting-code-review
+
+也就是说，用户先感知“我将怎样工作”，而不是“skills 仓库内部怎样装配”。[README](https://raw.githubusercontent.com/obra/superpowers/main/README.md)
+
+#### 安装 / 分发面
+
+`superpowers` 的分发层非常重，但被很好地隔离在宿主文档和 plugin manifest 中：
+
+- Claude Code marketplace
+- Superpowers marketplace
+- Codex CLI / App
+- Cursor
+- OpenCode
+- Copilot CLI
+- Gemini CLI
+
+每个平台都有自己的安装入口、manifest 或 hook：
+
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json`
+- `.cursor-plugin/plugin.json`
+- `.codex/INSTALL.md`
+- `.opencode/INSTALL.md`
+- `.opencode/plugins/superpowers.js`
+- `hooks/*.json`
+
+关键点不在于“它没有 adapter”，恰恰相反，它 adapter 很多；但这些 adapter 细节被系统性地留在宿主层，而不是写进 skill 首屏。[docs/README.codex.md](https://raw.githubusercontent.com/obra/superpowers/main/docs/README.codex.md) [.codex/INSTALL.md](https://raw.githubusercontent.com/obra/superpowers/main/.codex/INSTALL.md) [.claude-plugin/plugin.json](https://raw.githubusercontent.com/obra/superpowers/main/.claude-plugin/plugin.json)
+
+#### 技能单元与 shared 层
+
+`superpowers` 的 shared 层不是一个 runtime library，而是一个“方法论 bootstrap”：
+
+- `using-superpowers` 是根技能
+- `writing-skills` 是 meta-skill
+- 各类 workflow skills 表达流程纪律
+
+这意味着它的共享层更偏行为约束和流程编排，而不是 shared scripts contract。[skills/using-superpowers/SKILL.md](https://raw.githubusercontent.com/obra/superpowers/main/skills/using-superpowers/SKILL.md) [skills/writing-skills/SKILL.md](https://raw.githubusercontent.com/obra/superpowers/main/skills/writing-skills/SKILL.md)
+
+#### runtime / adapter 面
+
+`superpowers` 的 root/bootstrapping 非常典型：
+
+- Claude / Cursor 通过 `SessionStart` hook 注入 `using-superpowers`
+- OpenCode 通过 plugin 代码改写 config，并把 bootstrap 塞进第一条用户消息
+- Codex 通过 symlink / native discovery 暴露 skills
+
+这里最值得注意的不是“用了 hook”，而是：
+
+- root bootstrap 很薄，只负责强制你先进入 skills 纪律
+- 平台差异通过 hook / plugin output format / tool mapping 单独适配
+- 平台适配细节没有污染到每个 skill 的正文
+
+[hooks/session-start](https://raw.githubusercontent.com/obra/superpowers/main/hooks/session-start) [.opencode/plugins/superpowers.js](https://raw.githubusercontent.com/obra/superpowers/main/.opencode/plugins/superpowers.js)
+
+#### 测试 / 验证面
+
+`superpowers` 是三个样本里最重视 skill behavior regression 的一个。它明确测试：
+
+- 隐式 skill triggering
+- 显式 skill requests
+- Claude Code 集成行为
+- subagent-driven-development 端到端行为
+- OpenCode 插件加载和 tools 兼容
+
+也就是说，它验证的是“agent 会不会真的按 skill 行事”，而不只是文档存在与否。[tests/skill-triggering/run-all.sh](https://raw.githubusercontent.com/obra/superpowers/main/tests/skill-triggering/run-all.sh) [tests/explicit-skill-requests/run-all.sh](https://raw.githubusercontent.com/obra/superpowers/main/tests/explicit-skill-requests/run-all.sh) [tests/claude-code/README.md](https://raw.githubusercontent.com/obra/superpowers/main/tests/claude-code/README.md)
+
+#### 版本 / 升级 / 兼容面
+
+`superpowers` 有 version truth，但它不是一个单独的 skills protocol contract，而是宿主工件共同持有：
+
+- `package.json` version
+- plugin manifests version
+- `RELEASE-NOTES.md`
+- 各平台自己的 update story
+
+这说明 multi-host 分发可以 versioned，但不必以仓库级 `registry + install-layout + upgrade-contract` 三件套出现。
+
+#### 对 Loom 的直接启发
+
+- 强启发
+  - 宿主适配可以很多，但必须隔离在宿主层
+  - root bootstrap 应薄，只做纪律注入和导向
+  - skill behavior regression 值得单独测试
+- 不能直接照搬
+  - `using-superpowers` 的强方法论 bootstrap 不一定适合作为 Loom 的默认用户体验
+  - 它更像 process operating system，不是单纯 bundle
+
+### 3.3 `larksuite/cli`: 稳定工具层 + skills 编排层
+
+#### 产品面
+
+`lark-cli` 最关键的结构不是 skills，而是 CLI first。它把产品心智明确分为：
+
+- Human Quick Start
+- AI Agent Quick Start
+- Agent Skills
+- Three-Layer Command System
+
+也就是说，skills 不是孤立产品，而是稳定 CLI 真相层上的 agent-facing 编排面。[README](https://raw.githubusercontent.com/larksuite/cli/main/README.md)
+
+#### 安装 / 分发面
+
+`lark-cli` 的安装故事非常短：
+
+```bash
+npm install -g @larksuite/cli
+npx skills add larksuite/cli -y -g
+```
+
+它的 skill 安装和 CLI 安装是两步，但都是用户可理解的标准动作，不要求用户先理解任何内部 registry / layout / runtime taxonomy。[README](https://raw.githubusercontent.com/larksuite/cli/main/README.md)
+
+#### 技能单元与 shared 层
+
+`lark-cli` 的 shared 层非常清楚：
+
+- `lark-shared` 承担 auth、scope、identity、安全、更新提示
+- domain skills 只讲各自业务域
+- domain skills 用 references 承接长指南
+
+这是一种很干净的 shared pattern：
+
+- shared skill 负责横切问题
+- domain skill 负责业务操作
+- 底层 CLI 才是真相源
+
+[skills/lark-shared/SKILL.md](https://raw.githubusercontent.com/larksuite/cli/main/skills/lark-shared/SKILL.md) [skills/lark-doc/SKILL.md](https://raw.githubusercontent.com/larksuite/cli/main/skills/lark-doc/SKILL.md)
+
+#### runtime / tooling 面
+
+`lark-cli` 把真相源明确放在 CLI：
+
+- shortcuts
+- API commands
+- raw API
+- schema
+- embedded registry metadata
+- async update notice
+
+skills 主要做三件事：
+
+- 告诉 agent 什么时候用哪个 domain skill
+- 教 agent 如何调用 `lark-cli`
+- 把公共认证和安全规则下沉到 `lark-shared`
+
+这种分层的价值非常高：skill 不需要自己再发明一套 install/runtime truth surface，因为 CLI 已经承担了这层。[cmd/root.go](https://raw.githubusercontent.com/larksuite/cli/main/cmd/root.go) [internal/registry/loader.go](https://raw.githubusercontent.com/larksuite/cli/main/internal/registry/loader.go) [internal/registry/loader_embedded.go](https://raw.githubusercontent.com/larksuite/cli/main/internal/registry/loader_embedded.go)
+
+#### 测试 / 验证面
+
+`lark-cli` 的验证重点不在 automatic skill triggering，而在真实命令工作流：
+
+- 大量 unit tests
+- `tests/cli_e2e` 直接跑真实 CLI workflows
+- 甚至自带一个本地 skill 来帮助新增 E2E testcase
+
+这说明它把“skill 是否有用”的基础，放在“底层命令系统是否稳定”上，而不是放在一套独立 runtime-state 合同上。[tests/cli_e2e/README.md](https://raw.githubusercontent.com/larksuite/cli/main/tests/cli_e2e/README.md)
+
+#### 版本 / 升级 / 兼容面
+
+`lark-cli` 的升级面也落在 CLI 真相层：
+
+- `cmd/update/update.go` 提供 update command
+- JSON 输出中注入 `_notice.update`
+- `CHANGELOG.md` 明确持续记录 skills、shortcuts、auth、docs 的变更
+- `lark-shared` 甚至要求 agent 在看到 `_notice.update` 后主动提示用户升级 CLI 和 skills
+
+这是一种非常强的分层信号：upgrade semantics 不在 skills repo contract，而在 CLI product contract。[cmd/update/update.go](https://raw.githubusercontent.com/larksuite/cli/main/cmd/update/update.go) [skills/lark-shared/SKILL.md](https://raw.githubusercontent.com/larksuite/cli/main/skills/lark-shared/SKILL.md) [CHANGELOG.md](https://raw.githubusercontent.com/larksuite/cli/main/CHANGELOG.md)
+
+#### 对 Loom 的直接启发
+
+- 强启发
+  - 如果存在更底层的稳定工具面，skill 应依附它，而不是复制一套 runtime truth
+  - shared skill 是承接横切心智的好模式
+  - update / version / compatibility 最好落在更底层产品面
+- 不能直接照搬
+  - Loom 不是一个域命令行工具
+  - `CLI first` 不能被简单翻译为 `scripts first`
+
+## 4. 横向 benchmark
+
+| 维度 | `anthropics/skills` | `superpowers` | `lark-cli` |
+| --- | --- | --- | --- |
+| 用户主叙事 | 技能目录 + marketplace | workflow product + platform installs | CLI product + agent skills |
+| 对外技能单元 | self-contained folder | workflow skill + bootstrap | domain skill + shared skill |
+| shared 层 | 少，偏 skill-local resources | 行为约束 / bootstrap / meta-skill | `lark-shared` 横切能力 |
+| runtime 真相源 | skill-local scripts/resources | host hooks/plugins + skill discipline | CLI / registry / shortcuts / schema |
+| 分发形态 | Claude plugin marketplace + `.skill` 打包 | 多宿主 manifests / hooks / install docs | npm + `npx skills add` |
+| 版本面 | 很薄，主要 manifest/template/tooling | package + plugin manifests + release notes | CLI update command + changelog + JSON notice |
+| 技能行为回归 | authoring/eval tooling 为主 | 最强，显式测 triggering / integration | 主要测 CLI workflows |
+| 用户是否需要理解 runtime taxonomy | 基本不需要 | 基本不需要 | 基本不需要 |
+
+### 4.1 共同成立的结论
+
+三个样本都支持以下结论：
+
+1. 用户主路径必须短
+2. 首屏先讲什么时候用、怎么开始
+3. 深知识必须下沉
+4. 宿主适配可以复杂，但不应占据技能首屏
+5. skills 的对外同步面应尽量窄
+
+### 4.2 只在部分样本成立的结论
+
+这些结论不能被过早上移为 Loom 默认内核：
+
+1. root bootstrap 应该很薄
+   - 主要由 `superpowers` 强支持
+   - `anthropics/skills` 没有同类 root
+   - `lark-cli` 也不是 root skill 模式
+2. 入口层行为需要专门 trigger regression
+   - `superpowers` 强支持
+   - `anthropics/skills` 更偏 authoring eval
+   - `lark-cli` 更偏 CLI E2E
+3. skills 仓库应持有正式安装 / 发现 / 升级 machine contract
+   - 三个样本都不强支持 Loom 当前这条做法
+   - 它们都证明“需要安装与升级故事”
+   - 但都没有证明“必须以仓库级 `registry + install-layout + upgrade-contract` 形式暴露给用户”
+
+## 5. 修正后的设计清单
+
+和上一版相比，这一版把“用户层 checklist”和“结构层 checklist”拆开。
+
+### 5.1 用户层 checklist
+
+| 编号 | 设计项 | benchmark 结论 |
+| --- | --- | --- |
+| U1 | 用户先看到单一路径 | 必须成立 |
+| U2 | `SKILL.md` 首屏先讲触发条件和 quick path | 必须成立 |
+| U3 | 用户不需要理解 runtime taxonomy | 必须成立 |
+| U4 | 宿主适配细节不占据第一层心智 | 必须成立 |
+| U5 | 技能命名与分组贴近用户任务 | 应成立 |
+
+### 5.2 结构层 checklist
+
+| 编号 | 设计项 | benchmark 结论 |
+| --- | --- | --- |
+| S1 | 深知识下沉到 references / scripts / assets | 必须成立 |
+| S2 | 横切能力集中承接 | 应成立 |
+| S3 | 若存在更底层工具真相源，skills 依附它 | 强建议 |
+| S4 | 宿主安装 / 分发 / hook / manifest 与 skill 正文分层 | 必须成立 |
+| S5 | 版本 / 升级面应尽量收敛，不制造多处真相 | 必须成立 |
+| S6 | 入口层行为回归值得单独测试 | 候选增强能力 |
+| S7 | root bootstrap 应尽量轻薄 | 候选增强能力 |
+
+## 6. Loom 修正版 Gap Analysis
+
+### 6.1 用户层
+
+#### U1. 用户先看到单一路径
+
+Loom 当前状态：
+
+- 弱
+- 顶层安装叙事要求宿主读取 `skills/registry.json`、同步 `upgrade-contract.json`、同步 `install-layout.json`、安装 `shared/scripts/assets/references`、再校验 runtime scene，[README.md](/Users/mc/dev/Loom/README.md)
+
+基准对照：
+
+- 三个 benchmark 都把安装故事收成用户可以直接执行的路径
+- 没有一个把“技能仓库的内部合同文件”当成用户主叙事
+
+结论：
+
+- 这是 Loom 当前最大的产品面偏差之一
+
+#### U2. `SKILL.md` 首屏先讲触发条件和 quick path
+
+Loom 当前状态：
+
+- 部分成立
+- `loom-init` 虽然先讲初始化/路由，但很快进入 CLI、读取顺序、问诊和装配细则，[skills/loom-init/SKILL.md](/Users/mc/dev/Loom/skills/loom-init/SKILL.md)
+
+基准对照：
+
+- `pptx`、`brainstorming`、`lark-doc` 都更克制
+
+结论：
+
+- Loom 的 root skill 首屏仍然太像作者合同，不够像用户入口
+
+#### U3. 用户不需要理解 runtime taxonomy
+
+Loom 当前状态：
+
+- 弱
+- `repo-local-demo`、`installed-runtime`、`upgrade-rehearsal` 已经进入 README、`skills/README.md` 和 runtime 脚本词汇，[README.md](/Users/mc/dev/Loom/README.md) [skills/README.md](/Users/mc/dev/Loom/skills/README.md)
+
+基准对照：
+
+- 三个 benchmark 都不会要求用户先形成这一层心智
+
+结论：
+
+- Loom 当前把作者/调试层 vocabulary 泄漏到了用户层
+
+#### U4. 宿主适配细节不占据第一层心智
+
+Loom 当前状态：
+
+- 原则上成立，产品面上未兑现
+- `skills/distribution-and-adapter-contract.md` 已经正确表达了 adapter 边界
+- 但首屏文档仍然从 adapter/operator 视角写作
+
+基准对照：
+
+- `superpowers` 是最强反例：adapter 很复杂，但写法上被彻底留在宿主层
+
+结论：
+
+- Loom 的问题不是“有 adapter contract”，而是“adapter contract 太靠前”
+
+### 6.2 结构层
+
+#### S1. 深知识下沉
+
+Loom 当前状态：
+
+- 基础设施已具备
+- `shared/references/`、`shared/scripts/` 已经在做这件事
+
+问题：
+
+- 首屏没有真正克制，仍重复解释大量 runtime / install / drift 概念
+
+结论：
+
+- Loom 不是不会下沉，而是没有完成用户层与深层的真正切分
+
+#### S2. 横切能力集中承接
+
+Loom 当前状态：
+
+- 部分成立
+- 有 `shared/scripts` 与 `shared/references`
+
+基准对照：
+
+- `lark-shared` 给了更好的对照：shared 层应优先承接共享用户心智，而不是只承接共享 runtime 合同
+
+结论：
+
+- Loom 的 shared 层过度偏向内部执行合同中心
+
+#### S3. 若存在更底层工具真相源，skills 依附它
+
+Loom 当前状态：
+
+- 这里最不稳定
+- Loom 有 `skills/*/scripts` 与 `shared/scripts`
+- 但当前又把脚本树和安装布局一起提升成公开同步面
+
+基准对照：
+
+- `lark-cli` 显示最健康的方式是“skill 依附更底层产品真相”
+- Loom 还没有明确它的更底层真相究竟是 CLI、runtime 包、还是 root skill 合同
+
+结论：
+
+- Loom 需要先明确技能层之下的真相边界，再决定哪些工件要公开、哪些只供宿主消费
+
+#### S4. 宿主安装 / 分发 / hook / manifest 与 skill 正文分层
+
+Loom 当前状态：
+
+- 弱
+
+基准对照：
+
+- `superpowers` 证明可以有很多 manifest / hook / install docs，但不让它们变成 skill 首屏内容
+- `anthropics/skills` 证明 plugin marketplace grouping 可以存在，同时 skill 仍然保持自包含
+
+结论：
+
+- Loom 当前混层最明显的地方就在这里
+
+#### S5. 版本 / 升级面收敛
+
+Loom 当前状态：
+
+- 弱
+- 入口、版本、安装、升级、运行态识别、shared runtime 检查分散在 `registry.json`、`upgrade-contract.json`、`install-layout.json`、各 skill `contract.json`、`runtime_state.py` 和 README 中
+
+基准对照：
+
+- 没有 benchmark 样本支持 Loom 当前这种宽公开面的做法
+- 它们支持“需要 upgrade story”
+- 但不支持“需要把升级和安装布局同时暴露为用户公开技能合同”
+
+结论：
+
+- Loom 当前的多工件校验是有价值的，但其公开层级明显过高
+
+#### S6. 入口层行为回归
+
+Loom 当前状态：
+
+- 候选增强能力
+
+基准对照：
+
+- `superpowers` 强支持
+- `anthropics/skills` 和 `lark-cli` 提供的是侧面支持，不足以上移为默认 core
+
+结论：
+
+- Loom 可以继续保留为 `adapt`
+- 但不应把这条当作已经被多个独立样本强验证的稳定边界
+
+#### S7. root bootstrap 应尽量轻薄
+
+Loom 当前状态：
+
+- 弱
+
+基准对照：
+
+- 这条目前主要由 `superpowers` 强支持
+- `anthropics/skills` 与 `lark-cli` 不能直接充当第二、第三个 root bootstrap 样本
+
+结论：
+
+- 这条仍适合保留为候选增强能力
+- 但在产品直觉上，Loom 仍应朝这个方向收敛
+
+## 7. 对 Loom 的最终判断
+
+如果只从“优秀 `SKILLS` 仓库”来评价，Loom 当前的核心问题不是能力不足，而是分层暴露失衡。
+
+更具体地说：
+
+- Loom 已经具备不错的场景 skill 切分
+- Loom 也已经具备 shared references / shared scripts 这种深知识承载能力
+- Loom 的主要短板在于：
+  - 用户主路径不够短
+  - root skill 首屏不够轻
+  - 安装态 / 源码态 / rehearsal 态词汇泄漏到首层心智
+  - 安装 / 升级 / 运行态合同的公开面过宽
+  - `skills/` 同时承担用户产品面、宿主合同面、内部 runtime 认知面
+
+所以更准确的结论不是：
+
+- Loom 不应该有 adapter/runtime/install contract
+
+而是：
+
+- Loom 不应该把这些层直接暴露成 `SKILLS` 仓库的第一层产品面
+
+## 8. 优先修正顺序
+
+若只针对 `SKILLS` 仓库产品面收敛，建议顺序如下：
+
+1. 重写顶层安装叙事
+   - 拆开“用户如何安装使用”和“宿主如何适配 Loom”
+2. 收缩 `skills/README.md`
+   - 让它重新成为入口层产品说明，而不是入口层协议总览
+3. 收缩 `loom-init` 首屏
+   - 先只保留触发条件、判断入口、场景路由摘要
+4. 把 runtime scene / carrier 退到调试和宿主层
+   - 不再让 `repo-local-demo` / `installed-runtime` / `upgrade-rehearsal` 占据首层心智
+5. 重新划分公开同步面
+   - 明确哪些只给宿主消费，哪些才是用户公开面
+
+## 9. 本轮调研的边界
+
+本轮结论已经比“只看 `README` 和 `SKILL.md`”扎实得多，但仍有边界：
+
+- 它是仓库结构研究，不是 live install usability study
+- 它没有在每个平台真实执行全部安装流程
+- 它没有把所有 skill 都逐个消费一遍
+
+因此它适合用于：
+
+- 修正 Loom 的 `SKILLS` 产品面
+- 收窄 Loom 的公开合同面
+- 校正哪些结论可以上移，哪些仍应停在候选层
+
+但不适合直接声称：
+
+- 某个 benchmark 仓库的所有细节都能直接成为 Loom 默认规则

--- a/docs/skills-surface-delivery-judgment.md
+++ b/docs/skills-surface-delivery-judgment.md
@@ -1,0 +1,309 @@
+# SKILLS Surface Delivery Judgment
+
+本文基于 [adoption/skills-repo-design-checklist.md](/Users/mc/dev/Loom/adoption/skills-repo-design-checklist.md) 的 benchmark 调研，冻结 Loom 下一轮 `SKILLS` 产品面收敛工作的交付判断。
+
+它回答五件事：
+
+1. 这轮工作的交付目标是什么
+2. 这轮工作的 issue tree 应如何拆
+3. PR 应如何分批，哪些不得混线
+4. release goal 与默认版本判断是什么
+5. 什么条件满足后，这轮工作才算 closeout
+
+它不回答：
+
+- Loom 全局长期路线
+- `skills` 机读合同是否最终要重写成另一套结构
+- 宿主 adapter 的具体实现细节
+
+长期阶段路线仍以 [roadmap.md](/Users/mc/dev/Loom/docs/roadmap.md) 为准。
+版本语义仍以 [adoption/versioning-and-upgrades.md](/Users/mc/dev/Loom/adoption/versioning-and-upgrades.md) 为准。
+issue 类型与 parent / child closeout 语义仍以 [governance/issue-model.md](/Users/mc/dev/Loom/governance/issue-model.md) 为准。
+可直接提交的 issue tree 草案见 [skills-surface-issue-tree-draft.md](/Users/mc/dev/Loom/docs/skills-surface-issue-tree-draft.md)。
+
+## 1. 一句话判断
+
+Loom 当前 `SKILLS` 层的主要问题不是能力缺失，而是产品面、宿主合同面和内部 runtime 认知面混层。
+
+因此下一轮工作的正确目标不是：
+
+- 重写整个 `skills` runtime
+- 立刻推翻 `registry/install-layout/upgrade-contract`
+
+而是：
+
+- 先把 Loom 从“协议暴露型 `skills` 仓库”收敛到“用户主路径清晰的 `SKILLS` bundle”
+- 同时显式冻结哪些 machine contract 仍保留、但不再占据第一层产品面
+
+## 2. 本轮交付目标
+
+本轮工作只收以下目标：
+
+1. 用户主路径收敛
+   - 顶层 README 不再以 adapter/operator 视角作为第一叙事
+   - 用户可以先理解“怎么安装、怎么开始用 Loom skills”
+2. `skills` 产品面收敛
+   - `skills/README.md` 重新成为入口层产品说明，而不是协议总览
+3. root skill 首屏收敛
+   - `loom-init` 首屏只承担触发、判断和导向摘要
+   - 深知识继续下沉到 references
+4. runtime vocabulary 降层
+   - `repo-local-demo`、`installed-runtime`、`upgrade-rehearsal` 退出首层用户心智
+   - 保留在调试、宿主适配或深层文档中
+5. 公开面边界重述
+   - 明确区分“用户公开面”和“宿主公开面”
+   - 但本轮不强行重写 machine contract 本身
+
+## 3. 本轮非目标
+
+以下内容明确不进入本轮：
+
+1. 重写 `skills/registry.json`
+2. 重写 `skills/install-layout.json`
+3. 重写 `skills/upgrade-contract.json`
+4. 修改隐式路由优先级、root entry 身份或场景 skill 角色合同
+5. 重写 runtime detection 代码语义
+6. 重新定义 installed runtime 的 machine evidence
+
+原因很简单：
+
+- 一旦本轮同时碰这些内容，版本语义会迅速抬升到 `major`
+- benchmark 已经证明 Loom 当前最紧迫的问题在产品面暴露，而不是 machine contract 先天不存在
+
+换句话说：
+
+- 本轮先收“用户看见什么”
+- 下一轮再决定“机器如何读这些合同”
+
+## 4. issue tree 判断
+
+这轮工作应建立父 issue。
+
+原因：
+
+- 它同时涉及 `README` / `skills` / `root skill` / adoption / release / closeout
+- 若不提前固定拆分方式，很容易把文档收敛、入口行为、公开面边界和 release 判断混成一条 PR
+
+### 4.1 Parent issue 语义
+
+parent issue 负责：
+
+- 总目标
+  - Loom `SKILLS` 产品面收敛
+- 默认 PR slices
+- release goal
+- closeout basis
+
+parent issue 不直接承担实现主体。
+
+### 4.2 Child issue 默认拆分
+
+默认拆为 5 个 child issue，不混线：
+
+1. `skills-benchmark-and-target-freeze`
+   - 类型：`spec / planning issue`
+   - 负责 benchmark、目标边界、非目标和默认版本判断
+   - 可直接消费当前 [adoption/skills-repo-design-checklist.md](/Users/mc/dev/Loom/adoption/skills-repo-design-checklist.md) 与本文
+
+2. `top-level-install-and-readme-surface`
+   - 类型：`active execution issue`
+   - 负责顶层 README 的安装叙事、快速开始和用户主路径收敛
+
+3. `skills-readme-and-root-entry-surface`
+   - 类型：`active execution issue`
+   - 负责 `skills/README.md` 与 `skills/loom-init/SKILL.md` 首屏收敛
+
+4. `public-vs-host-surface-boundary`
+   - 类型：`active execution issue`
+   - 负责 `skills/distribution-and-adapter-contract.md`、`adoption/upstream-delivery-surface.md`、`adoption/versioning-and-upgrades.md` 等边界重述
+   - 目标是收紧公开面叙事，而不是修改 machine contract
+
+5. `skills-surface-validation-release-closeout`
+   - 类型：`validation / closeout issue`
+   - 负责验证记录、release judgment、closeout basis 和对外收口说明
+
+### 4.3 明确延期的后续树
+
+以下内容应明确延期到下一棵树，不混入本轮 parent：
+
+1. `machine-contract-narrowing`
+   - 若要改 `registry/install-layout/upgrade-contract` 的公开职责
+2. `runtime-evidence-hardening`
+   - 若要收紧 installed/runtime 识别条件
+3. `entry-behavior-regression-suite`
+   - 若要把 trigger / route regression 从候选提升为默认门禁
+
+这些都可能牵动 `major` 级版本判断，不应和本轮产品面收敛混线。
+
+## 5. 默认 PR Slices
+
+本轮默认固定为 4 批 PR：
+
+### PR-1 `benchmark + delivery judgment`
+
+职责：
+
+- benchmark 文档
+- 本文
+- 必要的 adoption / docs 索引
+
+不得混入：
+
+- README 重写
+- `loom-init` 重写
+- release note
+
+### PR-2 `top-level user surface`
+
+职责：
+
+- 根 README 的安装、快速开始、用户主路径收敛
+
+不得混入：
+
+- `skills/README.md`
+- `loom-init/SKILL.md`
+- `distribution-and-adapter-contract.md`
+
+### PR-3 `skills surface`
+
+职责：
+
+- `skills/README.md`
+- `skills/loom-init/SKILL.md`
+- 必要的 references 摘要调整
+
+不得混入：
+
+- machine contract JSON
+- runtime detection 代码
+- release note
+
+### PR-4 `boundary + release + closeout`
+
+职责：
+
+- `skills/distribution-and-adapter-contract.md`
+- `adoption/upstream-delivery-surface.md`
+- `adoption/versioning-and-upgrades.md`
+- release note / closeout 文档
+
+不得混入：
+
+- `registry/install-layout/upgrade-contract` 语义重写
+- runtime script 行为变化
+
+## 6. release goal 判断
+
+### 6.1 本轮 release goal
+
+本轮 release goal 应明确写成：
+
+`让 Loom 的 SKILLS 层从协议暴露型入口说明，收敛为用户主路径清晰、宿主边界清楚、但 machine contract 暂不重写的产品面。`
+
+这个目标的重点不是新增技能能力，而是：
+
+- 修正用户如何理解 Loom skills
+- 修正仓库如何对外描述 `skills`
+- 修正哪些内容属于首层公开面
+
+### 6.2 默认版本判断
+
+本轮默认按 `minor` 规划。
+
+理由：
+
+- 会明显改变用户可见的 `skills` 产品叙事
+- 会调整 root skill 与入口层说明的对外表达
+- 但若严格遵守本文件边界，不会破坏既有 machine contract、route priority 或 executable semantics
+
+### 6.3 何时升为 `major`
+
+若本轮出现以下任一变化，版本判断必须升级为 `major`：
+
+1. `bootstrap/root contract` 最小职责发生变化
+2. 隐式路由优先级变化
+3. 场景 skill 角色合同变化
+4. `registry/install-layout/upgrade-contract` 的对外 machine 语义变化
+5. installed/runtime/upgrade rehearsal 的 machine evidence 发生变化
+
+这也是为什么这些内容被明确移出本轮。
+
+### 6.4 何时可降为 `patch`
+
+仅当本轮最终只剩：
+
+- benchmark 文档
+- delivery judgment 文档
+- 非行为性说明补强
+
+且没有实质改动 README / `skills/README` / `loom-init` 首屏时，才可降为 `patch`。
+
+但按当前目标，本轮默认不按 `patch` 管理。
+
+## 7. 最小验证面
+
+本轮 closeout 前至少要验证：
+
+1. 新用户只读根 README，就能理解：
+   - 如何安装 / 接入 Loom skills
+   - `loom-init` 是默认入口
+   - 下一步如何开始
+2. 只读 `skills/README.md`，不会再先进入 adapter/runtime 词汇
+3. 只读 `loom-init/SKILL.md` 首屏，能先理解：
+   - 什么时候触发
+   - 先判断什么
+   - 会被导向哪些场景
+4. `distribution-and-adapter-contract.md` 仍保留宿主合同边界
+   - 但不再被默认当成首屏用户说明
+5. release / upgrade / delivery surface 文档对这轮变更的版本语义一致
+
+这轮验证的重点不是“脚本能不能跑”，而是：
+
+- 用户主路径是否收清
+- 产品面和宿主面是否分层
+- release judgment 是否与实际改动一致
+
+## 8. Done When
+
+只有当以下条件同时满足时，这棵树才算完成：
+
+1. benchmark 与交付判断已进入版本控制
+2. 顶层 README 已完成用户主路径收敛
+3. `skills/README.md` 已完成入口层产品面收敛
+4. `loom-init` 首屏已完成收敛，深知识已退回 references
+5. `distribution-and-adapter-contract.md`、`upstream-delivery-surface.md`、`versioning-and-upgrades.md` 已对齐新的边界表述
+6. release goal、默认版本判断和 closeout basis 已进入版本控制
+7. parent issue 不再依赖会话解释“为什么这轮不改 machine contract”
+
+如果只完成 benchmark 和交付判断，而未完成 README / root skill / boundary 收敛：
+
+- parent issue 不能 closeout
+- 只能停留在 planning freeze 已完成、execution 未完成
+
+## 9. Closeout basis
+
+本树 closeout 时，parent issue 至少要消费以下真相：
+
+- benchmark 文档
+- 本文
+- 根 README 收敛 PR
+- `skills/README.md` / `loom-init` 收敛 PR
+- boundary / release / closeout PR
+
+并且 parent closeout comment 至少要写清：
+
+1. 这轮明确收的是什么
+2. 哪些 machine contract 问题被有意延期
+3. 为什么当前版本判断仍是 `minor`
+4. 下一棵树应从哪里接续
+
+## 10. 下一树的接续点
+
+本轮完成后，下一棵树默认从这里继续：
+
+1. 判断是否要正式收窄 `registry/install-layout/upgrade-contract` 的公开职责
+2. 判断是否要把 runtime detection 从路径形状推断改为更强 evidence
+3. 判断入口层行为回归测试是否进入默认 core
+
+在这之前，不应让本轮树无限膨胀成 `skills` 全面重构树。

--- a/docs/skills-surface-issue-tree-draft.md
+++ b/docs/skills-surface-issue-tree-draft.md
@@ -1,0 +1,428 @@
+# SKILLS Surface Issue Tree Draft
+
+本文把 [skills-surface-delivery-judgment.md](/Users/mc/dev/Loom/docs/skills-surface-delivery-judgment.md) 直接翻成一版可提交的 GitHub issue tree 草案。
+
+目标不是继续分析，而是提供：
+
+- 1 个 parent issue 草案
+- 5 个 child issue 草案
+- 4 个 PR slice 对应关系
+
+本稿默认用于 Loom 下一轮 `SKILLS` 产品面收敛工作。
+
+## 1. Parent Issue Draft
+
+### 标题
+
+`SKILLS surface convergence: from protocol-exposed entry layer to user-facing bundle`
+
+### 类型
+
+`spec / planning issue`
+
+### 建议正文
+
+```md
+## Goal
+
+收敛 Loom 当前 `SKILLS` 层的产品面，使其从“协议暴露型入口说明”推进到“用户主路径清晰、宿主边界清楚、但 machine contract 暂不重写的 `SKILLS` bundle”。
+
+## Why
+
+当前 `skills/` 的主要问题不是能力缺失，而是三层混在了一起：
+
+- 用户产品面
+- 宿主合同面
+- 内部 runtime 认知面
+
+结果是：
+
+- 用户先看到安装协议，而不是使用主路径
+- `skills/README.md` 更像协议总览，而不是入口层产品说明
+- `loom-init` 首屏合同密度高于可用性
+- `repo-local-demo` / `installed-runtime` / `upgrade-rehearsal` 等词汇泄漏到首层心智
+
+## Scope
+
+本树只收以下目标：
+
+1. 顶层 README 的用户主路径收敛
+2. `skills/README.md` 的入口层产品面收敛
+3. `skills/loom-init/SKILL.md` 首屏收敛
+4. `skills` 用户公开面与宿主公开面的边界重述
+5. release goal、版本判断与 closeout basis 收口
+
+## Non-goals
+
+以下内容不进入本树：
+
+- 重写 `skills/registry.json`
+- 重写 `skills/install-layout.json`
+- 重写 `skills/upgrade-contract.json`
+- 修改 root entry 身份、隐式路由优先级或场景 skill 角色合同
+- 重写 runtime detection 代码语义
+- 重新定义 installed runtime 的 machine evidence
+
+这些工作若进入本树，版本语义将直接升级到 `major`，应另起后续树处理。
+
+## Child Issues
+
+1. `skills-benchmark-and-target-freeze`
+2. `top-level-install-and-readme-surface`
+3. `skills-readme-and-root-entry-surface`
+4. `public-vs-host-surface-boundary`
+5. `skills-surface-validation-release-closeout`
+
+## Default PR Slices
+
+1. `benchmark + delivery judgment`
+2. `top-level user surface`
+3. `skills surface`
+4. `boundary + release + closeout`
+
+## Release Goal
+
+让 Loom 的 `SKILLS` 层从协议暴露型入口说明，收敛为用户主路径清晰、宿主边界清楚、但 machine contract 暂不重写的产品面。
+
+默认版本判断：`minor`
+
+若出现以下任一变化，必须升级为 `major`：
+
+- `bootstrap/root contract` 最小职责变化
+- 隐式路由优先级变化
+- 场景 skill 角色合同变化
+- `registry/install-layout/upgrade-contract` 的 machine 语义变化
+- installed/runtime evidence 变化
+
+## Done When
+
+只有当以下条件同时满足时，本 issue 才可 closeout：
+
+1. benchmark 与交付判断已进入版本控制
+2. 根 README 已完成用户主路径收敛
+3. `skills/README.md` 已完成入口层产品面收敛
+4. `loom-init` 首屏已完成收敛，深知识已退回 references
+5. `distribution-and-adapter-contract.md`、`upstream-delivery-surface.md`、`versioning-and-upgrades.md` 已对齐新的边界表述
+6. release goal、默认版本判断和 closeout basis 已进入版本控制
+7. parent issue 不再依赖会话解释“为什么这轮不改 machine contract”
+
+## Closeout Basis
+
+parent closeout 时只消费子 issue 已成立真相，不替代子 issue 的独立完成判断。
+
+closeout comment 至少应写清：
+
+1. 这轮明确收了什么
+2. 哪些 machine contract 问题被有意延期
+3. 为什么当前版本判断仍是 `minor`
+4. 下一棵树应从哪里接续
+```
+
+## 2. Child Issue Drafts
+
+### 2.1 `skills-benchmark-and-target-freeze`
+
+#### 标题
+
+`Benchmark and freeze the target boundary for SKILLS surface convergence`
+
+#### 类型
+
+`spec / planning issue`
+
+#### 建议正文
+
+```md
+## Goal
+
+把外部 benchmark 与 Loom 当前 `SKILLS` 问题收成版本控制中的冻结判断，作为后续 README、root entry、boundary 和 release 工作的统一输入。
+
+## Scope
+
+- 固定 benchmark 样本与调研边界
+- 固定本轮收什么、不收什么
+- 固定默认版本判断
+- 固定 issue tree 与 PR slices
+
+## Inputs
+
+- `adoption/skills-repo-design-checklist.md`
+- `docs/skills-surface-delivery-judgment.md`
+
+## Deliverables
+
+- benchmark 文档
+- delivery judgment 文档
+- 必要的索引补链
+
+## Done When
+
+1. benchmark 文档已明确：
+   - 样本
+   - 方法
+   - 结论
+   - Loom gap analysis
+2. delivery judgment 已明确：
+   - scope
+   - non-goals
+   - issue tree
+   - PR slices
+   - release goal
+   - version judgment
+3. 后续执行 issue 不再需要重新讨论“本轮为什么不改 machine contract”
+```
+
+### 2.2 `top-level-install-and-readme-surface`
+
+#### 标题
+
+`Converge top-level install story and user-facing README surface`
+
+#### 类型
+
+`active execution issue`
+
+#### 建议正文
+
+```md
+## Goal
+
+把根 README 从 adapter/operator-first 的安装叙事，收敛为用户可直接消费的 Loom skills 主路径说明。
+
+## Scope
+
+- 重写安装与快速开始主叙事
+- 先讲如何接入和开始使用 Loom skills
+- 保留深层文档入口，但不再让协议工件占据首屏
+
+## Must Preserve
+
+- 不改 machine contract
+- 不改 root entry 身份
+- 不改 executable semantics
+
+## Out of Scope
+
+- `skills/README.md`
+- `skills/loom-init/SKILL.md`
+- `skills/distribution-and-adapter-contract.md`
+
+## Done When
+
+1. 新用户只读根 README，就能理解：
+   - 如何安装 / 接入 Loom skills
+   - `loom-init` 是默认入口
+   - 下一步如何开始
+2. README 首屏不再要求用户先理解：
+   - `registry.json`
+   - `install-layout.json`
+   - `upgrade-contract.json`
+   - runtime scene vocabulary
+3. 深层协议文档仍可从 README 进入，但已退居第二层
+```
+
+### 2.3 `skills-readme-and-root-entry-surface`
+
+#### 标题
+
+`Converge skills README and loom-init root entry surface`
+
+#### 类型
+
+`active execution issue`
+
+#### 建议正文
+
+```md
+## Goal
+
+把 `skills/README.md` 与 `skills/loom-init/SKILL.md` 收成真正的入口层产品说明，而不是协议总览或作者合同。
+
+## Scope
+
+- 重写 `skills/README.md`
+- 收缩 `loom-init` 首屏
+- 把深知识继续压回 references
+
+## Must Preserve
+
+- root entry 仍为 `loom-init`
+- 场景 skill 切分不变
+- route semantics 不变
+
+## Out of Scope
+
+- `registry/install-layout/upgrade-contract` JSON
+- runtime detection 代码
+- release note
+
+## Done When
+
+1. 只读 `skills/README.md`，不会再先进入 adapter/runtime 词汇
+2. 只读 `loom-init/SKILL.md` 首屏，能先理解：
+   - 什么时候触发
+   - 先判断什么
+   - 会被导向哪些场景
+3. `repo-local-demo` / `installed-runtime` / `upgrade-rehearsal` 不再作为首屏主叙事
+4. 深知识已有清晰 references 落点，不需要再挤回首屏
+```
+
+### 2.4 `public-vs-host-surface-boundary`
+
+#### 标题
+
+`Restate public-vs-host boundary for the skills surface`
+
+#### 类型
+
+`active execution issue`
+
+#### 建议正文
+
+```md
+## Goal
+
+重新表述 Loom `SKILLS` 的用户公开面与宿主公开面边界，明确哪些内容属于第一层产品面，哪些内容只给宿主/adapter 消费。
+
+## Scope
+
+- `skills/distribution-and-adapter-contract.md`
+- `adoption/upstream-delivery-surface.md`
+- `adoption/versioning-and-upgrades.md`
+
+## Must Preserve
+
+- adapter 边界原则仍成立
+- machine contract 仍保留
+- 不修改其实际 JSON 语义
+
+## Out of Scope
+
+- runtime script 代码
+- registry/install-layout/upgrade-contract 文件内容
+- 路由或 executable 语义
+
+## Done When
+
+1. 文档已经明确区分：
+   - 用户公开面
+   - 宿主公开面
+2. `distribution-and-adapter-contract.md` 不再被默认当成首屏用户说明
+3. `upstream-delivery-surface.md` 与 `versioning-and-upgrades.md` 已对齐本轮 `minor` 判断
+4. 后续若要改 machine contract，对外已经有清晰的下一树入口
+```
+
+### 2.5 `skills-surface-validation-release-closeout`
+
+#### 标题
+
+`Validate, release-judge, and close out the skills surface convergence tree`
+
+#### 类型
+
+`validation / closeout issue`
+
+#### 建议正文
+
+```md
+## Goal
+
+为本轮 `SKILLS` 产品面收敛补齐验证记录、release judgment、closeout basis 与对外收口说明。
+
+## Scope
+
+- 验证记录
+- release goal 对账
+- 版本判断对账
+- closeout basis
+
+## Inputs
+
+- parent issue
+- README surface PR
+- skills surface PR
+- boundary PR
+
+## Done When
+
+1. 本轮最小验证面已对齐：
+   - 根 README 用户主路径
+   - `skills/README.md` 首屏
+   - `loom-init` 首屏
+   - boundary 文档
+   - release/version 文档
+2. release goal 已进入版本控制
+3. 默认版本判断与实际改动一致
+4. parent closeout comment 已明确：
+   - 本轮收口对象
+   - 延期对象
+   - `minor` 判断依据
+   - 下一树接续点
+```
+
+## 3. PR Slice Mapping
+
+### PR-1 `benchmark + delivery judgment`
+
+对应 issue：
+
+- `skills-benchmark-and-target-freeze`
+
+建议内容：
+
+- benchmark 文档
+- delivery judgment 文档
+- adoption / docs / README 索引补链
+
+### PR-2 `top-level user surface`
+
+对应 issue：
+
+- `top-level-install-and-readme-surface`
+
+建议内容：
+
+- 根 README 的安装与快速开始收敛
+
+### PR-3 `skills surface`
+
+对应 issue：
+
+- `skills-readme-and-root-entry-surface`
+
+建议内容：
+
+- `skills/README.md`
+- `skills/loom-init/SKILL.md`
+- 必要的 references 摘要调整
+
+### PR-4 `boundary + release + closeout`
+
+对应 issue：
+
+- `public-vs-host-surface-boundary`
+- `skills-surface-validation-release-closeout`
+
+建议内容：
+
+- `skills/distribution-and-adapter-contract.md`
+- `adoption/upstream-delivery-surface.md`
+- `adoption/versioning-and-upgrades.md`
+- release note / closeout 文档
+
+## 4. 使用说明
+
+推荐提交顺序：
+
+1. 先开 parent issue
+2. 再开 5 个 child issue
+3. PR 严格按 4 批推进
+4. parent closeout 只消费 child issue 已成立真相
+
+推荐不要在 issue tree 里提前引入的条目：
+
+- `machine-contract-narrowing`
+- `runtime-evidence-hardening`
+- `entry-behavior-regression-suite`
+
+这些应保留为下一树，而不是在本轮执行期膨胀进来。


### PR DESCRIPTION
## Summary

- Problem: Loom 当前 `SKILLS` 层缺的不是能力，而是缺少一份冻结后的 benchmark 与交付判断，导致后续 README、root entry、boundary 和 release 工作会反复回到 scope 争论。
- Scope: 只收 `#223` 的 benchmark、delivery judgment、issue tree draft 与索引补链，不改 README 用户面、不改 skills 首屏、不改 boundary/versioning 文档。

## Validation

- [ ] Verified locally
- [x] Verified by automation
- [ ] Not applicable

Validation details:

- Ran `make loom-check`
- Checked the PR-1 diff stays within `README.md`, `adoption/README.md`, `adoption/skills-repo-design-checklist.md`, `docs/skills-surface-delivery-judgment.md`, and `docs/skills-surface-issue-tree-draft.md`

## Risks And Follow-ups

- Risks: If later PRs drift into machine contract JSON or runtime detection semantics, this tree must escalate from `minor` to `major` and be split.
- Follow-ups: `#224` root README user path, `#225` skills entry surface, `#226` boundary restatement, `#227` validation/release/closeout.

## Related Work

- Issue: `#223`
- Spec / plan: `docs/skills-surface-delivery-judgment.md`
