### PR TITLE
feat(cli): 收敛 repo-local loom CLI 操作面

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Loom 不是业务模板，也不是一组散落的规则文档。
 | `governance` 判断层 | 统一回答什么时候能继续、什么时候能 review、什么时候算完成 |
 | `repo companion` 接入层 | 为既有仓库暴露 locator-only manifest、机读 repo requirements 和 specialized gates，而不把单仓规则抬升为 Loom core |
 | Agent 平台接入 | 把 Loom skills 安装进 Claude Code / Codex 等 Agent 平台，并让 `loom-init` 成为默认入口 |
-| 次级 CLI | 为自动化、脚本和调试保留等价入口 |
+| repo-local `loom CLI` | 次级入口，承接自动化、验证、调试与宿主编排；不替代 plugin 安装主路径或 scene skill 用户入口 |
 
 ## 安装与快速开始
 
@@ -76,7 +76,14 @@ Loom 不是业务模板，也不是一组散落的规则文档。
 - 默认进入方式是 `loom-init`
 - 其余能力由 7 个场景 skills 承接，`loom-init` 会把你导向正确入口
 
-repo-local `loom CLI` 仍保留，但它是次级入口，主要用于自动化、验证、调试和宿主编排，不是安装主路径。
+repo-local `loom CLI` 仍保留，但它是次级入口，主要用于自动化、验证、调试和宿主编排，不是安装主路径，也不替代 `loom-init` 与其余 scene skills 的用户入口。
+
+文档里提到 repo-local `loom CLI` 时，默认是在说统一的 repo-local 操作面，例如：
+
+- `loom init bootstrap --target <repo> --write --verify`
+- `loom flow pre-review --target <repo> --item <id>`
+- `loom review record --target <repo> --item <id> ...`
+- `loom flow closeout check --target <repo>`
 
 如果你需要看每个 skill 的作用和入口分工，读 [skills/README.md](./skills/README.md)。
 
@@ -366,22 +373,24 @@ Loom 在这里做了什么：
 
 Loom 的首选入口是 `SKILLS`。
 
-CLI 主要给这些情况使用：
+repo-local `loom CLI` 主要给这些情况使用：
 
 - 写脚本
-- 做自动化
+- 做自动化 / 验证
 - 调试底层行为
+- 编排 `git`、`gh`、`make` 等宿主动作
 
-最常见的底层命令包括：
+文档中统一把这组 repo-local 操作面写成 `loom ...`，例如：
 
-- `python3 tools/loom_init.py route --target <repo> ...`
-- `python3 tools/loom_flow.py flow resume|pre-review|review|handoff|merge-ready --target <repo>`
-- `python3 tools/loom_flow.py closeout ...`
-- `python3 skills/loom-init/scripts/loom-init.py route --target <repo> ...`
-- `python3 skills/shared/scripts/loom_flow.py checkpoint|state-check|closeout ...`
-- `make loom-check`
+- `loom route --target <repo> [--skill <id>] [--task "<request>"]`
+- `loom flow resume --target <repo> [--item <id>]`
+- `loom flow pre-review --target <repo> [--item <id>]`
+- `loom flow review --target <repo> [--item <id>]`
+- `loom review record --target <repo> [--item <id>] ...`
+- `loom flow closeout check --target <repo>`
+- `loom check <repo>`
 
-其中 `skills/*/scripts/` 与 `skills/shared/scripts/` 是安装态可调用入口；repo-local `tools/` 只用于当前仓库开发和调试。
+在当前 Loom 仓库开发态中，这组 repo-local CLI 动作仍由 `tools/loom_init.py`、`tools/loom_flow.py`、`tools/loom_check.py` 等 carrier 承接；安装态则会映射到对应的 `skills/*/scripts/` 与 `skills/shared/scripts/`。这层统一写法的目的，是让自动化、验证、调试和宿主编排共享同一组操作语义，而不是让用户绕过 `loom-init` 或 scene skills 直接把 CLI 当成首层产品。
 
 安装、升级、运行态识别和失败可见性的正式合同不在本节展开，统一见 [skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)。
 

