### PR TITLE
feat(adoption): 增加 deep-existing-repo 接入路径

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -24,6 +24,7 @@
 - `repo companion` WebEnvoy 参考接口样本：[reference-companion-spec-webenvoy.md](./reference-companion-spec-webenvoy.md)
 - `repo companion` 接口状态验证：[validation-repo-companion-interface.md](./validation-repo-companion-interface.md)
 - 小型既有仓库的默认 retrofit 策略：[lightweight-retrofit-default.md](./lightweight-retrofit-default.md)
+- 成熟治理重仓的默认 attach 策略：[deep-existing-repo-default.md](./deep-existing-repo-default.md)
 - 暂不固化、待继续验证的候选模式：[candidate-patterns.md](./candidate-patterns.md)
 - 外部优秀 `SKILLS` 仓库设计清单与 Loom gap analysis：[skills-repo-design-checklist.md](./skills-repo-design-checklist.md)
 - 初始化 `SKILL` 模拟验证：[demo-init-validation.md](./demo-init-validation.md)

--- a/adoption/deep-existing-repo-default.md
+++ b/adoption/deep-existing-repo-default.md
@@ -1,0 +1,66 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 [lightweight-retrofit-default.md](./lightweight-retrofit-default.md)，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `complex-existing`
+- 已有清晰的根级边界文档，例如 `AGENTS.md`、`WORKFLOW.md` 或等价根规则
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+换句话说，Loom 这一步接管的是入口与读面，不是宿主动作底层实现。
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-adopt/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-adopt/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-adopt/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-adopt/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-adopt/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-adopt/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/packages/skills/loom-handoff/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-handoff/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-handoff/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-handoff/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-handoff/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-handoff/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/packages/skills/loom-init/.loom-runtime/loom-init/SKILL.md
+++ b/packages/skills/loom-init/.loom-runtime/loom-init/SKILL.md
@@ -76,6 +76,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/governance/maturity-and-closing.md`
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
+  - `skills/shared/references/adoption/deep-existing-repo-default.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/status-surface.md`
@@ -167,7 +168,8 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 默认动作：
 
-- 进入更完整装配
+- 若根规则清晰、验证入口稳定且命中 `merge_review_semantic_overload`，优先进入 `deep-existing-repo` / `recognize-and-attach`
+- 否则进入更完整装配
 - 显式纳入：
   - 恢复主入口
   - 执行上下文
@@ -176,6 +178,13 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - 隔离现场与纯度规则
 - 对涉及共享契约、运行模型、高风险核心抽象的事项，默认纳入正式规约套件与前移 checkpoint
 - 对恢复成本明显升高的事项，默认从 `checkpoint-lite` 升级到标准恢复形态
+
+当命中 `deep-existing-repo` 时，额外保持以下纪律：
+
+- 保留 root rules
+- 保留 retained host actions
+- 保留 repo-native carriers
+- 第一轮不生成 Loom-owned `work-item` / `progress` / `status-surface` placeholder
 
 ## 4. 输出初始化结果
 

--- a/packages/skills/loom-init/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-init/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-init/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-init/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-init/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-init/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/packages/skills/loom-init/SKILL.md
+++ b/packages/skills/loom-init/SKILL.md
@@ -49,7 +49,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 如果信号不足或同时命中多个场景，不要猜测。回退到 `loom-init`，并要求最小补充信号。
 
-完整场景路由规则见 [references/route-matrix.md](references/route-matrix.md)。
+完整场景路由规则见 [./.loom-runtime/route-matrix.md](./.loom-runtime/route-matrix.md)。
 
 ## Installed Entry Surface
 
@@ -71,24 +71,25 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `AGENTS.md`
   - `README.md`
 - Loom 核心规则：
-  - `references/shared/governance/principles.md`
-  - `references/shared/governance/review-model.md`
-  - `references/shared/governance/maturity-and-closing.md`
-  - `references/shared/adoption/routing-and-checkpoints.md`
-  - `references/shared/adoption/lightweight-retrofit-default.md`
-- `references/shared/harness/recovery-model.md`
-- `references/shared/harness/fact-chain-contract.md`
-- `references/shared/harness/status-surface.md`
-- `references/shared/harness/work-item-contract.md`
-- `references/shared/harness/workspace-model.md`
-- `references/route-matrix.md`
-- `references/input-signals.md`
-- `references/shared/harness/automation-frontload.md`
-- `references/shared/harness/workspace-and-purity.md`
-- `references/shared/harness/execution-context.md`
-- `references/shared/templates/spec-suite.md`
-- `references/shared/templates/pull-request.md`
-- `references/output-contract.md`
+  - `skills/shared/references/governance/principles.md`
+  - `skills/shared/references/governance/review-model.md`
+  - `skills/shared/references/governance/maturity-and-closing.md`
+  - `skills/shared/references/adoption/routing-and-checkpoints.md`
+  - `skills/shared/references/adoption/lightweight-retrofit-default.md`
+  - `skills/shared/references/adoption/deep-existing-repo-default.md`
+- `skills/shared/references/harness/recovery-model.md`
+- `skills/shared/references/harness/fact-chain-contract.md`
+- `skills/shared/references/harness/status-surface.md`
+- `skills/shared/references/harness/work-item-contract.md`
+- `skills/shared/references/harness/workspace-model.md`
+- `skills/route-matrix.md`
+- `skills/loom-init/references/input-signals.md`
+- `skills/shared/references/harness/automation-frontload.md`
+- `skills/shared/references/harness/workspace-and-purity.md`
+- `skills/shared/references/harness/execution-context.md`
+- `skills/shared/references/templates/spec-suite.md`
+- `skills/shared/references/templates/pull-request.md`
+- `skills/loom-init/references/output-contract.md`
 
 只有在事项带有明显不确定性、需要进一步分层时，才补读：
 
@@ -98,7 +99,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 优先从仓库现状推断答案，只在关键信息缺失时再问用户。
 
-使用 [references/input-signals.md](references/input-signals.md) 组织问诊。必须先完成最小必判字段的收集，再做路径判断。
+使用 [references/input-signals.md](./references/input-signals.md) 组织问诊。必须先完成最小必判字段的收集，再做路径判断。
 
 问诊结果必须收成以下结论，而不是停留在零散观察：
 
@@ -137,7 +138,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 ### 3.2 小型既有仓库
 
-当仓库满足 [references/shared/adoption/lightweight-retrofit-default.md](references/shared/adoption/lightweight-retrofit-default.md) 的默认条件时，判为 `小型既有仓库`。
+当仓库满足 [./.loom-runtime/shared/references/adoption/lightweight-retrofit-default.md](./.loom-runtime/shared/references/adoption/lightweight-retrofit-default.md) 的默认条件时，判为 `小型既有仓库`。
 
 默认动作：
 
@@ -167,7 +168,8 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 默认动作：
 
-- 进入更完整装配
+- 若根规则清晰、验证入口稳定且命中 `merge_review_semantic_overload`，优先进入 `deep-existing-repo` / `recognize-and-attach`
+- 否则进入更完整装配
 - 显式纳入：
   - 恢复主入口
   - 执行上下文
@@ -177,9 +179,16 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 - 对涉及共享契约、运行模型、高风险核心抽象的事项，默认纳入正式规约套件与前移 checkpoint
 - 对恢复成本明显升高的事项，默认从 `checkpoint-lite` 升级到标准恢复形态
 
+当命中 `deep-existing-repo` 时，额外保持以下纪律：
+
+- 保留 root rules
+- 保留 retained host actions
+- 保留 repo-native carriers
+- 第一轮不生成 Loom-owned `work-item` / `progress` / `status-surface` placeholder
+
 ## 4. 输出初始化结果
 
-始终使用 [references/output-contract.md](references/output-contract.md) 的结构输出结果。
+始终使用 [references/output-contract.md](./references/output-contract.md) 的结构输出结果。
 
 输出中必须显式写出：
 

--- a/packages/skills/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-init/references/intake-signals.md
@@ -84,7 +84,7 @@
 
 默认装配路径：
 
-- 直接采用 [shared/adoption/lightweight-retrofit-default.md](shared/adoption/lightweight-retrofit-default.md)
+- 直接采用 [../.loom-runtime/shared/references/adoption/lightweight-retrofit-default.md](../.loom-runtime/shared/references/adoption/lightweight-retrofit-default.md)
 - 默认 `companion docs` 接入
 - 默认装配最小治理包
 - 默认不装配完整 recovery、work item、状态面与重 harness
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,10 +142,11 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 
-`loom-init` 对小型既有仓库的默认入口不是临场经验，而是直接消费 [shared/adoption/lightweight-retrofit-default.md](shared/adoption/lightweight-retrofit-default.md)。
+`loom-init` 对小型既有仓库的默认入口不是临场经验，而是直接消费 [../.loom-runtime/shared/references/adoption/lightweight-retrofit-default.md](../.loom-runtime/shared/references/adoption/lightweight-retrofit-default.md)。
 
 这意味着：
 

--- a/packages/skills/loom-init/references/output-contract.md
+++ b/packages/skills/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-merge-ready/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-merge-ready/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-merge-ready/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-merge-ready/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/packages/skills/loom-pre-review/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-pre-review/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-pre-review/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-pre-review/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-pre-review/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-pre-review/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/packages/skills/loom-resume/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-resume/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-resume/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-resume/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-resume/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-resume/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/packages/skills/loom-retire/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-retire/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-retire/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-retire/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-retire/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-retire/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/packages/skills/loom-review/.loom-runtime/loom-init/references/intake-signals.md
+++ b/packages/skills/loom-review/.loom-runtime/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/packages/skills/loom-review/.loom-runtime/loom-init/references/output-contract.md
+++ b/packages/skills/loom-review/.loom-runtime/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/packages/skills/loom-review/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
+++ b/packages/skills/loom-review/.loom-runtime/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/packages/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/packages/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -421,6 +421,102 @@ def load_command_json(
     return payload, None
 
 
+def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = dict(extra or {})
+    current_path = os.environ.get("PATH", "")
+    env["PATH"] = str(bin_dir) if not current_path else f"{bin_dir}:{current_path}"
+    return env
+
+
+def write_fake_codex(
+    path: Path,
+    *,
+    mode: str,
+    tracked_edit_target: str | None = None,
+) -> None:
+    if mode == "success":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "summary": "Default Codex reviewer found the item ready for merge checkpoint consumption.",
+    "findings": [
+        {
+            "id": "warn-1",
+            "summary": "Keep the follow-up validation note visible in the review record.",
+            "severity": "warn",
+            "rebuttal": None,
+            "disposition": {
+                "status": "accepted",
+                "summary": "The reviewer accepts the current validation coverage."
+            },
+            "details": "This finding is advisory and should not block merge-ready."
+        }
+    ]
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "schema_drift":
+        body = """#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+output_path = pathlib.Path(args[args.index("-o") + 1])
+payload = {
+    "decision": "allow",
+    "findings": []
+}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    elif mode == "tracked_edit":
+        target = tracked_edit_target or ""
+        body = f"""#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+args = sys.argv[1:]
+cwd = pathlib.Path(args[args.index("-C") + 1])
+output_path = pathlib.Path(args[args.index("-o") + 1])
+target = cwd / {target!r}
+target.write_text(target.read_text(encoding="utf-8") + "\\ntracked edit from fake codex\\n", encoding="utf-8")
+payload = {{
+    "decision": "block",
+    "summary": "Tracked repository content was modified during review.",
+    "findings": [
+        {{
+            "id": "block-1",
+            "summary": "Tracked repo content changed during review execution.",
+            "severity": "block",
+            "rebuttal": None,
+            "disposition": {{
+                "status": "rejected",
+                "summary": "The run must fail closed."
+            }}
+        }}
+    ]
+}}
+output_path.parent.mkdir(parents=True, exist_ok=True)
+output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    else:
+        raise ValueError(f"unknown fake codex mode: {mode}")
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
 def require_governance_surface(
     failures: list[Failure],
     *,
@@ -773,6 +869,15 @@ def require_review_record_contract(
     for list_field in ("blocking_issues", "follow_ups"):
         if not isinstance(payload.get(list_field), list):
             failures.append(Failure(category, f"{context} must include review `{list_field}` as a list"))
+    consumed_inputs = payload.get("consumed_inputs")
+    if consumed_inputs is not None:
+        if not isinstance(consumed_inputs, dict):
+            failures.append(Failure(category, f"{context} review `consumed_inputs` must be an object when present"))
+        else:
+            for key in ("engine_adapter", "engine_evidence", "normalized_findings"):
+                value = consumed_inputs.get(key)
+                if value is not None and (not isinstance(value, str) or not value):
+                    failures.append(Failure(category, f"{context} review consumed input `{key}` must be null or a non-empty string"))
     for finding in findings:
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} review findings must be JSON objects"))
@@ -797,6 +902,81 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition status must stay within the stable contract"))
             if not isinstance(disposition.get("summary"), str) or not disposition.get("summary"):
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
+
+
+def require_review_run_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_result: set[str],
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    if payload.get("command") != "review":
+        failures.append(Failure(category, f"{context} must report `command: review`"))
+    if payload.get("operation") != "run":
+        failures.append(Failure(category, f"{context} must report `operation: run`"))
+    if payload.get("result") not in expected_result:
+        failures.append(Failure(category, f"{context} returned an unexpected result"))
+    for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "engine", "manual_review"):
+        if not isinstance(payload.get(key), dict):
+            failures.append(Failure(category, f"{context} must include `{key}`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        allowed_results={"pass", "block"},
+    )
+    engine = payload.get("engine")
+    if not isinstance(engine, dict):
+        return
+    if engine.get("engine") != "codex":
+        failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
+    if engine.get("adapter") != "loom/default-codex":
+        failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    if engine.get("result") not in {"pass", "block", "not_run"}:
+        failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
+    if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
+        failures.append(Failure(category, f"{context} engine failure reason must stay within the stable contract"))
+    evidence = engine.get("evidence")
+    if engine.get("result") == "not_run":
+        if evidence is not None:
+            failures.append(Failure(category, f"{context} engine evidence must be null when the engine is not run"))
+    else:
+        if not isinstance(evidence, dict):
+            failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
+        else:
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+                value = evidence.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
+    manual_review = payload.get("manual_review")
+    if isinstance(manual_review, dict):
+        if not isinstance(manual_review.get("summary"), str) or not manual_review.get("summary"):
+            failures.append(Failure(category, f"{context} manual_review must include non-empty `summary`"))
+        if not isinstance(manual_review.get("review_record_path"), str) or not manual_review.get("review_record_path"):
+            failures.append(Failure(category, f"{context} manual_review must include `review_record_path`"))
+        if manual_review.get("recommended_kind") not in {"general_review", "code_review", "spec_review"}:
+            failures.append(Failure(category, f"{context} manual_review recommended kind must stay within the stable contract"))
+        if not isinstance(manual_review.get("command"), list):
+            failures.append(Failure(category, f"{context} manual_review must include `command` as a list"))
+    review_record_input = payload.get("review_record_input")
+    if payload.get("result") == "pass":
+        if not isinstance(review_record_input, dict):
+            failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
+        else:
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+                value = review_record_input.get(key)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
+                failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
+            if review_record_input.get("reviewer") != "loom/default-codex":
+                failures.append(Failure(category, f"{context} review_record_input reviewer must stay `loom/default-codex`"))
 
 
 def require_runtime_state_payload(
@@ -1363,6 +1543,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
             continue
         if payload.get(expected_key) is not True:
             failures.append(Failure("demo-repo-local-cli", f"`{label}` must report `{expected_key}: true`"))
+    return failures
+
+
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
     return failures
 
 
@@ -2003,6 +2287,187 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
 
+    with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
+        source_snapshot = Path(tmp) / "source-snapshot"
+        review_target = Path(tmp) / "new-project"
+        fake_bin = Path(tmp) / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
+
+        def prepare_review_target(target: Path, label: str) -> bool:
+            shutil.copytree(source_snapshot, target)
+            for args in (
+                ["git", "init"],
+                ["git", "config", "user.email", "loom-check@example.com"],
+                ["git", "config", "user.name", "loom-check"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git setup failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_init.py",
+                    "bootstrap",
+                    "--target",
+                    ".",
+                    "--write",
+                    "--force",
+                    "--verify",
+                    "--install-pr-template",
+                ],
+                cwd=target,
+            )
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap failed: {error}"))
+                return False
+            verification = payload.get("verification")
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("daily-execution-cli", f"`{label}` bootstrap must verify successfully"))
+                return False
+            for args in (
+                ["git", "add", "."],
+                ["git", "commit", "-m", "review-run baseline"],
+            ):
+                result = run_command(root, args, cwd=target)
+                if result.returncode != 0:
+                    detail = result.stderr.strip() or result.stdout.strip() or "git baseline commit failed"
+                    failures.append(Failure("daily-execution-cli", f"`{label}` setup failed: {detail}"))
+                    return False
+            return True
+
+        prepare_review_target(review_target, "review run positive chain")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        success_env = prepend_path_env(fake_bin)
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(review_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` positive chain failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` positive chain",
+                payload=payload,
+                expected_result={"pass"},
+            )
+
+        engine_missing_target = Path(tmp) / "engine-missing"
+        prepare_review_target(engine_missing_target, "review run engine unavailable")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(engine_missing_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env={"PATH": "/usr/bin:/bin"},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` engine unavailable failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when the default engine is unavailable"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` engine unavailable",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "engine_unavailable":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `engine_unavailable` when Codex is missing"))
+            if payload.get("fallback_to") is not None:
+                failures.append(Failure("daily-execution-cli", "`review run` must not convert engine failure into checkpoint fallback"))
+
+        schema_target = Path(tmp) / "schema-drift"
+        prepare_review_target(schema_target, "review run schema drift")
+        write_fake_codex(fake_bin / "codex", mode="schema_drift")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(schema_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` schema drift failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block on schema drift"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` schema drift",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "schema_drift":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `schema_drift` for invalid engine output"))
+
+        dirty_target = Path(tmp) / "tracked-edit"
+        prepare_review_target(dirty_target, "review run tracked edit")
+        write_fake_codex(fake_bin / "codex", mode="tracked_edit", tracked_edit_target=".loom/status/current.md")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(dirty_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` tracked edit failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` must block when engine modifies tracked repo content"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` tracked edit",
+                payload=payload,
+                expected_result={"block"},
+            )
+            engine = payload.get("engine")
+            if isinstance(engine, dict) and engine.get("failure_reason") != "repo_diff_detected":
+                failures.append(Failure("daily-execution-cli", "`review run` must report `repo_diff_detected` when tracked files change"))
+
     with tempfile.TemporaryDirectory(prefix="loom-check-flow-") as tmp:
         lifecycle_target = Path(tmp) / "new-project"
         shutil.copytree(example_target, lifecycle_target)
