### PR TITLE
docs(skills): 收敛 skills README 与 loom-init 首屏

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,101 +1,78 @@
 # Skills
 
-`skills/` 负责 Loom 的入口层。
+`skills/` 是 Loom 面向用户的入口层。
 
-当前 `skills/` 的核心职责，是把 Loom 已有能力装配成可直接使用的入口，并把执行者导向正确场景。
+当 Loom 被安装到 Codex、Claude Code 或其他 agent 平台后，用户真正会看到并调用的，就是这里的 skill 名称。
 
-当前稳定结构为：
+默认从 `loom-init` 开始。它是 Loom 唯一的 root entry，负责两件事：
 
-- 1 个 root entry
-  - `loom-init`
-- 7 个场景 skills
-  - `loom-adopt`
-  - `loom-resume`
-  - `loom-pre-review`
-  - `loom-review`
-  - `loom-handoff`
-  - `loom-retire`
-  - `loom-merge-ready`
+- 初始化 Loom，或把 Loom retrofit 进既有仓库
+- 在没有显式指定场景 skill 时，根据任务信号把执行者导向正确场景
 
-当前已落以下入口合同与分发工件：
+不要把 `skills/` 当成新的事实真相源。这里的职责是把 Loom 已有能力装配成稳定入口，并把用户带到正确场景。
 
-- [registry.json](./registry.json)
-  - 仓库内机读入口注册表，声明 root 入口、场景入口与合同版本
-- [upgrade-contract.json](./upgrade-contract.json)
-  - 仓库内机读升级协议，声明显式升级、多 entry 版本可见、runtime-state 兼容问题与刷新要求
-- [install-layout.json](./install-layout.json)
-  - 仓库内机读安装布局合同，声明 installed-skills 最小必须面与 installed runtime 判定面
-- [route-matrix.md](./route-matrix.md)
-  - root entry 的显式 / 隐式路由矩阵，声明任务信号与目标 skill 的稳定对应关系
+## 用户会看到哪些入口
+
+Loom 当前稳定提供 1 个 root entry 和 7 个场景 skills：
+
+- `loom-init`
+  - 默认入口；负责初始化与路由
+- `loom-adopt`
+  - 初始化新项目，或把 Loom 接入既有仓库
+- `loom-resume`
+  - 接手事项、恢复上下文、继续推进
+- `loom-pre-review`
+  - 正式 review 前的统一检查
+- `loom-review`
+  - 正式 review、语义审查、输出 review 结论
+- `loom-handoff`
+  - 交接当前事项，回写停点与下一步
+- `loom-retire`
+  - 清理或 retire 当前工作现场
+- `loom-merge-ready`
+  - merge 前最后一次放行检查
+
+## 入口如何工作
+
+Loom 的入口有两种进入方式：
+
+- 显式进入
+  - 用户已经知道当前是哪个场景，直接调用对应 skill
+  - 显式 skill 优先，不再经过额外路由
+- 路由进入
+  - 用户没有显式指定场景时，先进入 `loom-init`
+  - `loom-init` 根据任务信号，把执行者路由到正确场景 skill
+
+若任务信号不足、同时命中多个场景，或缺少稳定执行所需的最小输入，不要猜测。回退到 `loom-init`，并要求最小补充信号。
+
+稳定路由规则见 [route-matrix.md](./route-matrix.md)。
+
+## 什么时候先用 `loom-init`
+
+以下情况默认都先进入 `loom-init`：
+
+- 第一次把 Loom 带进一个仓库
+- 你只知道“现在要开始”，但还不知道该进入哪个场景
+- 你需要 Loom 先判断这是初始化、恢复执行、review、交接还是 merge-ready
+- 当前任务信号不完整，需要 root entry 先收清最小判断输入
+
+如果你已经明确知道自己就是在做 review、handoff、retire 或 merge-ready，就直接进入对应场景 skill。
+
+## 深入文档放在哪里
+
+以下文档继续存在，但它们不再是用户理解 `skills/` 的第一屏：
+
 - [loom-init/SKILL.md](./loom-init/SKILL.md)