--- a/docs/demo-new-project.md
+++ b/docs/demo-new-project.md
@@ -4,7 +4,7 @@
 
 ## 目标
 
-验证 `tools/loom_init.py` 能把一个空的新项目目录初始化为最小可执行 Loom 工作现场，而不只是输出说明文字。
+验证 repo-local `loom CLI` 的 `init` / `flow` / `review` / `check` 操作面，能把一个空的新项目目录初始化为最小可执行 Loom 工作现场，而不只是输出说明文字。
 
 ## 演示目录
 
@@ -17,10 +17,17 @@
 在 Loom 仓库根目录执行：
 
 ```bash
-make loom-demo-new-project
+loom init bootstrap \
+  --target examples/new-project \
+  --write \
+  --force \
+  --verify \
+  --install-pr-template
 ```
 
-等价命令：
+本文统一把 repo-local 操作面写成 `loom ...`。当前 Loom 仓库开发态下，这些命令由 `tools/loom_init.py`、`tools/loom_flow.py`、`tools/loom_check.py` 承接；仓库里的 `make loom-demo-new-project` 只是对同一 bootstrap 动作的便捷封装。
+
+当前仓库中的等价 carrier 命令是：
 
 ```bash
 python3 tools/loom_init.py bootstrap \
@@ -53,6 +60,29 @@ python3 tools/loom_init.py bootstrap \
 
 ```bash
 cd examples/new-project
+loom init verify --target .
+loom init runtime-state --target .
+loom init fact-chain --target .
+loom flow fact-chain --target . --item INIT-0001
+loom flow runtime-state --target . --item INIT-0001
+loom flow runtime-evidence --target . --item INIT-0001
+loom flow state-check --target . --item INIT-0001
+loom flow pre-review --target . --item INIT-0001
+loom flow review --target . --item INIT-0001
+loom review read --target . --item INIT-0001
+loom review record --target . --item INIT-0001 --decision fallback --kind general_review --summary "Bootstrap is not merge-ready." --reviewer demo --fallback-to admission
+loom flow recovery writeback --target . --item INIT-0001 --current-stop "Bootstrap review has started." --next-step "Replace the bootstrap placeholder item."
+loom flow work-item create --target . --item NEXT-0001 --goal "Promote the first real work item." --scope "Limit the demo to `.loom/` artifacts." --execution-path execution/support --workspace-entry . --validation-entry "loom init verify --target ." --closing-condition "The authored work item reads cleanly." --init-recovery
+loom flow host-lifecycle --target . --item INIT-0001
+loom flow closeout check --target . --skip-gate
+loom flow checkpoint admission --target . --item INIT-0001
+loom flow workspace locate --target . --item INIT-0001
+loom flow purity-check --target . --item INIT-0001
+```
+
+安装态 `.loom/bin/` carrier 的等价命令仍然保留，方便 gate 与宿主显式核对：
+
+```bash
 python3 .loom/bin/loom_init.py verify --target .
 python3 .loom/bin/loom_init.py runtime-state --target .
 python3 .loom/bin/loom_init.py fact-chain --target .
@@ -80,6 +110,6 @@ python3 .loom/bin/loom_flow.py purity-check --target . --item INIT-0001
 - `bootstrap` 命令退出码为 `0`
 - `verify` 命令退出码为 `0`
 - `fact-chain` 命令退出码为 `0`
-- `loom_init.py` 的 `runtime-state`，以及 `loom_flow.py` 的 `runtime-state`、`fact-chain`、`runtime-evidence`、`state-check`、`flow pre-review`、`flow review`、`review read`、`review record`、`recovery writeback`、`work-item create`、`host-lifecycle`、`closeout check`、`checkpoint admission`、`workspace locate`、`purity-check` 命令都可读取或更新当前样例
+- repo-local `loom CLI` 的 `runtime-state`、`fact-chain`、`runtime-evidence`、`state-check`、`flow pre-review`、`flow review`、`review read`、`review record`、`recovery writeback`、`work-item create`、`host-lifecycle`、`closeout check`、`checkpoint admission`、`workspace locate`、`purity-check` 命令都可读取或更新当前样例
 - `init-result.json` 含有 7 个必需区块
 - 首批 work item、recovery entry、状态面与 spec/plan 工件都已落位

