### PR TITLE
docs(adoption): 冻结成熟治理重仓接入树工作流边界

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -18,6 +18,7 @@
 - 事项分流、checkpoint 与入口策略：[routing-and-checkpoints.md](./routing-and-checkpoints.md)
 - `repo companion` 主合同：[repo-companion-contract.md](./repo-companion-contract.md)
 - `repo companion` scoped adoption/workflow contract：[companion-oriented-workflow.md](./companion-oriented-workflow.md)
+- 成熟治理重仓接入树 workflow contract：[deep-existing-repo-workflow.md](./deep-existing-repo-workflow.md)
 - `repo companion` migration contract：[repo-companion-migration.md](./repo-companion-migration.md)
 - `repo companion` Syvert 参考接口样本：[reference-companion-spec-syvert.md](./reference-companion-spec-syvert.md)
 - `repo companion` WebEnvoy 参考接口样本：[reference-companion-spec-webenvoy.md](./reference-companion-spec-webenvoy.md)

--- a/adoption/deep-existing-repo-workflow.md
+++ b/adoption/deep-existing-repo-workflow.md
@@ -1,0 +1,106 @@
+# Deep Existing Repo Workflow
+
+本文定义 Loom 面向成熟治理重仓接入树的 scoped workflow contract。
+
+它只约束这类 `deep-existing-repo` / typed `repo companion` / `host adapter` / `shadow mode` 工作如何拆 issue、切 PR、做 release judgment 与 closeout 回写；它不是 Loom 全局 issue-model 规则，也不替代 [issue-model.md](/Users/mc/dev/Loom/governance/issue-model.md)、[versioning-and-upgrades.md](/Users/mc/dev/Loom/adoption/versioning-and-upgrades.md) 或 [closeout-gate.md](/Users/mc/dev/Loom/harness/closeout-gate.md)。
+
+## 1. 使用边界
+
+本文件仅适用于以下工作：
+
+- 目标是让 Loom 稳定接入成熟既有治理重仓，而不是继续泛化 `complex-existing`
+- 工作同时涉及 adoption path、`repo companion` 机读合同、retained host action 结果消费与 validation / closeout
+- 需要提前固定拆分方式，避免边界冻结、脚本接线、schema 扩展、验证收口混成一条 PR
+
+它不声明：
+
+- Loom 全局 parent / child issue 默认真相
+- Loom 要接管 branch / PR / worktree / merge / ruleset 的底层实现
+- 任意 `complex-existing` 仓库都必须升级到 `deep-existing-repo`
+
+## 2. 何时建立父/子 Issue
+
+当成熟治理重仓接入同时涉及以下至少两个面向时，应建立父 issue：
+
+- `deep-existing-repo` / `recognize-and-attach` adoption path
+- typed `repo companion` machine contract
+- retained host action / repo-native carrier / `shadow mode` 只读消费
+- validation / release / parent closeout
+
+在这类树中：
+
+- parent issue
+  - 负责总目标、默认 PR slices、版本判断口径与 closeout basis
+- child issue
+  - 负责单一执行面
+
+这只是成熟治理重仓 adoption 的拆分建议，不改变 Loom 全局 issue-model 的抽象边界。
+
+## 3. 默认 PR Slices
+
+成熟治理重仓接入默认固定为以下 5 批，不混线：
+
+1. `#243`
+   - 冻结目标边界、默认 PR slices、版本判断口径与 closeout basis
+2. `#244`
+   - `deep-existing-repo` / `recognize-and-attach`
+3. `#245`
+   - typed `repo companion`：`repo-interface v2`
+4. `#246`
+   - `host adapter`、repo-native interop 与 `shadow mode`
+5. `#247`
+   - `Syvert` / `WebEnvoy` validation、release judgment 与 closeout
+
+禁止混线：
+
+- `#244` 不得提前引入 `repo-interface v2` 或 `interop.json`
+- `#245` 不得接管 retained host actions 的底层实现
+- `#246` 不得把 `shadow mode` 直接升级成新的 merge gate
+- `#247` 不得抢前置 issue 的实现职责
+
+## 4. 默认 Release Judgment
+
+这类批次默认按 `minor` 规划。
+
+仅当破坏以下任一稳定合同，才升为 `major`：
+
+- `governance_surface.repository_mode`
+- root contract
+- 既有 CLI 顶层结果语义
+- 必备工件
+
+本树中的默认判断含义固定为：
+
+- `deep-existing-repo`
+  - 是 `complex-existing` 的 adoption path，不是新的 `repository_mode`
+- typed `repo companion`
+  - 通过 `repo-interface v2` 承接，并保持 `v1` 可读
+- `shadow mode`
+  - 当前只做 validation / parity，不直接成为 merge gate
+
+release judgment 的正式版本语义仍以 [versioning-and-upgrades.md](/Users/mc/dev/Loom/adoption/versioning-and-upgrades.md) 为准；本文只固定成熟治理重仓接入树的默认判断。
+
+## 5. 最小 Closeout 回写
+
+这类 issue tree closeout 时，至少要对齐以下真相：
+
+- `#243 -> #247` 已按固定顺序完成或明确吸收
+- `deep-existing-repo`、typed `repo companion`、`host adapter`、repo-native interop 与 `shadow mode` 的边界已进入版本控制
+- release note 已补默认版本判断与下游升级入口
+- validation record 已覆盖 `Syvert` / `WebEnvoy` 样本，并明确 `keep`、`adapt`、`needs_validation`
+- parent closeout basis 已说明：
+  - 这轮新收了什么能力
+  - 哪些边界继续保留在宿主层
+  - 哪些候选项仍未进入 Loom core
+  - 下一棵树从哪里继续
+
+换句话说，这棵树的 closeout 不应再依赖会话反复解释“为什么 `deep-existing-repo` 不是第四个 scenario”“为什么 Loom 仍不接管宿主动作底层实现”。
+
+## 6. 读取顺序
+
+1. 目标仓库原有根级边界文档
+2. [lightweight-retrofit-default.md](/Users/mc/dev/Loom/adoption/lightweight-retrofit-default.md)
+3. [repo-companion-contract.md](/Users/mc/dev/Loom/adoption/repo-companion-contract.md)
+4. [host-action-contract.md](/Users/mc/dev/Loom/harness/host-action-contract.md)
+5. 本文件
+6. 相关 reference / validation / release 文档