@@ -2387,6 +2852,10 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             source_snapshot = tmp_root / "source-snapshot"
             positive_target = tmp_root / "positive-target"
             review_fallback_target = tmp_root / "review-fallback-target"
+            fake_bin = tmp_root / "bin"
+            fake_bin.mkdir(parents=True, exist_ok=True)
+            write_fake_codex(fake_bin / "codex", mode="success")
+            installed_review_env = prepend_path_env(fake_bin)
             shutil.copytree(root / "skills", install_root)
             shutil.copytree(root, source_snapshot, ignore=shutil.ignore_patterns(".git", ".DS_Store", "__pycache__"))
 
@@ -2630,6 +3099,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             payload=review.get("record"),
                         )
 
+                review_run_payload: dict[str, object] | None = None
+                review_record_input: dict[str, object] | None = None
+                review_run_payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "review",
+                        "run",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                    env=installed_review_env,
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
+                elif review_run_payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed review run` must pass for the positive chain"))
+                else:
+                    require_review_run_payload(
+                        failures,
+                        category="daily-execution-cli",
+                        context="`installed review run`",
+                        payload=review_run_payload,
+                        expected_result={"pass"},
+                    )
+                    review_record_input = review_run_payload.get("review_record_input") if isinstance(review_run_payload, dict) else None
                 review_record_payload, error = load_command_json(
                     root,
                     [
@@ -2642,13 +3140,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "--item",
                         "INIT-0001",
                         "--decision",
-                        "allow",
+                        str(review_record_input.get("decision", "allow")) if isinstance(review_record_input, dict) else "allow",
                         "--kind",
-                        "code_review",
+                        str(review_record_input.get("kind", "code_review")) if isinstance(review_record_input, dict) else "code_review",
                         "--summary",
-                        "Installed pre-merge chain is ready for merge checkpoint consumption.",
+                        str(review_record_input.get("summary", "Installed pre-merge chain is ready for merge checkpoint consumption."))
+                        if isinstance(review_record_input, dict)
+                        else "Installed pre-merge chain is ready for merge checkpoint consumption.",
                         "--reviewer",
-                        "loom-check",
+                        str(review_record_input.get("reviewer", "loom-check")) if isinstance(review_record_input, dict) else "loom-check",
+                        "--findings-file",
+                        str(review_record_input.get("findings_file", ".loom/review-findings.json")) if isinstance(review_record_input, dict) else ".loom/review-findings.json",
+                        "--engine-adapter",
+                        str(review_record_input.get("engine_adapter", "loom/default-codex")) if isinstance(review_record_input, dict) else "loom/default-codex",
+                        "--engine-evidence",
+                        str(review_record_input.get("engine_evidence", ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/runtime/review/INIT-0001/unknown-head/engine-result.json",
+                        "--normalized-findings",
+                        str(review_record_input.get("normalized_findings", ".loom/review-findings.json"))
+                        if isinstance(review_record_input, dict)
+                        else ".loom/review-findings.json",
                     ],
                 )
                 if error:
@@ -3722,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/packages/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/packages/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/plugins/loom/skills/install-layout.json
+++ b/plugins/loom/skills/install-layout.json
@@ -49,6 +49,7 @@
     "shared/references/templates/pull-request.md",
     "shared/references/templates/review-record.md",
     "shared/references/adoption/lightweight-retrofit-default.md",
+    "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
     "loom-init",
     "loom-adopt",

--- a/plugins/loom/skills/loom-init/SKILL.md
+++ b/plugins/loom/skills/loom-init/SKILL.md
@@ -76,6 +76,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/governance/maturity-and-closing.md`
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
+  - `skills/shared/references/adoption/deep-existing-repo-default.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/status-surface.md`
@@ -167,7 +168,8 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 默认动作：
 