--- a/harness/automation-frontload.md
+++ b/harness/automation-frontload.md
@@ -15,6 +15,8 @@
 自动化前置负责降低重复人工判断，不负责替代语义审查。
 merge checkpoint 只消费这些结果，不把它们扩写成第一次高质量判断。
 
+本文统一把 repo-local 自动化与验证入口写成 `loom ...`。这组命令是 repo-local `loom CLI` 的次级操作面，主要服务 CI、自动化、调试和宿主编排；用户首层入口仍是 plugin 安装后的 `loom-init` 与各场景 skill。
+
 ## 2. 通用 core 检查矩阵
 
 | 检查类别 | 检查对象 | 失败含义 | 非目标 | 是否阻断 merge checkpoint |
@@ -68,17 +70,18 @@ Loom 内核只定义这些检查面的边界，不内置宿主特定 CI、测试
 
 Loom 仓库当前通过以下入口承接最小 core 前置检查：
 
-- `make loom-check`
-- `python3 tools/loom_check.py`
-- `python3 tools/loom_init.py verify --target <repo>`
-- `python3 tools/loom_init.py fact-chain --target <repo>`
-- `python3 tools/loom_flow.py fact-chain --target <repo> [--item <id>]`
-- `python3 tools/loom_flow.py runtime-evidence --target <repo> [--item <id>]`
-- `python3 tools/loom_flow.py state-check --target <repo> [--item <id>]`
-- `python3 tools/loom_flow.py flow pre-review --target <repo> [--item <id>]`
-- `python3 tools/loom_flow.py checkpoint <admission|build|merge> --target <repo> [--item <id>]`
-- `python3 tools/loom_flow.py workspace <create|locate|cleanup|retire> --target <repo> --item <id>`
-- `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]`
+- `loom check <repo>`
+- `loom init verify --target <repo>`
+- `loom init runtime-state --target <repo>`
+- `loom flow fact-chain --target <repo> [--item <id>]`
+- `loom flow runtime-evidence --target <repo> [--item <id>]`
+- `loom flow state-check --target <repo> [--item <id>]`
+- `loom flow pre-review --target <repo> [--item <id>]`
+- `loom flow checkpoint <admission|build|merge> --target <repo> [--item <id>]`
+- `loom flow workspace <create|locate|cleanup|retire> --target <repo> --item <id>`
+- `loom flow purity-check --target <repo> [--item <id>]`
+
+在当前 Loom 仓库开发态中，这些 repo-local `loom CLI` 动作由 `tools/loom_init.py`、`tools/loom_flow.py`、`tools/loom_check.py` 承接；自动化前置关注的是统一命令语义，而不是要求读者先记住底层 carrier 文件名。
 
 当前脚本至少覆盖：
 
