### PR TITLE
docs(skills): 重述公开面边界并完成 release closeout

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -46,6 +46,7 @@
 - checkpoint 链路复验：[validation-checkpoints-hotcp.md](./validation-checkpoints-hotcp.md)
 - 运行时证据复验：[validation-runtime-evidence-hotcp.md](./validation-runtime-evidence-hotcp.md)
 - automation-frontload 复验：[validation-automation-frontload-hotcp.md](./validation-automation-frontload-hotcp.md)
+- `SKILLS` 产品面收敛验证与 closeout：[validation-skills-surface-convergence.md](./validation-skills-surface-convergence.md)
 - 执行入口兼容与操作流：[execution-entry-compatibility.md](./execution-entry-compatibility.md)
 - 新项目完整执行内核复验：[validation-complete-kernel-new-project.md](./validation-complete-kernel-new-project.md)
 - 既有仓库完整执行内核复验：[validation-complete-kernel-existing-repos.md](./validation-complete-kernel-existing-repos.md)
@@ -59,7 +60,9 @@ Issue -> 验证 / 回写索引：
 - `#180` -> [validation-retrofit-143-tree.md](./validation-retrofit-143-tree.md)
 - `#209` -> [validation-installed-skills-pre-merge-chain.md](./validation-installed-skills-pre-merge-chain.md)
 - `#210` -> [validation-installed-skills-post-merge-closeout.md](./validation-installed-skills-post-merge-closeout.md)
+- `#227` -> [validation-skills-surface-convergence.md](./validation-skills-surface-convergence.md)
 - `#223` -> [skills-repo-design-checklist.md](./skills-repo-design-checklist.md); [../docs/skills-surface-delivery-judgment.md](../docs/skills-surface-delivery-judgment.md); [../docs/skills-surface-issue-tree-draft.md](../docs/skills-surface-issue-tree-draft.md)
+- `#226` -> [upstream-delivery-surface.md](./upstream-delivery-surface.md); [versioning-and-upgrades.md](./versioning-and-upgrades.md); [../skills/distribution-and-adapter-contract.md](../skills/distribution-and-adapter-contract.md)
 - `#169` -> [landing-map.md](./landing-map.md); [upstream-delivery-surface.md](./upstream-delivery-surface.md); [versioning-and-upgrades.md](./versioning-and-upgrades.md); [../docs/complete-kernel-release.md](../docs/complete-kernel-release.md)
 
 当前目录对应的主要 `EXT-*` 条目：

--- a/adoption/upstream-delivery-surface.md
+++ b/adoption/upstream-delivery-surface.md
@@ -15,7 +15,21 @@
 - `templates/`
   - 最小正式规约模板与最小 PR 模板
 - `skills/`
-  - 稳定入口合同、`loom-init` root 路由、7 个场景 skills、`registry.json`、`upgrade-contract.json` 与 `route-matrix.md`
+  - 用户首层入口面：
+    - 根 `README.md` 的安装 / 快速开始
+    - `skills/README.md` 的入口层总览
+    - `skills/loom-init/SKILL.md` 的 root entry 首屏
+  - 宿主 / adapter 公开面：
+    - `skills/distribution-and-adapter-contract.md`
+    - `skills/registry.json`
+    - `skills/install-layout.json`
+    - `skills/upgrade-contract.json`
+    - `skills/route-matrix.md`
+    - `skills/<entry>/contract.json`
+    - `skills/shared/scripts/assets/references`
+  - 上述两层共同承接：
+    - `loom-init` root 路由
+    - 7 个场景 skills
 - `adoption/`
   - 稳定 adoption 路径、经验回流、验证记录合同、版本化与升级路径
   - `repo companion migration` 稳定下游合同
@@ -28,6 +42,8 @@
     - `adoption/reference-companion-spec-syvert.md`
     - `adoption/reference-companion-spec-webenvoy.md`
     - `adoption/validation-repo-companion-interface.md`
+  - `SKILLS` 产品面收敛验证与 closeout：
+    - `adoption/validation-skills-surface-convergence.md`
   - Loom 自身 `#143` 树 retrofit 记录：
     - `adoption/validation-retrofit-143-tree.md`
     - 只作为 Loom 自身 closeout / retrofit 依据，不单独提升为新的默认 adoption 路径
@@ -64,6 +80,7 @@ Loom 对下游交付的对象不是单个文件，而是以下组合：
 
 ## 4. 交付边界约束
 