-  - Loom 的唯一 root entry，负责初始化与场景路由
-- [loom-init/contract.json](./loom-init/contract.json)
-  - `loom-init` 的机读 root 合同，声明输入 / 输出合同、路由引用与安装关系
-- 各场景 skill 的 `SKILL.md` / `contract.json` / `agents/openai.yaml` / `references/*`
-  - 声明对应场景的触发信号、输出合同与底层 CLI 编排
-- 各场景 skill 的 `scripts/*`
-  - 作为 installed-skills 的正式入口脚本
-- [shared/scripts/](./shared/scripts/)
-  - 共享 deterministic runtime，供所有 skill-local scripts 复用
-- [shared/assets/](./shared/assets/)
-  - bootstrap 写入目标仓库所需的模板和 PR 资产
-- [shared/references/](./shared/references/)
-  - installed-skills 必需的 Loom 真相读面
-- [distribution-and-adapter-contract.md](./distribution-and-adapter-contract.md)
-  - 约束 `skills/` 作为入口层时的最小分发、发现、升级、版本识别与宿主适配边界
-
-当前 `skills/` 的职责包括：
-
-- 读取 `shared/references/` 中镜像的 adoption / governance / harness / templates 真相读面
-- 将这些能力装配成初始化、执行、审查与收口入口
-- 暴露可被宿主直接调用的执行入口，例如各 skill 的 `scripts/*.py` 与 `shared/scripts/*.py`
-- 让 root entry 在显式调用与隐式信号下，都能导向正确场景 skill
-- 让宿主能读出当前是 `repo-local-demo`、`installed-runtime` 还是 `upgrade-rehearsal`
-- 在 runtime/resources/version drift 时 fail-closed，而不是把“入口存在”伪装成“入口可运行”
-
-对入口层自身，Loom 当前至少要求能表达以下验证面：
-
-- 显式触发是否正确
-- 隐式触发是否正确
-- 行为是否出现退化
-- adapter 失败是否可见
-- 版本变化是否可见
-
-这些验证面的最小边界由 [distribution-and-adapter-contract.md](./distribution-and-adapter-contract.md) 承接；宿主完整测试矩阵与 CI 产品细节不进入 Loom 内核。
-
-当前 `skills/` 的直接输入主要来自：
-
-- [shared/references/adoption/routing-and-checkpoints.md](./shared/references/adoption/routing-and-checkpoints.md)
-- [shared/references/adoption/lightweight-retrofit-default.md](./shared/references/adoption/lightweight-retrofit-default.md)
-- [shared/references/governance/review-model.md](./shared/references/governance/review-model.md)
-- [shared/references/harness/daily-entry-matrix.md](./shared/references/harness/daily-entry-matrix.md)
-- [shared/references/harness/recovery-model.md](./shared/references/harness/recovery-model.md)
-- [shared/references/templates/spec-suite.md](./shared/references/templates/spec-suite.md)
+  - root entry 的触发方式、快速判断与路由摘要
 - [route-matrix.md](./route-matrix.md)
-- [loom-init/references/input-signals.md](./loom-init/references/input-signals.md)
-- [loom-init/references/output-contract.md](./loom-init/references/output-contract.md)
+  - 显式进入 / 路由进入 / fallback 的稳定规则
+- [distribution-and-adapter-contract.md](./distribution-and-adapter-contract.md)
+  - 宿主适配、安装、升级、分发与失败可见性边界
+- [registry.json](./registry.json)
+  - 机读入口注册表
+- [upgrade-contract.json](./upgrade-contract.json)
+  - 机读升级协议
+- [install-layout.json](./install-layout.json)
+  - 机读安装布局合同
 
-其中 `loom-init` 负责两件事：
-
-- 做初始化 bootstrap
-- 在未显式指定 skill 时，基于任务信号路由到正确场景
-
-场景 skill 负责：
-
-- 解释什么时候该用这个入口
-- 明确应该读取哪些 Loom 真相载体
-- 编排对应 CLI 或 flow
-- 输出该场景的最小稳定结果
-
-其中 `loom-init` 负责把以下入口合同转成实际判断与输出：
-
-- 输入信号合同
-  - [loom-init/references/input-signals.md](./loom-init/references/input-signals.md)
-- 输出合同
-  - [loom-init/references/output-contract.md](./loom-init/references/output-contract.md)
-- 场景路由矩阵
-  - [route-matrix.md](./route-matrix.md)
-- 小型既有仓库默认策略
-  - [shared/references/adoption/lightweight-retrofit-default.md](./shared/references/adoption/lightweight-retrofit-default.md)
-- `skills` 分发与适配合同
-  - [distribution-and-adapter-contract.md](./distribution-and-adapter-contract.md)
+只有在你处理分发、升级、宿主适配、机读合同或 runtime 诊断时，才需要优先进入这些深层材料。