@@ -110,7 +113,7 @@ closeout 需要控制面对齐时，顺序必须是先处理 `fix-needed` / `blo
 
 最小接入 demo 则通过以下入口复验：
 
-- `make loom-demo-new-project`
+- `loom init bootstrap --target examples/new-project --write --force --verify --install-pr-template`
 
 ## 4. 不应错误前置的判断
 

--- a/harness/daily-entry-matrix.md
+++ b/harness/daily-entry-matrix.md
@@ -10,35 +10,38 @@
 
 宿主动作的统一结果词表与 `fallback_to` 纪律见 [host-action-contract.md](./host-action-contract.md)；本文件只保留矩阵视图。
 
+本文统一把 repo-local 次级操作面写成 `loom ...`。这组命令主要服务自动化、验证、调试和宿主编排；用户首层入口仍是 plugin 安装后的 `loom-init` 与其余 scene skills。当前仓库开发态或安装态可以把这组命令映射到底层 `tools/` / `scripts/` carrier，但不改变这里定义的入口职责。
+
 ## 1. 入口矩阵
 
 | 动作 | 首选入口 | 读取基线 | 结果形态 | 备注 |
 | --- | --- | --- | --- | --- |
-| `bootstrap` | `python3 tools/loom_init.py bootstrap --target <repo>` | intake + 仓库信号 | 初始化结果 JSON + 首批工件 | `skills/loom-init` 负责路由，CLI 负责落盘 |
-| `verify` | `python3 tools/loom_init.py verify --target <repo>` | init-result + fact-chain + flow 子命令 | `ok` / `errors` | 核验初始化产物与入口可读性 |
-| `fact-chain` | `python3 tools/loom_flow.py fact-chain --target <repo> [--item <id>]` | 单一事实链 | `pass` / `block` | 日常统一读取入口 |
-| `pre-review`（统一高频入口） | `python3 tools/loom_flow.py flow pre-review --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + runtime evidence + admission + workspace locate | `pass` / `block` / `fallback` | 第一版聚焦 review 前高频检查流；`runtime_state` 不一致时直接 fail-closed |
-| `review` | `python3 tools/loom_flow.py flow review --target <repo> [--item <id>]` -> `python3 tools/loom_flow.py review record --target <repo> [--item <id>] ...` | runtime-state + fact-chain + state-check + runtime evidence + build checkpoint + review record | `pass` / `block` / `fallback` | 正式 review 先读基线，再显式记录 reviewer 结论；`runtime_state` 不一致时直接 fail-closed |
-| `checkpoint` | `python3 tools/loom_flow.py checkpoint <admission\\|build\\|merge> --target <repo> [--item <id>]` | fact-chain + purity + merge 放行材料 | `pass` / `block` / `fallback` | `merge` 可额外消费 PR 模板 |
-| `resume` | `python3 tools/loom_flow.py flow resume --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + workspace locate + recovery 的 `next_step` / `blockers` / `checkpoint` | `pass` / `block` | 只输出恢复摘要，不回写任何载体；`runtime_state` 不一致时直接 fail-closed |
-| `handoff` | `python3 tools/loom_flow.py flow handoff --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + workspace locate + recovery/status locator + handoff writeback fields | `pass` / `block` | 只输出最小回写清单与载体定位，不直接写 authored 状态；`runtime_state` 不一致时直接 fail-closed |
-| `recovery writeback` | `python3 tools/loom_flow.py recovery writeback --target <repo> [--item <id>] ...` | 当前 fact-chain + recovery authored 字段 | `pass` / `block` | 只写 recovery 主入口，再同步状态面 |
-| `work item authoring` | `python3 tools/loom_flow.py work-item create|update --target <repo> --item <id> ... [--activate]` | init-result locator + work item static fields | `pass` / `block` | `--activate` 只切当前 locator，不隐式写动态状态 |
-| `host lifecycle boundary` | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | fact-chain + purity + 当前 branch/worktree 观测 | `pass` / `block` | 明确 workspace 由 Loom 管，branch/PR/worktree 由宿主管 |
-| `reconciliation audit` | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | runtime-state + issue tree + PR merge事实 + Project 状态 | `pass` / `warn` / `fix-needed` / `block` | 只报出 drift，不修改 GitHub 控制面；runtime/layout 漂移时直接 fail-closed；非 `pass` 的去向由 [host-action-contract.md](./host-action-contract.md) 统一定义 |
-| `reconciliation sync` | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | runtime-state + 同范围 reconciliation audit + issue/PR/project 控制面 | `pass` / `block` | 只修机械可证明的 `fix-needed` drift；runtime/layout 漂移时直接 fail-closed；`block` 零写入，`warn` 仅保留提示，不提升成第二套 closeout 语义 |
-| `merge-ready` | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + runtime evidence + build checkpoint + merge checkpoint | `pass` / `block` / `fallback` | 只输出统一放行摘要，不替代宿主平台 merge；`runtime_state` 不一致时直接 fail-closed，`fallback_to` 只能回到 Loom 内部 checkpoint |
+| `bootstrap` | `loom init bootstrap --target <repo>` | intake + 仓库信号 | 初始化结果 JSON + 首批工件 | `skills/loom-init` 负责路由，repo-local `loom CLI` 负责落盘 |
+| `verify` | `loom init verify --target <repo>` | init-result + fact-chain + flow 子命令 | `ok` / `errors` | 核验初始化产物与入口可读性 |
+| `fact-chain` | `loom flow fact-chain --target <repo> [--item <id>]` | 单一事实链 | `pass` / `block` | 日常统一读取入口 |
+| `pre-review`（统一高频入口） | `loom flow pre-review --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + runtime evidence + admission + workspace locate | `pass` / `block` / `fallback` | 第一版聚焦 review 前高频检查流；`runtime_state` 不一致时直接 fail-closed |
+| `review` | `loom flow review --target <repo> [--item <id>]` -> `loom review record --target <repo> [--item <id>] ...` | runtime-state + fact-chain + state-check + runtime evidence + build checkpoint + review record | `pass` / `block` / `fallback` | 正式 review 先读基线，再显式记录 reviewer 结论；`runtime_state` 不一致时直接 fail-closed |
+| `checkpoint` | `loom flow checkpoint <admission\\|build\\|merge> --target <repo> [--item <id>]` | fact-chain + purity + merge 放行材料 | `pass` / `block` / `fallback` | `merge` 可额外消费 PR 模板 |
+| `resume` | `loom flow resume --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + workspace locate + recovery 的 `next_step` / `blockers` / `checkpoint` | `pass` / `block` | 只输出恢复摘要，不回写任何载体；`runtime_state` 不一致时直接 fail-closed |
+| `handoff` | `loom flow handoff --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + workspace locate + recovery/status locator + handoff writeback fields | `pass` / `block` | 只输出最小回写清单与载体定位，不直接写 authored 状态；`runtime_state` 不一致时直接 fail-closed |
+| `recovery writeback` | `loom flow recovery writeback --target <repo> [--item <id>] ...` | 当前 fact-chain + recovery authored 字段 | `pass` / `block` | 只写 recovery 主入口，再同步状态面 |
+| `work item authoring` | `loom flow work-item create|update --target <repo> --item <id> ... [--activate]` | init-result locator + work item static fields | `pass` / `block` | `--activate` 只切当前 locator，不隐式写动态状态 |
+| `host lifecycle boundary` | `loom flow host-lifecycle --target <repo> [--item <id>]` | fact-chain + purity + 当前 branch/worktree 观测 | `pass` / `block` | 明确 workspace 由 Loom 管，branch/PR/worktree 由宿主管 |
+| `reconciliation audit` | `loom flow reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | runtime-state + issue tree + PR merge事实 + Project 状态 | `pass` / `warn` / `fix-needed` / `block` | 只报出 drift，不修改 GitHub 控制面；runtime/layout 漂移时直接 fail-closed；非 `pass` 的去向由 [host-action-contract.md](./host-action-contract.md) 统一定义 |
+| `reconciliation sync` | `loom flow reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | runtime-state + 同范围 reconciliation audit + issue/PR/project 控制面 | `pass` / `block` | 只修机械可证明的 `fix-needed` drift；runtime/layout 漂移时直接 fail-closed；`block` 零写入，`warn` 仅保留提示，不提升成第二套 closeout 语义 |
+| `merge-ready` | `loom flow merge-ready --target <repo> [--item <id>]` | runtime-state + fact-chain + state-check + runtime evidence + build checkpoint + merge checkpoint | `pass` / `block` / `fallback` | 只输出统一放行摘要，不替代宿主平台 merge；`runtime_state` 不一致时直接 fail-closed，`fallback_to` 只能回到 Loom 内部 checkpoint |
 | `merge` | `merge checkpoint` + 仓库平台合并动作 | build 结果 + 风险回滚 + 验证摘要 | 放行或阻断 | Loom 不替代宿主平台合并接口 |
-| `retire` | `python3 tools/loom_flow.py purity-check --target <repo> [--item <id>]` -> `workspace cleanup` -> `workspace retire` | runtime-state + purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录；runtime/layout 漂移时直接 fail-closed |
-| `closeout` | `python3 tools/loom_flow.py closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | runtime-state + loom_check + 同范围 reconciliation audit/sync + issue/PR/project/main | `pass` / `block` | closeout 负责消费 reconciliation 结果；`fix-needed` / `block` 必须先停下并处理，`warn` 只显式展示，且不得伪装成 `fallback`；runtime/layout 漂移时直接 fail-closed |
+| `retire` | `loom flow purity-check --target <repo> [--item <id>]` -> `loom flow workspace cleanup --target <repo> [--item <id>]` -> `loom flow workspace retire --target <repo> [--item <id>]` | runtime-state + purity 结果 + cleanup 结果 + recovery 主入口 | checkpoint 终态 `retired` | 默认先解释 retire 前置条件，不默认删除现场目录；runtime/layout 漂移时直接 fail-closed |
+| `closeout` | `loom flow closeout check|sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | runtime-state + loom_check + 同范围 reconciliation audit/sync + issue/PR/project/main | `pass` / `block` | closeout 负责消费 reconciliation 结果；`fix-needed` / `block` 必须先停下并处理，`warn` 只显式展示，且不得伪装成 `fallback`；runtime/layout 漂移时直接 fail-closed |
 
 ## 2. 分层边界
 
 - `skills`
   - 负责“把执行者导向正确入口”
   - 不承接 authored 执行真相
-- CLI
+- repo-local `loom CLI`
   - 负责读取、校验、回写与输出稳定 JSON 语义
+  - 作为自动化、验证、调试和宿主编排的次级入口
   - 不替代 reviewer 的语义判断
 - `reconciliation audit`
   - 负责把 GitHub drift 显式化
@@ -49,8 +52,8 @@
 - `closeout`
   - 负责把 reconciliation 结果接入 closeout 判定与控制面对齐
   - 不另写新的 reconciliation 主合同，也不绕过先处理 `fix-needed` / `block` 再 closeout 的顺序
-- gate (`loom_check` / CI)
-  - 负责复用同一 CLI 入口做机械阻断
+- gate (`loom check` / CI)
+  - 负责复用同一 repo-local CLI 入口做机械阻断
   - 不维护第二套检查口径
 
 ## 3. 非目标

--- a/plugins/loom/skills/loom-init/SKILL.md
+++ b/plugins/loom/skills/loom-init/SKILL.md
@@ -15,6 +15,8 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 不要把 root skill 继续扩成第二套事实真相源。它负责先判断，再导向正确场景。
 
+对执行者的首层说明仍应以 `loom-init` 作为 root entry。repo-local 自动化、验证、调试和宿主编排可以统一落到 repo-local `loom CLI`，但这不改变 `loom-init` 的 route 语义，也不把 CLI 升格成用户第一入口。
+
 ## Quick Path
 
 1. 先判断当前任务属于初始化 / retrofit，还是已经进入日常执行场景。
@@ -53,10 +55,12 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 当前安装态中的最小可执行入口为：
 
-- `python3 scripts/loom-init.py bootstrap --target <repo>`
-- `python3 scripts/loom-init.py verify --target <repo>`
-- `python3 scripts/loom-init.py fact-chain --target <repo>`
-- `python3 scripts/loom-init.py route --target <repo> [--skill <id>] [--task "<request>"]`
+- `loom init bootstrap --target <repo>`
+- `loom init verify --target <repo>`
+- `loom init fact-chain --target <repo>`
+- `loom route --target <repo> [--skill <id>] [--task "<request>"]`
+
+安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或 `tools/...` carrier；首层用户入口仍然是 `loom-init` 这个 skill。
 
 ## 1. 读取顺序
 

--- a/plugins/loom/skills/loom-review/SKILL.md
+++ b/plugins/loom/skills/loom-review/SKILL.md
@@ -13,6 +13,8 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `loom-review` 负责执行正式语义审查并产出审查结论
 - `loom-merge-ready` 负责 merge 前统一放行聚合
 
+对执行者来说，正式 review 的首层入口仍是 `loom-review` 这个场景 skill。repo-local 自动化、验证、调试和宿主编排可以统一调用 repo-local `loom CLI`，但这不替代场景 skill 的用户入口，也不改变 review / merge-ready 的边界。
+
 ## 1. 使用时机
 
 当任务满足以下任一条件时，进入 `loom-review`：
@@ -30,8 +32,8 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 统一入口固定为：
 
-- `python3 scripts/loom-review.py flow review --target <repo> [--item <id>]`
-- `python3 scripts/loom-review.py review record --target <repo> [--item <id>] --decision <allow|block|fallback> --kind <general_review|code_review|spec_review> --summary <text> --reviewer <id>`
+- `loom flow review --target <repo> [--item <id>]`
+- `loom review record --target <repo> [--item <id>] --decision <allow|block|fallback> --kind <general_review|code_review|spec_review> --summary <text> --reviewer <id>`
 
 补充约束：
 
@@ -40,6 +42,8 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
 这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review record` 把审查结论写成可消费载体。