+- `skills` 的用户首层公开面与宿主 / adapter 公开面必须分层表达
 - 宿主实现细节不进入稳定交付面
 - 单仓验证不足的结论不进入稳定交付面
 - 根入口摘要不重复内核正文；内核正文只保留在唯一主落点

--- a/adoption/validation-skills-surface-convergence.md
+++ b/adoption/validation-skills-surface-convergence.md
@@ -1,0 +1,173 @@
+# Validation: SKILLS Surface Convergence Tree
+
+## 1. 样本标识
+
+- 验证对象：Loom 仓库当前 `SKILLS surface convergence` 树
+- 目标仓库：`/Users/mc/dev/Loom`
+- parent issue：`#222`
+- child issues：
+  - `#223`
+  - `#224`
+  - `#225`
+  - `#226`
+  - `#227`
+- 对应 PR slices：
+  - `#223` -> benchmark + delivery judgment
+  - `#224` -> top-level user surface
+  - `#225` -> skills surface
+  - `#226/#227` -> boundary + release + closeout
+- 验证日期：`2026-04-20`
+
+## 2. 本轮固定边界
+
+本轮只验证 `SKILLS` 产品面收敛是否成立，不验证以下后续树内容：
+
+- 不重写 `skills/registry.json`
+- 不重写 `skills/install-layout.json`
+- 不重写 `skills/upgrade-contract.json`
+- 不修改 `loom-init` 的 root entry 身份
+- 不修改隐式路由优先级
+- 不修改场景 skill 角色合同
+- 不重写 runtime detection 代码语义
+- 不重新定义 installed/runtime evidence
+
+因此，本记录只承接四件事：
+
+1. 用户首层产品面是否已收清
+2. `skills` 用户公开面与宿主公开面是否已分层
+3. 默认版本判断是否仍然是 `minor`
+4. parent closeout 应消费哪些已成立真相
+
+## 3. 用户首层产品面验证
+
+### 3.1 根 README
+
+当前根 `README.md` 已先回答：
+
+- 如何把 Loom skills 安装进 Agent 平台
+- `loom-init` 是默认入口
+- 安装完成后应先由 `loom-init` 判断当前场景，再继续执行
+
+当前首屏已不再把以下内容当作安装主路径：
+
+- `skills/registry.json`
+- `skills/install-layout.json`
+- `skills/upgrade-contract.json`
+- `repo-local-demo` / `installed-runtime` / `upgrade-rehearsal`
+
+这些内容已经退回到 [../skills/distribution-and-adapter-contract.md](../skills/distribution-and-adapter-contract.md) 等深层文档。
+
+### 3.2 `skills/README.md`
+
+当前 `skills/README.md` 已先回答：
+
+- `skills/` 是 Loom 的入口层
+- 默认从 `loom-init` 进入
+- 7 个场景 skills 各自何时使用
+- 显式进入与 `loom-init` 路由进入的关系
+
+机读分发工件与 shared runtime/resources 已退到宿主 / adapter 说明，不再占据首屏。
+
+### 3.3 `skills/loom-init/SKILL.md`
+
+当前 `loom-init` 首屏已先回答：
+
+- 什么时候先进入 `loom-init`
+- 它先判断什么
+- 显式 skill 优先
+- 未显式指定时按任务信号路由
+- 信号不足时停在 root entry，而不是猜测
+
+读取顺序、问诊、装配判断与输出细则仍保留，但已退到首屏之后。
+
+## 4. 边界与版本判断验证
+
+### 4.1 用户公开面 vs 宿主公开面
+
+当前仓库已明确分层：
+
+- 用户首层公开面
+  - 根 `README.md`
+  - `skills/README.md`
+  - `skills/loom-init/SKILL.md`
+- 宿主 / adapter 公开面
+  - `skills/distribution-and-adapter-contract.md`
+  - `skills/registry.json`
+  - `skills/install-layout.json`
+  - `skills/upgrade-contract.json`
+  - `skills/shared/scripts/assets/references`
+
+这意味着：
+
+- 用户先消费“怎么开始用 Loom skills”
+- 宿主再消费“怎么发现、安装、升级、识别运行态并暴露失败”
+
+### 4.2 `#226/#227` 的默认版本判断仍为 `minor`
+
+本轮默认版本判断仍是 `minor`，原因是：
+
+- 改动集中在用户可见的产品面、边界表述、验证记录与 closeout 说明
+- `bootstrap/root contract` 最小职责未变
+- 隐式路由优先级未变
+- 场景 skill 角色合同未变
+- `registry/install-layout/upgrade-contract` 的 machine 语义未变
+- installed/runtime evidence 未变
+
+若未来改动进入上述任一机器语义面，应升级为新的 `major` 树，而不是继续挤进本轮。
+
+## 5. 最小门禁与验证结果
+
+本轮执行 PR 在本地都按同一条门禁验证：
+
+- `make loom-check`
+
+其中，`#225/#226/#227` 的本地 `loom-check` 在历史 closeout 样本上出现过环境性波动：
+
+- `#225`
+  - 历史 closeout 样本的 `installed closeout sync` 曾短暂失败
+  - 同一条 `closeout sync` 命令随后独立复验为 `pass`
+  - 完整 `make loom-check` 重跑恢复为 `pass`
+- `#226/#227`
+  - 历史 closeout 样本的 `installed closeout check/sync` 失败原因被明确定位为 GitHub GraphQL API rate limit
+  - 失败信息为：
+    - `API rate limit already exceeded for user ID 9820018`
+    - `project: unknown owner type`
+
+因此，本记录将这组失败归类为宿主控制面 / GitHub API 环境限制，而不是 `SKILLS` 文档回归。本轮正式门禁仍以 PR CI 为准。
+
+## 6. Parent Closeout Basis
+
+`#222` closeout 时，至少应消费以下已成立真相：
+
+- `#223`
+  - benchmark 文档已进入版本控制
+  - 交付判断、非目标、PR slices、release goal 与默认版本判断已冻结
+- `#224`
+  - 根 README 已完成用户主路径收敛
+- `#225`
+  - `skills/README.md` 与 `loom-init` 首屏已完成入口层产品面收敛
+- `#226/#227`
+  - 用户公开面 / 宿主公开面边界已重述
+  - 默认版本判断仍为 `minor`
+  - 本验证记录已进入版本控制
+
+parent closeout comment 至少要写清：
+
+1. 本轮明确收了什么
+2. 哪些 machine contract 问题被有意延期
+3. 为什么当前版本判断仍是 `minor`
+4. 下一棵树应从哪里接续
+
+对 `#226` 而言，closeout 依据是边界文档已把用户公开面与宿主公开面分层，并保留既有 machine semantics。
+
+对 `#227` 而言，closeout 依据是本记录已经把验证结果、`minor` 判断依据、延期项与 parent closeout basis 收成版本控制真相。
+
+## 7. 结论
+
+`#222` 这棵树当前已经把 Loom `SKILLS` 层从“协议暴露型入口说明”推进到“用户主路径清晰、宿主边界清楚、但 machine contract 暂不重写”的状态。
+
+因此，本记录确认：
+
+- `#223/#224/#225/#226/#227` 的目标拆分是有效的
+- 本轮不需要再靠会话解释“为什么这轮不改 machine contract”
+- 下一棵树应改收 machine contract narrowing、runtime evidence hardening 或 entry behavior regression 是否进入默认 core