-- 进入更完整装配
+- 若根规则清晰、验证入口稳定且命中 `merge_review_semantic_overload`，优先进入 `deep-existing-repo` / `recognize-and-attach`
+- 否则进入更完整装配
 - 显式纳入：
   - 恢复主入口
   - 执行上下文
@@ -176,6 +178,13 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - 隔离现场与纯度规则
 - 对涉及共享契约、运行模型、高风险核心抽象的事项，默认纳入正式规约套件与前移 checkpoint
 - 对恢复成本明显升高的事项，默认从 `checkpoint-lite` 升级到标准恢复形态
+
+当命中 `deep-existing-repo` 时，额外保持以下纪律：
+
+- 保留 root rules
+- 保留 retained host actions
+- 保留 repo-native carriers
+- 第一轮不生成 Loom-owned `work-item` / `progress` / `status-surface` placeholder
 
 ## 4. 输出初始化结果
 

--- a/plugins/loom/skills/loom-init/references/intake-signals.md
+++ b/plugins/loom/skills/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/plugins/loom/skills/loom-init/references/output-contract.md
+++ b/plugins/loom/skills/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/plugins/loom/skills/shared/references/adoption/deep-existing-repo-default.md
+++ b/plugins/loom/skills/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/plugins/loom/skills/shared/scripts/loom_check.py
+++ b/plugins/loom/skills/shared/scripts/loom_check.py
@@ -1546,6 +1546,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
     return failures
 
 
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
+    return failures
+
+
 def check_daily_execution_cli(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -4130,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/plugins/loom/skills/shared/scripts/loom_init.py
+++ b/plugins/loom/skills/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -49,6 +49,7 @@
     "shared/references/templates/pull-request.md",
     "shared/references/templates/review-record.md",
     "shared/references/adoption/lightweight-retrofit-default.md",
+    "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
     "loom-init",
     "loom-adopt",

--- a/skills/loom-init/SKILL.md
+++ b/skills/loom-init/SKILL.md
@@ -76,6 +76,7 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - `skills/shared/references/governance/maturity-and-closing.md`
   - `skills/shared/references/adoption/routing-and-checkpoints.md`
   - `skills/shared/references/adoption/lightweight-retrofit-default.md`
+  - `skills/shared/references/adoption/deep-existing-repo-default.md`
 - `skills/shared/references/harness/recovery-model.md`
 - `skills/shared/references/harness/fact-chain-contract.md`
 - `skills/shared/references/harness/status-surface.md`
@@ -167,7 +168,8 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
 
 默认动作：
 
-- 进入更完整装配
+- 若根规则清晰、验证入口稳定且命中 `merge_review_semantic_overload`，优先进入 `deep-existing-repo` / `recognize-and-attach`
+- 否则进入更完整装配
 - 显式纳入：
   - 恢复主入口
   - 执行上下文
@@ -176,6 +178,13 @@ description: Loom 的 root entry。负责初始化新项目或既有仓库，并
   - 隔离现场与纯度规则
 - 对涉及共享契约、运行模型、高风险核心抽象的事项，默认纳入正式规约套件与前移 checkpoint
 - 对恢复成本明显升高的事项，默认从 `checkpoint-lite` 升级到标准恢复形态
+
+当命中 `deep-existing-repo` 时，额外保持以下纪律：
+
+- 保留 root rules
+- 保留 retained host actions
+- 保留 repo-native carriers
+- 第一轮不生成 Loom-owned `work-item` / `progress` / `status-surface` placeholder
 
 ## 4. 输出初始化结果
 

--- a/skills/loom-init/references/intake-signals.md
+++ b/skills/loom-init/references/intake-signals.md
@@ -108,6 +108,19 @@
 - 纳入恢复主入口、执行上下文、work item 或等价执行入口、状态读取、隔离现场与纯度规则
 - 对高风险边界事项纳入正式规约套件与前移 checkpoint
 
+若同时满足以下条件，则 `复杂既有仓库` 默认优先走 `deep-existing-repo`：
+
+- 根级边界文档清晰
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+
+这条路径的含义是：
+
+- 保留 `repository_mode = complex-existing`
+- 保留 root rules、retained host actions 与 repo-native carriers
+- 先做 `recognize-and-attach`
+- 不在第一轮直接写入 Loom-owned recovery/status carriers
+
 ## 5. 冲突处理规则
 
 当信号之间出现冲突时，按以下规则处理：
@@ -129,6 +142,7 @@
 - `复杂既有仓库`
   - 更完整装配
   - 重点是恢复、执行支撑、状态读取与高风险事项准入
+  - 若同时满足“根规则清晰 + 统一验证入口 + `merge_review_semantic_overload`”，默认优先走 `deep-existing-repo`
 
 ## 7. `lightweight retrofit default` 的消费关系
 

--- a/skills/loom-init/references/output-contract.md
+++ b/skills/loom-init/references/output-contract.md
@@ -28,6 +28,7 @@
 - 本轮启用的能力清单
 - 每项能力分别映射到哪些 `governance`、`harness`、`templates`、`adoption` 规则
 - 这次采用的是最小装配、轻量 retrofit 还是更完整装配
+- 若命中成熟治理重仓 attach path，必须显式写出 `recommended_adoption.path = deep-existing-repo`
 - 接入方式是根级重写还是 `repo companion`（历史表述：`companion docs`）
 - 恢复形态是 `checkpoint-lite` 还是标准恢复形态
 
@@ -93,6 +94,12 @@
   - `missing_inputs`
 
 若本轮不装配标准恢复或状态面，也必须写清现有载体如何承接这些职责。
+
+若本轮走 `deep-existing-repo`，还必须显式写出：
+
+- attach-only 必备工件是什么
+- 哪些 repo-native carriers 继续保留
+- 哪些 Loom-owned carriers 本轮不会生成
 
 `init-result` 只允许承接 locator-only 信息，不并行复制实时停点、下一步、阻断项或最近验证摘要。
 
@@ -197,3 +204,5 @@
 - 相关信息分别落在哪个载体上
 
 若这些问题仍需要靠临场解释补齐，说明输出合同未达标。
+
+对 `deep-existing-repo` 而言，这组问题的答案允许由 attach metadata、repo companion 入口与 repo-native carriers 共同承接；它不要求第一轮就生成 Loom-owned `work-item` / `progress` / `status-surface`。

--- a/skills/shared/references/adoption/deep-existing-repo-default.md
+++ b/skills/shared/references/adoption/deep-existing-repo-default.md
@@ -1,0 +1,64 @@
+# Deep Existing Repo Default
+
+本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
+
+它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+
+## 1. 适用场景
+
+当目标仓库同时满足以下条件时，默认采用本策略：
+
+- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
+- 已有清晰的根级边界文档
+- 已有统一的仓库级验证入口
+- 已出现 `merge_review_semantic_overload`
+- 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
+
+## 2. 默认目标
+
+第一轮接入的目标不是把成熟治理栈重写成 Loom 自己的 recovery / status 体系，而是让 Loom 先稳定挂到既有入口与读面上。
+
+默认先解决：
+
+- 让 `loom-init` 对这类仓库不再误走 `full-bootstrap`
+- 让 Loom 有稳定的 `recognize-and-attach` 入口
+- 让 repo companion 成为 Loom 读取 repo-specific rules 的正式入口
+- 让 root rules、retained host actions 与 repo-native carriers 明确保留在原 ownership
+
+## 3. 默认装配
+
+本策略默认优先装配：
+
+- `.loom/bootstrap/*` attach metadata
+- `.loom/README.md`
+- `.loom/companion/README.md`
+- companion-owned 的最小 repo-specific read surfaces
+- repo-local `.loom/bin/*` 读取与验证入口
+
+## 4. 默认接入方式
+
+本策略固定采用 `recognize-and-attach`：
+
+- 保留原有 root rules
+- 保留 retained host actions 的宿主 ownership
+- 保留 repo-native carriers
+- 只追加 Loom-owned attach metadata 与 companion 入口
+
+## 5. 默认不装配
+
+第一轮默认不装配：
+
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/status/current.md`
+- Loom-owned recovery/status carriers 的 bootstrap placeholder
+- 对 branch / PR / worktree / merge / ruleset 的底层宿主重写
+
+## 6. 升级信号
+
+以下任一条件出现时，不应继续停留在 attach-only 默认路径：
+
+- 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
+- repo-native carriers 无法稳定承接 recovery / review / closeout 真相
+- companion 之外还需要 Loom-owned status surface 承接统一读面
+- repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1546,6 +1546,110 @@ def check_demo_repo_local_cli(root: Path) -> list[Failure]:
     return failures
 
 
+def check_deep_existing_repo_bootstrap(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    with tempfile.TemporaryDirectory(prefix="loom-check-deep-existing-") as tmp:
+        tmp_root = Path(tmp)
+
+        def write_repo(target: Path, *, validation_entry: bool, pr_template: bool, workflow_doc: bool) -> None:
+            (target / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+            (target / "scripts").mkdir(parents=True, exist_ok=True)
+            (target / "src").mkdir(parents=True, exist_ok=True)
+            (target / "README.md").write_text("# Sample Repo\n", encoding="utf-8")
+            (target / "AGENTS.md").write_text("# Root Rules\n", encoding="utf-8")
+            (target / "src" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / "scripts" / "governance_status.py").write_text("print('ok')\n", encoding="utf-8")
+            (target / ".github" / "workflows" / "ci.yml").write_text("name: ci\n", encoding="utf-8")
+            if workflow_doc:
+                (target / "WORKFLOW.md").write_text("# Workflow\n", encoding="utf-8")
+            if validation_entry:
+                (target / "Makefile").write_text("check:\n\t@echo ok\n", encoding="utf-8")
+            if pr_template:
+                (target / ".github" / "PULL_REQUEST_TEMPLATE.md").write_text("## Summary\n", encoding="utf-8")
+
+        deep_target = tmp_root / "deep-existing"
+        write_repo(deep_target, validation_entry=True, pr_template=True, workflow_doc=True)
+        deep_payload, deep_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(deep_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if deep_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` failed: {deep_error}"))
+        else:
+            recommended = deep_payload.get("recommended_adoption")
+            verification = deep_payload.get("verification")
+            governance_surface = deep_payload.get("governance_surface")
+            if not isinstance(recommended, dict) or recommended.get("path") != "deep-existing-repo":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must select `recommended_adoption.path = deep-existing-repo`"))
+            run = deep_payload.get("run")
+            if not isinstance(run, dict) or run.get("scenario_key") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `scenario_key = complex-existing`"))
+            if not isinstance(verification, dict) or verification.get("ok") is not True:
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must verify successfully"))
+            if not isinstance(governance_surface, dict) or governance_surface.get("repository_mode") != "complex-existing":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `governance_surface.repository_mode = complex-existing`"))
+            for required in (
+                ".loom/companion/README.md",
+                ".loom/companion/checkpoints.md",
+                ".loom/companion/review.md",
+                ".loom/companion/merge-ready.md",
+                ".loom/companion/closeout.md",
+            ):
+                if not (deep_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` is missing `{required}`"))
+            for forbidden in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if (deep_target / forbidden).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`deep-existing bootstrap` must not generate `{forbidden}`"))
+            fact_chain = deep_payload.get("fact_chain")
+            if not isinstance(fact_chain, dict) or fact_chain.get("mode") != "repo-native attach-only":
+                failures.append(Failure("deep-existing-bootstrap", "`deep-existing bootstrap` must keep `fact_chain.mode = repo-native attach-only`"))
+
+        full_target = tmp_root / "full-bootstrap"
+        write_repo(full_target, validation_entry=False, pr_template=False, workflow_doc=False)
+        full_payload, full_error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "bootstrap",
+                "--target",
+                str(full_target),
+                "--write",
+                "--force",
+                "--verify",
+                "--install-pr-template",
+            ],
+        )
+        if full_error:
+            failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` failed: {full_error}"))
+        else:
+            recommended = full_payload.get("recommended_adoption")
+            if not isinstance(recommended, dict) or recommended.get("path") != "full-bootstrap":
+                failures.append(Failure("deep-existing-bootstrap", "complex existing sample without overload must keep `recommended_adoption.path = full-bootstrap`"))
+            for required in (
+                ".loom/work-items/INIT-0001.md",
+                ".loom/progress/INIT-0001.md",
+                ".loom/status/current.md",
+            ):
+                if not (full_target / required).exists():
+                    failures.append(Failure("deep-existing-bootstrap", f"`full-bootstrap fallback sample` must generate `{required}`"))
+    return failures
+
+
 def check_daily_execution_cli(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -4130,6 +4234,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_demo_assets(root))
     failures.extend(check_demo_fact_chain(root))
     failures.extend(check_demo_repo_local_cli(root))
+    failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_markdown_links(root))

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -456,9 +456,11 @@ def detect_merge_review_overload(root: Path, validation_entry: bool) -> bool:
     code_dirs = sum(1 for hint in CODE_DIR_HINTS if (root / hint).exists())
     if code_dirs == 0:
         return False
-    if not validation_entry and not file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md"):
-        return True
-    return False
+    has_pr_template = file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md")
+    has_workflow_doc = any(file_exists(root, candidate) for candidate in ("WORKFLOW.md", "docs/WORKFLOW.md"))
+    has_repo_scripts = (root / "scripts").exists()
+    has_repo_native_governance = (root / "docs" / "exec-plans").exists() or (root / "scripts" / "policy").exists()
+    return bool(validation_entry and has_pr_template and has_repo_scripts and (has_workflow_doc or has_repo_native_governance))
 
 
 def detect_repository_type(root: Path) -> str:
@@ -549,7 +551,26 @@ def recovery_mode(scenario: str) -> str:
     return "checkpoint-lite" if scenario in {"new", "small-existing"} else "standard"
 
 
-def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
+def recommended_adoption_path(scenario: str, intake: dict[str, object]) -> str:
+    if scenario == "new":
+        return "minimal-bootstrap"
+    if scenario == "small-existing":
+        return "lightweight-retrofit"
+    if (
+        intake.get("repository_type") == "existing"
+        and intake.get("root_boundary_docs") == "clear"
+        and bool(intake.get("repository_level_validation_entry"))
+        and bool(intake.get("merge_review_semantic_overload"))
+    ):
+        return "deep-existing-repo"
+    return "full-bootstrap"
+
+
+def uses_attach_only_path(adoption_path: str) -> bool:
+    return adoption_path == "deep-existing-repo"
+
+
+def rule_refs_for_capabilities(scenario: str, adoption_path: str) -> list[dict[str, object]]:
     common = [
         {
             "name": "bootstrap/root",
@@ -587,6 +608,17 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
                 ],
             }
         )