+
+安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
 ## 3. 固定编排
 

--- a/skills/loom-init/SKILL.md
+++ b/skills/loom-init/SKILL.md
@@ -15,6 +15,8 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 不要把 root skill 继续扩成第二套事实真相源。它负责先判断，再导向正确场景。
 
+对执行者的首层说明仍应以 `loom-init` 作为 root entry。repo-local 自动化、验证、调试和宿主编排可以统一落到 repo-local `loom CLI`，但这不改变 `loom-init` 的 route 语义，也不把 CLI 升格成用户第一入口。
+
 ## Quick Path
 
 1. 先判断当前任务属于初始化 / retrofit，还是已经进入日常执行场景。
@@ -53,10 +55,12 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 当前安装态中的最小可执行入口为：
 
-- `python3 scripts/loom-init.py bootstrap --target <repo>`
-- `python3 scripts/loom-init.py verify --target <repo>`
-- `python3 scripts/loom-init.py fact-chain --target <repo>`
-- `python3 scripts/loom-init.py route --target <repo> [--skill <id>] [--task "<request>"]`
+- `loom init bootstrap --target <repo>`
+- `loom init verify --target <repo>`
+- `loom init fact-chain --target <repo>`
+- `loom route --target <repo> [--skill <id>] [--task "<request>"]`
+
+安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或 `tools/...` carrier；首层用户入口仍然是 `loom-init` 这个 skill。
 
 ## 1. 读取顺序
 