--- a/adoption/versioning-and-upgrades.md
+++ b/adoption/versioning-and-upgrades.md
@@ -44,6 +44,7 @@ Loom 采用语义版本：
   - 破坏现有下游采用合同、必备工件、checkpoint 语义、关闭语义或入口合同
 - `minor`
   - 新增可选能力、稳定新入口、扩展不破坏兼容的合同
+  - 或收敛用户公开面 / 宿主公开面边界，只要 machine semantics 不变
 - `patch`
   - 澄清、去歧义、非行为性修订与证据补强
 
@@ -124,6 +125,7 @@ Loom 采用语义版本：
 - 新增稳定场景 skill
 - 新增不破坏兼容的聚合 flow，并被场景 skill 正式消费
 - `skills/registry.json` 增加可发现 entry，但不改变既有 entry 的最小职责
+- 收敛根 README、`skills/README.md`、`loom-init/SKILL.md` 等用户首层产品面，并同步重述用户公开面 / 宿主公开面边界，但不改变 machine contract、route priority、scene role contract 或 runtime evidence
 
 ### 5.5 `adoption`
 
@@ -146,6 +148,7 @@ Loom 采用语义版本：
 
 - 新增一个稳定的宿主无关入口合同说明，但不改变现有下游必须遵守的接口
 - 这属于 `minor`
+- 像 `#226/#227` 所在的 `SKILLS surface convergence` 边界 / closeout 批次，只收用户首层产品面、宿主边界表述、验证记录与 release judgment，而不改 `registry/install-layout/upgrade-contract` 语义、root 最小职责、隐式路由优先级或 runtime evidence，也属于 `minor`
 
 ### `patch` 示例
 