+    elif uses_attach_only_path(adoption_path):
+        common.append(
+            {
+                "name": "deep-existing-repo",
+                "rules": [
+                    "skills/shared/references/adoption/deep-existing-repo-default.md",
+                    "skills/shared/references/adoption/routing-and-checkpoints.md",
+                    "skills/shared/references/harness/host-action-contract.md",
+                ],
+            }
+        )
     else:
         common.append(
             {
@@ -602,7 +634,7 @@ def rule_refs_for_capabilities(scenario: str) -> list[dict[str, object]]:
     return common
 
 
-def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
+def deferred_capabilities(scenario: str, adoption_path: str) -> list[dict[str, str]]:
     if scenario == "new":
         return [
             {
@@ -629,6 +661,19 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
                 "upgrade_trigger": "mixed work, shared boundaries, or review overload becomes structural",
             },
         ]
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "name": "loom-owned-recovery-carriers",
+                "reason": "the first attach-only round must preserve repo-native carriers instead of generating Loom-owned recovery/status placeholders",
+                "upgrade_trigger": "the repo needs Loom-owned recovery or status carriers to stabilize multi-round execution",
+            },
+            {
+                "name": "typed-repo-companion-and-interop",
+                "reason": "the first attach-only round only establishes the stable entry and read surface",
+                "upgrade_trigger": "the repo needs typed gates, metadata contracts, host adapters, or shadow parity",
+            },
+        ]
     return [
         {
             "name": "host-specific-skill-regression-matrix",
@@ -638,7 +683,49 @@ def deferred_capabilities(scenario: str) -> list[dict[str, str]]:
     ]
 
 
-def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, object]]:
+def attach_only_artifact_paths(target_root: Path, install_pr_template: bool) -> list[str]:
+    artifacts = [
+        ".loom/README.md",
+        ".loom/bootstrap/intake.snapshot.json",
+        ".loom/bootstrap/init-result.json",
+        ".loom/bootstrap/manifest.json",
+        ".loom/bootstrap/capability-map.md",
+        ".loom/companion/README.md",
+        ".loom/companion/checkpoints.md",
+        ".loom/companion/review.md",
+        ".loom/companion/merge-ready.md",
+        ".loom/companion/closeout.md",
+        ".loom/bin/loom_init.py",
+        ".loom/bin/fact_chain_support.py",
+        ".loom/bin/governance_surface.py",
+        ".loom/bin/loom_flow.py",
+        ".loom/bin/runtime_paths.py",
+        ".loom/bin/runtime_state.py",
+        ".loom/bin/loom_check.py",
+    ]
+    if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
+        artifacts.append(".github/PULL_REQUEST_TEMPLATE.md")
+    return artifacts
+
+
+def initial_work_items(scenario: str, target_root: Path, adoption_path: str, install_pr_template: bool) -> list[dict[str, object]]:
+    if uses_attach_only_path(adoption_path):
+        return [
+            {
+                "id": WORK_ITEM_ID,
+                "goal": "Attach Loom to the existing governance stack without replacing root rules or host-owned actions",
+                "scope": "Establish attach metadata, companion entry, and repo-local validation without generating Loom-owned recovery/status carriers",
+                "execution_path": "recognize-and-attach",
+                "workspace_entry": ".",
+                "recovery_entry": "existing root rules and repo-native carriers",
+                "review_entry": ".loom/companion/review.md",
+                "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
+                "artifacts": attach_only_artifact_paths(target_root, install_pr_template),
+                "closing_condition": "The attach metadata, companion entry, and repo-local validation path are readable without generated Loom-owned recovery/status carriers",
+                "post_build_continuation": "Extend the attached repo companion and interop surfaces without rewriting the retained host stack",
+                "owner_for_checkpoint_lite": "repository owner or current attach operator",
+            }
+        ]
     artifacts = [
         ".loom/bootstrap/init-result.json",
         ".loom/work-items/INIT-0001.md",
@@ -674,13 +761,8 @@ def initial_work_items(scenario: str, target_root: Path) -> list[dict[str, objec
     ]
 
 
-def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict[str, str]]:
+def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_path: str) -> list[dict[str, str]]:
     artifacts = [
-        {
-            "path": "AGENTS.md",
-            "kind": "root-entry",
-            "source": "generated",
-        },
         {
             "path": ".loom/README.md",
             "kind": "rule-entry",
@@ -704,26 +786,6 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
         {
             "path": ".loom/bootstrap/capability-map.md",
             "kind": "capability-map",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/work-items/INIT-0001.md",
-            "kind": "work-item",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/progress/INIT-0001.md",
-            "kind": "progress",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/reviews/INIT-0001.json",
-            "kind": "review-entry",
-            "source": "generated",
-        },
-        {
-            "path": ".loom/status/current.md",
-            "kind": "status-surface",
             "source": "generated",
         },
         {
@@ -761,17 +823,77 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
             "kind": "loom-tool",
             "source": CHECK_RUNTIME_SOURCE,
         },
-        {
-            "path": ".loom/specs/INIT-0001/spec.md",
-            "kind": "spec",
-            "source": "skills/shared/assets/templates/scaffold/spec.md",
-        },
-        {
-            "path": ".loom/specs/INIT-0001/plan.md",
-            "kind": "plan",
-            "source": "skills/shared/assets/templates/scaffold/plan.md",
-        },
     ]
+    if uses_attach_only_path(adoption_path):
+        artifacts.extend(
+            [
+                {
+                    "path": ".loom/companion/README.md",
+                    "kind": "repo-companion-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/checkpoints.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/review.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/merge-ready.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/companion/closeout.md",
+                    "kind": "repo-companion-doc",
+                    "source": "generated",
+                },
+            ]
+        )
+    else:
+        artifacts.extend(
+            [
+                {
+                    "path": "AGENTS.md",
+                    "kind": "root-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/work-items/INIT-0001.md",
+                    "kind": "work-item",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/progress/INIT-0001.md",
+                    "kind": "progress",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/reviews/INIT-0001.json",
+                    "kind": "review-entry",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/status/current.md",
+                    "kind": "status-surface",
+                    "source": "generated",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/spec.md",
+                    "kind": "spec",
+                    "source": "skills/shared/assets/templates/scaffold/spec.md",
+                },
+                {
+                    "path": ".loom/specs/INIT-0001/plan.md",
+                    "kind": "plan",
+                    "source": "skills/shared/assets/templates/scaffold/plan.md",
+                },
+            ]
+        )
     if install_pr_template or not (target_root / ".github/PULL_REQUEST_TEMPLATE.md").exists():
         artifacts.append(
             {
@@ -784,16 +906,26 @@ def initial_artifacts(target_root: Path, install_pr_template: bool) -> list[dict
 
 
 def build_result(target_root: Path, scenario: str, intake: dict[str, object], install_pr_template: bool) -> dict[str, object]:
+    adoption_path = recommended_adoption_path(scenario, intake)
+    attach_only = uses_attach_only_path(adoption_path)
     main_problem = {
         "new": "the repository has no controlled Loom entry yet",
         "small-existing": "the repo has a baseline but still lacks a stable Loom adoption entry and explicit first artifacts",
-        "complex-existing": "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance",
+        "complex-existing": (
+            "the repo already has a mature governance stack, so Loom must attach to the existing root rules and retained host actions"
+            if attach_only
+            else "the repo needs execution support, recovery, and status carriers instead of more ad hoc guidance"
+        ),
     }[scenario]
 
     reason = {
         "new": "the repo is still establishing its first baseline, so the bootstrap should create the smallest stable entry and first artifacts",
         "small-existing": "the repo already has a baseline, so Loom should enter through companion artifacts instead of rewriting the root",
-        "complex-existing": "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately",
+        "complex-existing": (
+            "the repo already has stable root rules and validation entry, so Loom should recognize and attach instead of materializing replacement recovery and status carriers"
+            if attach_only
+            else "the repo shows execution-support pressure, so the bootstrap must materialize recovery and status carriers immediately"
+        ),
     }[scenario]
 
     result = {
@@ -819,41 +951,70 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             "why_this_path": reason,
         },
         "recommended_adoption": {
-            "path": {
-                "new": "minimal-bootstrap",
-                "small-existing": "lightweight-retrofit",
-                "complex-existing": "full-bootstrap",
-            }[scenario],
+            "path": adoption_path,
             "integration_mode": integration_mode(scenario),
             "recovery_mode": recovery_mode(scenario),
-            "capabilities": rule_refs_for_capabilities(scenario),
+            "capabilities": rule_refs_for_capabilities(scenario, adoption_path),
         },
-        "deferred_capabilities": deferred_capabilities(scenario),
-        "fact_chain": {
-            "mode": "work-item + recovery-entry + derived status-surface",
-            "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
-            "entry_points": {
-                "current_item_id": WORK_ITEM_ID,
-                "work_item": ".loom/work-items/INIT-0001.md",
-                "recovery_entry": ".loom/progress/INIT-0001.md",
-                "status_surface": ".loom/status/current.md",
-            },
-        },
-        "initial_artifacts": initial_artifacts(target_root, install_pr_template),
-        "initial_work_items": initial_work_items(scenario, target_root),
+        "deferred_capabilities": deferred_capabilities(scenario, adoption_path),
+        "fact_chain": (
+            {
+                "mode": "repo-native attach-only",
+                "read_entry": "not_applicable",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": "not_applicable",
+                    "recovery_entry": "not_applicable",
+                    "status_surface": "not_applicable",
+                },
+            }
+            if attach_only
+            else {
+                "mode": "work-item + recovery-entry + derived status-surface",
+                "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                "entry_points": {
+                    "current_item_id": WORK_ITEM_ID,
+                    "work_item": ".loom/work-items/INIT-0001.md",
+                    "recovery_entry": ".loom/progress/INIT-0001.md",
+                    "status_surface": ".loom/status/current.md",
+                },
+            }
+        ),
+        "initial_artifacts": initial_artifacts(target_root, install_pr_template, adoption_path),
+        "initial_work_items": initial_work_items(scenario, target_root, adoption_path, install_pr_template),
         "validation_and_closing": {
             "validation_entry": "python3 .loom/bin/loom_init.py verify --target .",
-            "checkpoint_relationship": [
-                "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
-                "build checkpoint confirms generated carriers and templates are internally consistent",
-                "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
-            ],
-            "clean_state": "all generated Loom artifacts are readable, verified, and free of conflicting duplicates",
-            "close_when": [
-                "the target repo has a readable root or companion Loom entry",
-                "the first work item, progress carrier, and spec/plan artifacts exist",
-                "the bootstrap manifest and init-result are verifiable",
-            ],
+            "checkpoint_relationship": (
+                [
+                    "admission checkpoint confirms the attached companion entry and bootstrap metadata are readable",
+                    "build checkpoint confirms the attach-only surfaces and repo-local validation entry are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, companion extensions, and release judgment align",
+                ]
+                if attach_only
+                else [
+                    "admission checkpoint confirms the bootstrap work item and first artifacts are readable",
+                    "build checkpoint confirms generated carriers and templates are internally consistent",
+                    "merge checkpoint should only pass after downstream repo truth, docs, and delivery state align",
+                ]
+            ),
+            "clean_state": (
+                "all generated attach-only Loom artifacts are readable, verified, and do not introduce Loom-owned recovery/status placeholders"
+                if attach_only
+                else "all generated Loom artifacts are readable, verified, and free of conflicting duplicates"
+            ),
+            "close_when": (
+                [
+                    "the target repo has a readable root rule entry and attached repo companion entry",
+                    "the attach-only bootstrap metadata and repo-local validation path are verifiable",
+                    "the bootstrap manifest does not declare Loom-owned recovery/status carriers for this path",
+                ]
+                if attach_only
+                else [
+                    "the target repo has a readable root or companion Loom entry",
+                    "the first work item, progress carrier, and spec/plan artifacts exist",
+                    "the bootstrap manifest and init-result are verifiable",
+                ]
+            ),
         },
         "runtime_state": runtime_state_payload(target_root),
         "governance_surface": build_governance_surface(
@@ -867,19 +1028,28 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
 
 def render_loom_readme(result: dict[str, object]) -> str:
     run = result["run"]
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
+    path_lines = (
+        "- Repo companion entry: `.loom/companion/README.md`\n"
+        "- Companion checkpoints: `.loom/companion/checkpoints.md`\n"
+        "- Companion review surface: `.loom/companion/review.md`\n"
+        if attach_only
+        else "- First work item: `.loom/work-items/INIT-0001.md`\n"
+        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
+        "- Status surface: `.loom/status/current.md`\n"
+    )
     return (
         "# Loom Bootstrap\n\n"
         f"This directory was generated by `{RUNTIME_SOURCE}`.\n\n"
         "## Current Path\n\n"
         f"- Scenario: {run['scenario']}\n"
+        f"- Recommended adoption path: {result['recommended_adoption']['path']}\n"
         f"- Integration mode: {run['integration_mode']}\n"
         f"- Recovery mode: {run['recovery_mode']}\n\n"
         "## Main Entry Points\n\n"
         "- Bootstrap manifest: `.loom/bootstrap/manifest.json`\n"
         "- Bootstrap result: `.loom/bootstrap/init-result.json`\n"
-        "- First work item: `.loom/work-items/INIT-0001.md`\n"
-        "- Progress carrier: `.loom/progress/INIT-0001.md`\n"
-        "- Status surface: `.loom/status/current.md`\n"
+        f"{path_lines}"
         "- Runtime-state entry: `.loom/bin/loom_init.py runtime-state --target .`\n"
         "- Daily execution CLI: `.loom/bin/loom_flow.py`\n"
         "- Gate CLI: `.loom/bin/loom_check.py`\n"
@@ -904,6 +1074,52 @@ def render_capability_map(result: dict[str, object]) -> str:
             lines.append(f"- `{rule}`")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_companion_readme(result: dict[str, object]) -> str:
+    return (
+        "# Repo Companion\n\n"
+        "This companion entry attaches Loom to the existing repository governance surface.\n\n"
+        "## Preserved Ownership\n\n"
+        "- Root rules remain in the repository's existing boundary docs.\n"
+        "- Retained host actions stay host-owned.\n"
+        "- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.\n\n"
+        "## Loom Entry Surfaces\n\n"
+        "- Review surface: `.loom/companion/review.md`\n"
+        "- Merge-ready surface: `.loom/companion/merge-ready.md`\n"
+        "- Closeout surface: `.loom/companion/closeout.md`\n"
+        "- Checkpoints surface: `.loom/companion/checkpoints.md`\n"
+    )
+
+
+def render_companion_checkpoints() -> str:
+    return (
+        "# Companion Checkpoints\n\n"
+        "- Admission: read the existing root rules and repo-native admission surface before entering implementation.\n"
+        "- Build: preserve retained host actions and repo-native carriers; do not assume Loom-owned recovery/status carriers exist.\n"
+        "- Merge-ready: consume companion extensions and host-owned gates without re-implementing the host lifecycle.\n"
+    )
+
+
+def render_companion_review() -> str:
+    return (
+        "# Companion Review Surface\n\n"
+        "Use this file to attach repo-specific review requirements while keeping the repository's existing root rules authoritative.\n"
+    )
+
+
+def render_companion_merge_ready() -> str:
+    return (
+        "# Companion Merge-Ready Surface\n\n"
+        "Use this file to summarize repo-specific merge-ready expectations without taking over host-owned merge controls.\n"
+    )
+
+
+def render_companion_closeout() -> str:
+    return (
+        "# Companion Closeout Surface\n\n"
+        "Use this file to attach repo-specific closeout expectations while preserving the host-owned closeout controls and repo-native truth.\n"
+    )
 
 
 def render_work_item(result: dict[str, object]) -> str:
@@ -1040,6 +1256,7 @@ def scaffold_target(
 ) -> tuple[int, list[str]]:
     written = 0
     touched: list[str] = []
+    attach_only = uses_attach_only_path(str(result["recommended_adoption"]["path"]))
 
     writes: list[tuple[Path, str | dict[str, object], str]] = [
         (target_root / ".loom/README.md", render_loom_readme(result), "text"),
@@ -1047,11 +1264,26 @@ def scaffold_target(
         (output_path, result, "json"),
         (target_root / ".loom/bootstrap/manifest.json", manifest_payload(result), "json"),
         (target_root / ".loom/bootstrap/capability-map.md", render_capability_map(result), "text"),
-        (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
-        (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
-        (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
-        (target_root / ".loom/status/current.md", render_status(result), "text"),
     ]
+    if attach_only:
+        writes.extend(
+            [
+                (target_root / ".loom/companion/README.md", render_companion_readme(result), "text"),
+                (target_root / ".loom/companion/checkpoints.md", render_companion_checkpoints(), "text"),
+                (target_root / ".loom/companion/review.md", render_companion_review(), "text"),
+                (target_root / ".loom/companion/merge-ready.md", render_companion_merge_ready(), "text"),
+                (target_root / ".loom/companion/closeout.md", render_companion_closeout(), "text"),
+            ]
+        )
+    else:
+        writes.extend(
+            [
+                (target_root / ".loom/work-items/INIT-0001.md", render_work_item(result), "text"),
+                (target_root / ".loom/progress/INIT-0001.md", render_progress(result), "text"),
+                (target_root / ".loom/reviews/INIT-0001.json", render_review_entry(result), "text"),
+                (target_root / ".loom/status/current.md", render_status(result), "text"),
+            ]
+        )
 
     for path, payload, kind in writes:
         changed = write_json(path, payload, force=force) if kind == "json" else write_text(path, payload, force=force)
@@ -1067,12 +1299,18 @@ def scaffold_target(
         (Path(__file__).with_name("runtime_paths.py"), target_root / ".loom/bin/runtime_paths.py"),
         (Path(__file__).with_name("runtime_state.py"), target_root / ".loom/bin/runtime_state.py"),
         (Path(__file__).with_name("loom_check.py"), target_root / ".loom/bin/loom_check.py"),
-        (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
-        (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
     ):
         if copy_file(source, destination, force=force):
             written += 1
             touched.append(str(destination.relative_to(target_root)))
+    if not attach_only:
+        for source, destination in (
+            (shared_asset(__file__, "templates/scaffold/spec.md"), target_root / ".loom/specs/INIT-0001/spec.md"),
+            (shared_asset(__file__, "templates/scaffold/plan.md"), target_root / ".loom/specs/INIT-0001/plan.md"),
+        ):
+            if copy_file(source, destination, force=force):
+                written += 1
+                touched.append(str(destination.relative_to(target_root)))
 
     pr_template_target = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if install_pr_template or not pr_template_target.exists():
@@ -1081,7 +1319,7 @@ def scaffold_target(
             touched.append(str(pr_template_target.relative_to(target_root)))
 
     root_agents = target_root / "AGENTS.md"
-    if not root_agents.exists():
+    if not attach_only and not root_agents.exists():
         if write_text(root_agents, render_root_agents(), force=force):
             written += 1
             touched.append(str(root_agents.relative_to(target_root)))
@@ -1090,42 +1328,59 @@ def scaffold_target(
 
 
 def verify_target(target_root: Path, output_path: Path) -> list[str]:
-    required_paths = [
-        "AGENTS.md",
-        ".loom/README.md",
-        ".loom/bootstrap/intake.snapshot.json",
-        str(output_path.relative_to(target_root)),
-        ".loom/bootstrap/manifest.json",
-        ".loom/bootstrap/capability-map.md",
-        ".loom/work-items/INIT-0001.md",
-        ".loom/progress/INIT-0001.md",
-        ".loom/reviews/INIT-0001.json",
-        ".loom/status/current.md",
-        ".loom/bin/loom_init.py",
-        ".loom/bin/fact_chain_support.py",
-        ".loom/bin/governance_surface.py",
-        ".loom/bin/loom_flow.py",
-        ".loom/bin/runtime_paths.py",
-        ".loom/bin/runtime_state.py",
-        ".loom/bin/loom_check.py",
-        ".loom/specs/INIT-0001/spec.md",
-        ".loom/specs/INIT-0001/plan.md",
-    ]
     errors: list[str] = []
     runtime_state = runtime_state_payload(target_root)
     if runtime_state["result"] != "pass":
         errors.extend(f"runtime-state: {message}" for message in runtime_state["missing_inputs"])
-    for relative in required_paths:
-        if not (target_root / relative).exists():
-            errors.append(f"missing required artifact: {relative}")
 
     current_item_id: str | None = None
+    attach_only = False
+    required_paths: list[str] = []
     if output_path.exists():
         try:
             result = read_json(output_path)
         except json.JSONDecodeError as exc:
             errors.append(f"invalid init-result JSON: {exc.msg}")
             return errors
+        adoption = result.get("recommended_adoption")
+        if isinstance(adoption, dict):
+            attach_only = uses_attach_only_path(str(adoption.get("path", "")))
+        required_paths = [
+            ".loom/README.md",
+            ".loom/bootstrap/intake.snapshot.json",
+            str(output_path.relative_to(target_root)),
+            ".loom/bootstrap/manifest.json",
+            ".loom/bootstrap/capability-map.md",
+            ".loom/bin/loom_init.py",
+            ".loom/bin/fact_chain_support.py",
+            ".loom/bin/governance_surface.py",
+            ".loom/bin/loom_flow.py",
+            ".loom/bin/runtime_paths.py",
+            ".loom/bin/runtime_state.py",
+            ".loom/bin/loom_check.py",
+        ]
+        if attach_only:
+            required_paths.extend(
+                [
+                    ".loom/companion/README.md",
+                    ".loom/companion/checkpoints.md",
+                    ".loom/companion/review.md",
+                    ".loom/companion/merge-ready.md",
+                    ".loom/companion/closeout.md",
+                ]
+            )
+        else:
+            required_paths.extend(
+                [
+                    "AGENTS.md",
+                    ".loom/work-items/INIT-0001.md",
+                    ".loom/progress/INIT-0001.md",
+                    ".loom/reviews/INIT-0001.json",
+                    ".loom/status/current.md",
+                    ".loom/specs/INIT-0001/spec.md",
+                    ".loom/specs/INIT-0001/plan.md",
+                ]
+            )
         for key in (
             "project_judgment",
             "recommended_adoption",
@@ -1172,50 +1427,79 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                     if not isinstance(value, str) or not value:
                         errors.append(f"initial work item is missing required field: {field}")
                 validated_work_items.append(work_item)
-
-    fact_chain_report, fact_chain_errors = inspect_fact_chain(
-        target_root,
-        str(output_path.relative_to(target_root)),
-    )
-    if fact_chain_errors:
-        errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
-    elif not fact_chain_report:
-        errors.append("fact-chain: no report was produced")
-    elif output_path.exists():
-        current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
-        runtime_evidence_report = fact_chain_report.get("runtime_evidence")
-        if not isinstance(runtime_evidence_report, dict):
-            errors.append("fact-chain: missing runtime_evidence report")
-        else:
-            for field in (
-                "run_entry",
-                "logs_entry",
-                "diagnostics_entry",
-                "verification_entry",
-                "lane_entry",
-            ):
-                if field not in runtime_evidence_report:
-                    errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-        matching_work_item = None
-        for work_item in validated_work_items:
-            if work_item.get("id") == current_item_id:
-                matching_work_item = work_item
-                break
-        if matching_work_item is None:
-            errors.append(f"init-result is missing the current work item `{current_item_id}`")
-        else:
-            expected_init_fields = {
-                "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
-                "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
-                "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+        if attach_only:
+            fact_chain = result.get("fact_chain")
+            if not isinstance(fact_chain, dict):
+                errors.append("init-result is missing required section: fact_chain")
+            else:
+                if fact_chain.get("mode") != "repo-native attach-only":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.mode = repo-native attach-only`")
+                if fact_chain.get("read_entry") != "not_applicable":
+                    errors.append("deep-existing-repo init-result must keep `fact_chain.read_entry = not_applicable`")
+                entry_points = fact_chain.get("entry_points")
+                if not isinstance(entry_points, dict):
+                    errors.append("deep-existing-repo init-result must include fact_chain.entry_points")
+                else:
+                    for field in ("work_item", "recovery_entry", "status_surface"):
+                        if entry_points.get(field) != "not_applicable":
+                            errors.append(f"deep-existing-repo init-result must keep `fact_chain.entry_points.{field} = not_applicable`")
+            declared_generated = {
+                artifact.get("path")
+                for artifact in result.get("initial_artifacts", [])
+                if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
             }
-            for field, expected_value in expected_init_fields.items():
-                actual_value = matching_work_item.get(field)
-                if actual_value != expected_value:
-                    errors.append(
-                        f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
-                        f"expected `{expected_value}`, got `{actual_value}`"
-                    )
+            for forbidden in (".loom/work-items/INIT-0001.md", ".loom/progress/INIT-0001.md", ".loom/status/current.md"):
+                if forbidden in declared_generated:
+                    errors.append(f"deep-existing-repo bootstrap must not declare generated carrier `{forbidden}`")
+
+    for relative in required_paths:
+        if not (target_root / relative).exists():
+            errors.append(f"missing required artifact: {relative}")
+
+    if not attach_only:
+        fact_chain_report, fact_chain_errors = inspect_fact_chain(
+            target_root,
+            str(output_path.relative_to(target_root)),
+        )
+        if fact_chain_errors:
+            errors.extend(f"fact-chain: {message}" for message in fact_chain_errors)
+        elif not fact_chain_report:
+            errors.append("fact-chain: no report was produced")
+        elif output_path.exists():
+            current_item_id = fact_chain_report["fact_chain"]["entry_points"]["current_item_id"]
+            runtime_evidence_report = fact_chain_report.get("runtime_evidence")
+            if not isinstance(runtime_evidence_report, dict):
+                errors.append("fact-chain: missing runtime_evidence report")
+            else:
+                for field in (
+                    "run_entry",
+                    "logs_entry",
+                    "diagnostics_entry",
+                    "verification_entry",
+                    "lane_entry",
+                ):
+                    if field not in runtime_evidence_report:
+                        errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
+            matching_work_item = None
+            for work_item in validated_work_items:
+                if work_item.get("id") == current_item_id:
+                    matching_work_item = work_item
+                    break
+            if matching_work_item is None:
+                errors.append(f"init-result is missing the current work item `{current_item_id}`")
+            else:
+                expected_init_fields = {
+                    "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
+                    "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
+                    "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
+                }
+                for field, expected_value in expected_init_fields.items():
+                    actual_value = matching_work_item.get(field)
+                    if actual_value != expected_value:
+                        errors.append(
+                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"expected `{expected_value}`, got `{actual_value}`"
+                        )
 
     pr_template = target_root / ".github/PULL_REQUEST_TEMPLATE.md"
     if pr_template.exists():
@@ -1228,24 +1512,29 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
     if flow_tool.exists():
         commands: list[tuple[str, list[str], set[str]]] = [
             (
-                "loom-flow fact-chain",
-                ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
-                {"pass"},
-            ),
-            (
-                "loom-flow runtime-evidence",
-                ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                "loom-init runtime-state",
+                ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
                 {"pass"},
             ),
         ]
-        if current_item_id:
+        if not attach_only:
             commands.extend(
                 [
                     (
-                        "loom-init runtime-state",
-                        ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+                        "loom-flow fact-chain",
+                        ["python3", ".loom/bin/loom_flow.py", "fact-chain", "--target", "."],
                         {"pass"},
                     ),
+                    (
+                        "loom-flow runtime-evidence",
+                        ["python3", ".loom/bin/loom_flow.py", "runtime-evidence", "--target", "."],
+                        {"pass"},
+                    ),
+                ]
+            )
+        if current_item_id and not attach_only:
+            commands.extend(
+                [
                     (
                         "loom-flow checkpoint admission",
                         [
@@ -1429,6 +1718,24 @@ def fact_chain(args: argparse.Namespace) -> int:
     except RuntimeError as exc:
         print(f"loom-init: {exc}", file=sys.stderr)
         return 2
+    if output_path.exists():
+        try:
+            result = read_json(output_path)
+        except json.JSONDecodeError:
+            result = {}
+        adoption = result.get("recommended_adoption") if isinstance(result, dict) else None
+        if isinstance(adoption, dict) and uses_attach_only_path(str(adoption.get("path", ""))):
+            print(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "errors": ["fact-chain is not available for `deep-existing-repo` attach-only bootstrap output"],
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+            return 1
 
     report, errors = inspect_fact_chain(target_root, str(output_path.relative_to(target_root)))
     if errors:


### PR DESCRIPTION
## Summary
- 新增成熟治理重仓的 `deep-existing-repo` attach-only 默认策略
- 让 `loom-init` 在 `complex-existing` 下识别并输出 `recommended_adoption.path = deep-existing-repo`
- 为 attach-only bootstrap/verify 与 plugin/package 镜像补齐对应合同和自检

## Testing
- `python3 tools/loom_check.py`
- `python3 -m py_compile skills/shared/scripts/loom_init.py skills/shared/scripts/loom_check.py plugins/loom/skills/shared/scripts/loom_init.py plugins/loom/skills/shared/scripts/loom_check.py`
- `git diff --check`

Closes #244