--- a/skills/loom-review/SKILL.md
+++ b/skills/loom-review/SKILL.md
@@ -13,6 +13,8 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - `loom-review` 负责执行正式语义审查并产出审查结论
 - `loom-merge-ready` 负责 merge 前统一放行聚合
 
+对执行者来说，正式 review 的首层入口仍是 `loom-review` 这个场景 skill。repo-local 自动化、验证、调试和宿主编排可以统一调用 repo-local `loom CLI`，但这不替代场景 skill 的用户入口，也不改变 review / merge-ready 的边界。
+
 ## 1. 使用时机
 
 当任务满足以下任一条件时，进入 `loom-review`：
@@ -30,8 +32,8 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 
 统一入口固定为：
 
-- `python3 scripts/loom-review.py flow review --target <repo> [--item <id>]`
-- `python3 scripts/loom-review.py review record --target <repo> [--item <id>] --decision <allow|block|fallback> --kind <general_review|code_review|spec_review> --summary <text> --reviewer <id>`
+- `loom flow review --target <repo> [--item <id>]`
+- `loom review record --target <repo> [--item <id>] --decision <allow|block|fallback> --kind <general_review|code_review|spec_review> --summary <text> --reviewer <id>`
 
 补充约束：
 
@@ -40,6 +42,8 @@ description: 负责正式 review 执行层。Use when Codex needs to run semanti
 - 无论通过哪种入口，最终都只允许写回单一 `review_entry` 指向的 review record
 
 这个 skill 先用 `flow review` 读取正式 review 的机械基线，再用 `review record` 把审查结论写成可消费载体。