--- a/adoption/versioning-and-upgrades.md
+++ b/adoption/versioning-and-upgrades.md
@@ -188,6 +188,22 @@ Loom 继续使用 `major` / `minor` / `patch` 的发布判断，但在 `pre-1` �
 - 新增稳定 `repo companion migration` 合同、但不破坏既有入口语义，通常为 `minor`
 - 对已有路径做澄清或补证据通常为 `patch`
 
+对于成熟治理重仓接入树：
+
+- `deep-existing-repo`
+  - 若继续保持 `repository_mode = complex-existing`，并把新增能力限制为 adoption path / attach strategy，通常为 `minor`
+- `repo-interface v2`
+  - 若保持 `v1` 可读、CLI 顶层结果语义不变，通常为 `minor`
+- `host adapter` / repo-native interop / `shadow mode`
+  - 若保持只读消费，不接管宿主底层生命周期，也通常为 `minor`
+
+只有以下变化同时出现时，才应考虑升为 `major`：
+
+- `repository_mode` 枚举被改写
+- root contract 或必备工件被改写
+- 既有 CLI 顶层结果语义被破坏
+- `shadow mode` 被直接提升为新的默认 blocking merge gate
+
 ## 7. `v0.5.0` 的发布判断
 
 `v0.5.0` 本次按 `minor` 管理，原因是：


### PR DESCRIPTION
## Summary
- 新增成熟治理重仓接入树 workflow contract
- 冻结 `#243 -> #247` 的默认 PR slices、release judgment 与 closeout basis
- 把 adoption README 与 versioning 口径对齐到同一条仓库真相

## Testing
- `git diff --check`
- `python3 tools/loom_check.py`
  - 本地唯一失败：`installed reconciliation sync --dry-run` 历史样本自检；本 PR 未改动相关脚本或样本

Closes #243