--- a/skills/loom-init/SKILL.md
+++ b/skills/loom-init/SKILL.md
@@ -5,29 +5,30 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 # Loom Init
 
-使用本 skill 作为 Loom 的唯一 root entry。
+把本 skill 作为 Loom 的默认入口。
 
-它承担两类职责：
+在以下情况先进入 `loom-init`：
 
-- 初始化或 retrofit Loom
-- 在没有显式指定场景 skill 时，根据任务信号做路由
+- 你要初始化 Loom，或把 Loom retrofit 进既有仓库
+- 你还不知道当前任务应该进入哪个场景 skill
+- 你希望 Loom 先根据任务信号判断下一步入口
 
-先判断当前任务究竟属于初始化还是日常执行场景，再决定进入哪个入口。不要把 root skill 继续扩成第二套事实真相源。
+不要把 root skill 继续扩成第二套事实真相源。它负责先判断，再导向正确场景。
 
-当前安装态中的最小可执行入口为：
+## Quick Path
 
-- `python3 scripts/loom-init.py bootstrap --target <repo>`
-- `python3 scripts/loom-init.py verify --target <repo>`
-- `python3 scripts/loom-init.py fact-chain --target <repo>`
-- `python3 scripts/loom-init.py route --target <repo> [--skill <id>] [--task "<request>"]`
+1. 先判断当前任务属于初始化 / retrofit，还是已经进入日常执行场景。
+2. 如果用户已经显式指定场景 skill，显式调用优先，直接进入该 skill。
+3. 如果没有显式指定 skill，由 `loom-init` 根据任务信号做路由。
+4. 如果信号不足、冲突，或缺少稳定执行所需的最小输入，保留在 `loom-init`，并要求最小补充信号。
 
-场景路由规则见：
-
-- [../route-matrix.md](../route-matrix.md)
+## Route Summary
 
 显式指定 skill 时，显式调用优先。
 
-未显式指定 skill 时，按任务信号做隐式路由：
+未显式指定 skill 时，`loom-init` 按任务信号做隐式路由。
+
+默认场景对应关系如下：
 
 - 初始化 / retrofit / 新项目接入
   - 路由到 `loom-adopt`
@@ -45,6 +46,17 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - 路由到 `loom-merge-ready`
 
 如果信号不足或同时命中多个场景，不要猜测。回退到 `loom-init`，并要求最小补充信号。
+
+完整场景路由规则见 [../route-matrix.md](../route-matrix.md)。
+
+## Installed Entry Surface
+
+当前安装态中的最小可执行入口为：
+
+- `python3 scripts/loom-init.py bootstrap --target <repo>`
+- `python3 scripts/loom-init.py verify --target <repo>`
+- `python3 scripts/loom-init.py fact-chain --target <repo>`
+- `python3 scripts/loom-init.py route --target <repo> [--skill <id>] [--task "<request>"]`
 
 ## 1. 读取顺序
 


### PR DESCRIPTION
## Summary

- Problem: `skills/README.md` and `skills/loom-init/SKILL.md` still read like protocol/author contracts before they read like user-facing entry docs.
- Scope: rewrite only the skills-layer first screen so users see the default entry, scene-skill map, and routing summary first; push deeper machine/distribution detail down without changing route semantics.

## Validation

- [ ] Verified locally
- [x] Verified by automation
- [ ] Not applicable

Validation details:

- Ran `make loom-check`
- Confirmed the diff stays within `skills/README.md` and `skills/loom-init/SKILL.md`
- Confirmed root entry identity and route semantics remain unchanged

## Risks And Follow-ups

- Risks: This PR intentionally does not change JSON contracts, runtime scripts, or adapter semantics.
- Follow-ups: `#226` public-vs-host boundary restatement; `#227` validation/release/closeout.

## Related Work

- Issue: `#225`
- Spec / plan: `docs/skills-surface-delivery-judgment.md`