+
+安装态或 repo-local 开发态可以把这些 `loom ...` 动作映射到底层 `scripts/...` 或共享 runtime carrier；但 `loom-review` 自身的场景合同、进入时机和输出责任保持不变。
 
 ## 3. 固定编排
 

--- a/tools/loom.py
+++ b/tools/loom.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Repo-local aggregate CLI for Loom wrapper tools."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOLS_ROOT = REPO_ROOT / "tools"
+
+COMMAND_ROUTES: dict[str, tuple[str, tuple[str, ...]]] = {
+    "init": ("loom_init.py", ()),
+    "route": ("loom_init.py", ("route",)),
+    "flow": ("loom_flow.py", ()),
+    "review": ("loom_flow.py", ("review",)),
+    "check": ("loom_check.py", ()),
+}
+
+
+def print_usage(stream) -> None:
+    stream.write(
+        "usage: loom <command> [args ...]\n\n"
+        "Repo-local aggregate entry for existing Loom wrapper tools.\n\n"
+        "commands:\n"
+        "  init    pass through to tools/loom_init.py\n"
+        "  route   shortcut for tools/loom_init.py route\n"
+        "  flow    pass through to tools/loom_flow.py\n"
+        "  review  shortcut for tools/loom_flow.py review\n"
+        "  check   pass through to tools/loom_check.py\n\n"
+        "examples:\n"
+        "  python3 tools/loom.py init bootstrap --target examples/new-project --write\n"
+        "  python3 tools/loom.py route --target examples/new-project --task \"请接手当前事项并恢复上下文后继续推进\"\n"
+        "  python3 tools/loom.py flow review --target examples/new-project --item INIT-0001\n"
+        "  python3 tools/loom.py review read --target examples/new-project --item INIT-0001\n"
+        "  python3 tools/loom.py check\n"
+    )
+
+
+def dispatch(command: str, forwarded_args: list[str]) -> int:
+    tool_name, prefix = COMMAND_ROUTES[command]
+    tool_path = TOOLS_ROOT / tool_name
+    if not tool_path.exists():
+        print(f"loom: missing delegated tool: {tool_path}", file=sys.stderr)
+        return 2
+    completed = subprocess.run(
+        [sys.executable, str(tool_path), *prefix, *forwarded_args],
+        check=False,
+    )
+    return completed.returncode
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) == 1:
+        print_usage(sys.stderr)
+        return 2
+
+    command = argv[1]
+    if command in {"-h", "--help", "help"}:
+        print_usage(sys.stdout)
+        return 0
+
+    if command not in COMMAND_ROUTES:
+        print(f"loom: unknown command `{command}`", file=sys.stderr)
+        print_usage(sys.stderr)
+        return 2
+
+    return dispatch(command, argv[2:])
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
- 新增 repo-local 聚合入口 `tools/loom.py`
- 把 README、demo、harness、`loom-init` / `loom-review` 首层说明统一到 `loom init|route|flow|review|check`
- 明确 repo-local `loom CLI` 只是次级执行面，不替代 plugin 安装主路径或 scene skills 用户入口