@@ -168,6 +171,13 @@ Loom 采用语义版本：
   - 承接最小机读升级协议，声明宿主必须重新读取 `registry/manifest/executable/referenced_resources/layout_manifest`
 
 它们不替代本文的版本对象定义，只负责把显式升级与版本可见性落成可读取工件。
+
+同样需要保持的边界是：
+
+- 用户首层说明可以收敛或重写
+- 但只要 `registry/install-layout/upgrade-contract` 的 machine 语义不变，它们就仍然只是宿主 / adapter 公开面的版本承载物，不会自动把产品版本升级为 `major`
+
+因此，`#226/#227` 当前这批边界重述与 closeout 回写，默认版本判断仍为 `minor`；只有 machine semantics 实际变化时，才必须升级为 `major`。
 
 `#206` 当前引入的 installed-skills 布局重构，会改变 `skills` 的安装合同与 executable/resource 解析方式。下一次 Loom 正式产品发布若带上这组变更，应按 `major` 处理；在正式发版前，应继续以 issue / PR / install-layout 机读工件维持仓库真相一致。
 

--- a/skills/distribution-and-adapter-contract.md
+++ b/skills/distribution-and-adapter-contract.md
@@ -12,9 +12,39 @@
 - 治理规则、执行机制、模板约束在安装态由 `skills/shared/references/` 暴露稳定读面；repo-local 源码真相仍分别维护在 `governance/`、`harness/`、`templates/`、`adoption/`
 - 宿主可以不同，但 Loom 对入口层的最小能力边界应保持稳定
 
+## 读者边界
+
+Loom 当前把 `skills` 公开面分成两层：
+
+- 用户首层公开面
+  - 根 `README.md` 的安装与快速开始
+  - `skills/README.md` 的入口层总览
+  - `skills/loom-init/SKILL.md` 的 root entry 首屏
+- 宿主 / adapter 首层公开面
+  - 本文
+  - `registry.json`
+  - `install-layout.json`
+  - `upgrade-contract.json`
+  - `shared/scripts/assets/references`
+
+换句话说：
+
+- 用户先回答“怎么开始用 Loom skills”
+- 宿主 / adapter 再回答“怎么发现、安装、升级、识别运行态并暴露失败”
+
+本文属于第二层。它是宿主公开面，不是默认用户首屏说明。
+
 ## 零、公开接口
 
-Loom 当前对 `skills` 的稳定公开接口包括：
+Loom 当前对 `skills` 的稳定公开接口分成两组。
+
+### 用户公开面
+
+- `loom-init` 作为唯一 root entry 的入口身份
+- 显式进入某个场景 skill，或在未显式指定时由 `loom-init` 做场景路由
+- 7 个场景 skills 的稳定分工
+
+### 宿主 / adapter 公开面
 
 - `bootstrap/root contract` 的最小职责
 - 安装合同
@@ -24,7 +54,7 @@ Loom 当前对 `skills` 的稳定公开接口包括：
 - adapter 职责边界
 - 版本识别与失败可见性
 
-宿主可以用不同机制实现这些接口，但不应改写它们的语义。
+宿主可以用不同机制实现第二组接口，但不应改写它们的语义。
 
 ## 一、分发面
 


### PR DESCRIPTION
## Summary

- Problem: Loom still needed one last pass to restate the skills-layer user-vs-host boundary, freeze the default `minor` judgment in versioning language, and record a version-controlled validation/closeout basis for the full `#222` tree.
- Scope: restate only the public-vs-host skills surface in boundary/versioning docs and add a validation/closeout record. No JSON contracts, runtime scripts, route semantics, or entry identity changes.

## Validation

- [ ] Verified locally
- [x] Verified by automation
- [ ] Not applicable

Validation details:

- Attempted `make loom-check`
- The local gate hit GitHub GraphQL/API rate limits on the historical closeout sample (`issue 131 / pr 138 / project 5`), so the failure was environment-bound rather than file-scope regression
- Captured that behavior in `adoption/validation-skills-surface-convergence.md`
- Formal merge gate remains PR CI

## Risks And Follow-ups

- Risks: Any future change to machine contract JSON, root minimum duties, route priority, scene role contracts, or runtime evidence must be split into a new `major` tree.
- Follow-ups: next tree should decide whether to narrow machine contracts, harden runtime evidence, or promote entry-behavior regression into core.

## Related Work

- Issue: `#226`, `#227`, `#222`
- Spec / plan: `docs/skills-surface-delivery-judgment.md`