## Problem
`#235` 要收的是 repo-local `loom CLI` 的定位、入口边界与 repo-local 操作面。如果主干继续只暴露分散的 `tools/loom_init.py` / `tools/loom_flow.py` / `tools/loom_check.py`，下游读者会把它理解成一组零散 carrier 文件，而不是同一套次级 CLI 语义；如果文档直接改写而没有聚合入口，又会制造新的漂移。

## This PR
- 引入 `tools/loom.py`，只做参数分发，不改现有 wrapper / runtime semantics
- 支持 `loom init ...`、`loom route ...`、`loom flow ...`、`loom review ...`、`loom check ...`
- 在 repo-local 文档里把自动化、验证、调试、宿主编排统一写成这组 CLI 语义
- 同步 `skills/loom-init`、`skills/loom-review` 及 plugin 镜像里的首层说明

## Not In Scope
- 不改单独 skill package 交付形态
- 不改 route priority、scene role contract、runtime semantics
- 不改 versioning / release judgment / closeout 文档

## Validation
- `python3 -m py_compile tools/loom.py`
- `git diff --check`
- `python3 tools/loom.py --help`
- `python3 tools/loom.py init runtime-state --target /Users/mc/dev/Loom`
- `python3 tools/loom.py route --target examples/new-project --skill loom-review`
- `python3 tools/loom.py review read --target examples/new-project --item INIT-0001`
- `python3 tools/loom.py flow checkpoint admission --target examples/new-project --item INIT-0001`
- `python3 tools/loom.py flow closeout check --target . --skip-gate`
- `python3 tools/loom.py check /Users/mc/dev/Loom`

Closes #235