### PR TITLE
feat: 扩展 repo companion v2 机读合同

### DIFF
--- a/adoption/execution-entry-compatibility.md
+++ b/adoption/execution-entry-compatibility.md
@@ -26,7 +26,7 @@
 | 层级 | 稳定入口 | 兼容承诺 |
 | --- | --- | --- |
 | root 入口与基础验证 | `loom route` / `loom init verify` | `loom-init` 继续作为唯一 root entry，路由能力不替代底层 CLI |
-| 初始化与恢复公共治理读面 | `loom-init` 输出合同 + `loom-adopt` / `loom-resume` 场景合同 | `governance_surface` 作为稳定公共字段存在；其中 `repo_interface` 只承接 `repo companion` locator 与机读 requirements / gates，场景 skill 只能复用或摘要，不新增第二套治理真相 |
+| 初始化与恢复公共治理读面 | `loom-init` 输出合同 + `loom-adopt` / `loom-resume` 场景合同 | `governance_surface` 作为稳定公共字段存在；其中 `repo_interface` 只承接 `repo companion` locator、机读 requirements / typed gates，以及 `v2` 下的 metadata/context 合同摘要，场景 skill 只能复用或摘要，不新增第二套治理真相 |
 | 日常读取与检查 | `loom flow fact-chain` / `loom flow runtime-evidence` / `loom flow state-check` | 输出保持 JSON 结果语义（`result/summary/missing_inputs/fallback_to`） |
 | 正式 review 执行 | `loom flow review` + `loom review run` + `loom review read|record` | `flow review` 保持只读，`review run` 负责默认 engine 执行与 evidence 落盘，正式 authored truth 仍只允许写回单一 `review record` |
 | checkpoint 执行 | `loom flow checkpoint admission/build/merge` | 三阶段语义与回退关系保持不变 |
@@ -44,7 +44,7 @@
 - 新增场景 skill 入口不替代 `loom-init` 的 root 身份，只补显式入口与隐式路由
 - 单 skill package 只补正式交付物，不重写场景 skill 合同
 - 新增 [../harness/host-action-contract.md](../harness/host-action-contract.md) 只收口既有 host-facing actions 的合同，不新增 umbrella CLI，也不改写既有命令输出结构
-- `governance_surface` 只允许扩充 locator 或职责说明，不允许更名、拆成并行字段或复制实时 authored 状态；`repo_interface` 只允许承接 `repo companion` 的 locator、requirements 与 specialized gates 机读摘要
+- `governance_surface` 只允许扩充 locator 或职责说明，不允许更名、拆成并行字段或复制实时 authored 状态；`repo_interface` 只允许承接 `repo companion` 的 locator、requirements、typed specialized gates，以及 `v2` 下的 metadata/context 机读摘要
 - gate 与 verify 始终复用同一 CLI，不维护第二套检查命令
 
 ## 4. 可复验操作流

--- a/adoption/reference-companion-spec-syvert.md
+++ b/adoption/reference-companion-spec-syvert.md
@@ -2,7 +2,7 @@
 
 本文提供 `Syvert` 的 `repo companion` 参考样本。
 
-它只证明当前 `.loom/companion/repo-interface.json` 最小 schema 足以承接一类真实下游；不把 `Syvert` 的 gate、目录名或命名习惯直接提升为 Loom core 默认规则。
+它只证明当前 `.loom/companion/repo-interface.json` 机读合同足以承接一类真实下游；不把 `Syvert` 的 gate、目录名或命名习惯直接提升为 Loom core 默认规则。
 
 ## 1. Companion Rules
 
@@ -38,7 +38,7 @@
 
 ```json
 {
-  "schema_version": "loom-repo-interface/v1",
+  "schema_version": "loom-repo-interface/v2",
   "companion_entry": ".loom/companion/README.md",
   "repo_specific_requirements": {
     "review": [
@@ -70,13 +70,54 @@
     {
       "id": "syvert-admission-checkpoint",
       "summary": "Syvert-specific admission checkpoint appendix.",
-      "locator": ".loom/companion/checkpoints.md"
+      "locator": ".loom/companion/checkpoints.md",
+      "gate_type": "admission"
     },
     {
       "id": "syvert-build-checkpoint",
       "summary": "Syvert-specific build checkpoint appendix.",
-      "locator": ".loom/companion/checkpoints.md"
+      "locator": ".loom/companion/checkpoints.md",
+      "gate_type": "build"
     }
-  ]
+  ],
+  "context_schema": {
+    "fields": [
+      {
+        "id": "issue",
+        "summary": "Primary Syvert issue identifier carried through execution and closeout.",
+        "type": "string",
+        "required": true,
+        "mapping_rule_locator": ".loom/companion/context-schema.md"
+      },
+      {
+        "id": "item_key",
+        "summary": "Stable repo-native item key used by Syvert execution lanes.",
+        "type": "string",
+        "required": true,
+        "mapping_rule_locator": ".loom/companion/context-schema.md"
+      },
+      {
+        "id": "item_type",
+        "summary": "Execution item type used by Syvert governance branching.",
+        "type": "string",
+        "required": true,
+        "mapping_rule_locator": ".loom/companion/context-schema.md"
+      },
+      {
+        "id": "release",
+        "summary": "Release line required for merge-ready and closeout decisions.",
+        "type": "string",
+        "required": false,
+        "mapping_rule_locator": ".loom/companion/context-schema.md"
+      },
+      {
+        "id": "sprint",
+        "summary": "Sprint label used by Syvert planning and reporting flows.",
+        "type": "string",
+        "required": false,
+        "mapping_rule_locator": ".loom/companion/context-schema.md"
+      }
+    ]
+  }
 }
 ```

--- a/adoption/reference-companion-spec-webenvoy.md
+++ b/adoption/reference-companion-spec-webenvoy.md
@@ -2,7 +2,7 @@
 
 本文提供 `WebEnvoy` 的 `repo companion` 参考样本。
 
-它只证明当前 `.loom/companion/repo-interface.json` 最小 schema 足以承接另一类真实下游；不把 `WebEnvoy` 的模板负担、流程命名或 host gate 直接提升为 Loom core 默认规则。
+它只证明当前 `.loom/companion/repo-interface.json` 机读合同足以承接另一类真实下游；不把 `WebEnvoy` 的模板负担、流程命名或 host gate 直接提升为 Loom core 默认规则。
 
 ## 1. Companion Rules
 
@@ -38,7 +38,7 @@
 
 ```json
 {
-  "schema_version": "loom-repo-interface/v1",
+  "schema_version": "loom-repo-interface/v2",
   "companion_entry": ".loom/companion/README.md",
   "repo_specific_requirements": {
     "review": [
@@ -70,13 +70,58 @@
     {
       "id": "webenvoy-pre-review",
       "summary": "WebEnvoy-specific pre-review appendix.",
-      "locator": ".loom/companion/pre-review.md"
+      "locator": ".loom/companion/pre-review.md",
+      "gate_type": "pre_review"
     },
     {
       "id": "webenvoy-formal-review",
       "summary": "WebEnvoy-specific formal review appendix.",
-      "locator": ".loom/companion/review.md"
+      "locator": ".loom/companion/review.md",
+      "gate_type": "review"
     }
-  ]
+  ],
+  "metadata_contract": {
+    "fields": [
+      {
+        "id": "integration_check",
+        "summary": "Declare the integration check metadata block required by guarded WebEnvoy changes.",
+        "applicability_locator": ".loom/companion/metadata-contract.md",
+        "authority_locator": ".github/PULL_REQUEST_TEMPLATE.md",
+        "enforcement": "blocking"
+      },
+      {
+        "id": "gate_applicability",
+        "summary": "Declare which repo-local gates apply to the current change before review can complete.",
+        "applicability_locator": ".loom/companion/metadata-contract.md",
+        "authority_locator": ".github/PULL_REQUEST_TEMPLATE.md",
+        "enforcement": "blocking"
+      },
+      {
+        "id": "live_evidence_record",
+        "summary": "Point review and merge-ready to the live evidence record consumed by WebEnvoy governance.",
+        "applicability_locator": ".loom/companion/metadata-contract.md",
+        "authority_locator": ".github/PULL_REQUEST_TEMPLATE.md",
+        "enforcement": "advisory"
+      }
+    ]
+  },
+  "context_schema": {
+    "fields": [
+      {
+        "id": "guardian_lane",
+        "summary": "Review lane used to determine which overload modules and guardian checks apply.",
+        "type": "string",
+        "required": true,
+        "mapping_rule_locator": ".loom/companion/context-schema.md"
+      },
+      {
+        "id": "evidence_window",
+        "summary": "Evidence freshness window consumed by pre-review and review preparation.",
+        "type": "string",
+        "required": false,
+        "mapping_rule_locator": ".loom/companion/context-schema.md"
+      }
+    ]
+  }
 }
 ```

--- a/adoption/repo-companion-contract.md
+++ b/adoption/repo-companion-contract.md
@@ -76,7 +76,17 @@
 
 `.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
 
-当前稳定 schema：
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract 与 context schema
+
+### 4.1 `v1` 兼容合同
 
 ```json
 {
@@ -91,12 +101,46 @@
 }
 ```
 
-字段约束：
+`v1` 字段约束：
 
 - `schema_version` 固定为 `loom-repo-interface/v1`
 - `companion_entry` 必须指向可读的 companion 主文档
 - `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
 - `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  }
+}
+```
+
+`v2` 在 `v1` 之上新增两个可选顶层 section：
+
+- `metadata_contract`
+- `context_schema`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
 
 `repo_specific_requirements` 的每条 requirement 固定字段：
 
@@ -115,6 +159,56 @@
 - `id`
 - `summary`
 - `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata fields，而不是把这些字段抬升为 Loom core 默认字段。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+### 4.5 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.6 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
 
 ## 5. 读面语义
 

--- a/adoption/repo-companion-migration.md
+++ b/adoption/repo-companion-migration.md
@@ -14,7 +14,7 @@
 其中：
 
 - `manifest.json` 只负责 locator，不承载 authored state
-- `repo-interface.json` 只负责 companion-owned requirements / gates 的机读声明
+- `repo-interface.json` 负责 companion-owned requirements / typed gates，以及 `v2` 下的 metadata/context 机读声明
 
 对应稳定 schema 见 [repo-companion-contract.md](/Users/mc/dev/Loom/adoption/repo-companion-contract.md)。
 
@@ -36,29 +36,44 @@
 
 ## 3. `repo-interface.json` 最小合同
 
-`v1` 只冻结以下顶层字段：
+下游迁移当前允许两种 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续兼容读取
+- `v2` 在 `v1` 基础上新增 typed `specialized_gates`、`metadata_contract`、`context_schema`
+
+`v1` 顶层字段固定为：
 
 - `schema_version`
 - `companion_entry`
 - `repo_specific_requirements`
 - `specialized_gates`
 
+`v2` 顶层字段固定为：
+
+- `schema_version`
+- `companion_entry`
+- `repo_specific_requirements`
+- `specialized_gates`
+- `metadata_contract`
+- `context_schema`
+
 其中：
 
-- `schema_version` 固定为 `loom-repo-interface/v1`
 - `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout`
-- `repo_specific_requirements` 每项 requirement 固定字段为：
-  - `id`
-  - `summary`
-  - `locator`
-  - `enforcement`
+- requirement 固定字段为 `id | summary | locator | enforcement`
 - `enforcement` 只允许 `blocking | advisory`
-- `specialized_gates` 每项 gate 固定字段为：
-  - `id`
-  - `summary`
-  - `locator`
+- `specialized_gates` 固定字段为 `id | summary | locator`，并允许可选 `gate_type`
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `metadata_contract.fields[*]` 固定字段为 `id | summary | applicability_locator | authority_locator | enforcement`
+- `context_schema.fields[*]` 固定字段为 `id | summary | type | required | mapping_rule_locator`
+- `context_schema.fields[*].type` 只允许 `string | integer | number | boolean`
 
-本批不引入 `contract_version`、repo metadata、validation status 或 retained host actions 的机读字段；这些边界继续由 companion 文档与既有 host-action 合同承接。
+本批仍不引入 `contract_version`、runtime status、review summary 或 retained host actions 的执行结果字段；这些边界继续由 companion 文档与既有 host-action 合同承接。
 
 ## 4. 迁移时的兼容结果
 

--- a/adoption/validation-repo-companion-interface.md
+++ b/adoption/validation-repo-companion-interface.md
@@ -6,11 +6,13 @@
 
 ## 1. 覆盖面
 
-本批验证至少覆盖以下 6 种情况：
+本批验证至少覆盖以下 8 种情况：
 
 - absent companion
 - companion docs only
 - incomplete manifest / repo-interface
+- present `v1` manifest + interface
+- present `v2` manifest + interface
 - present manifest + blocking review requirements
 - present manifest + advisory merge-ready requirements
 - present manifest + blocking closeout requirements
@@ -22,6 +24,8 @@
 | absent companion | 仓库不存在 `.loom/companion/manifest.json` | `governance_surface.repo_interface.availability = absent` |
 | companion docs only | 仓库存在旧式 companion docs，但无 manifest | `availability = companion_docs_only` |
 | incomplete | manifest 存在但 locator / schema / surface 缺失，或 manifest 带入 authored 字段 | `availability = incomplete` |
+| present `v1` | manifest 与 `repo-interface v1` 完整 | `availability = present`，`loom_flow` 继续可消费 requirements |
+| present `v2` | manifest 与 `repo-interface v2` 完整，且 typed gates / metadata / context 均合法 | `availability = present`，`v1`/`v2` 不分叉执行结果语义 |
 | present + review | manifest 与 repo-interface 完整，且 `review` surface 含 blocking requirement | `flow review` 必须显式 `block` |
 | present + merge-ready | manifest 与 repo-interface 完整，且 `merge_ready` surface 只含 advisory requirement | `repo_specific_requirements.result = pass`，不新增顶层阻断 |
 | present + closeout | manifest 与 repo-interface 完整，且 `closeout` surface 含 blocking requirement | `repo_specific_requirements.result = block`，closeout 不得宣称 Loom core 已覆盖 |
@@ -33,6 +37,9 @@
 - manifest 出现 `current_stop`、`blockers`、`review summary` 等 authored 字段
 - `repo-interface.json` 缺少 `review`、`merge_ready`、`closeout` 任一 surface
 - requirement 使用非法 `enforcement`
+- specialized gate 使用非法 `gate_type`
+- `metadata_contract` 缺少 `applicability_locator`、`authority_locator` 或使用非法 `enforcement`
+- `context_schema` 缺少 `type`、`required`、`mapping_rule_locator` 或使用非法基础类型
 - locator 指向不存在的文件
 - 旧式 companion docs 被伪装成 `present`
 
@@ -41,7 +48,7 @@
 本批 companion interface 的验证由以下入口共同承接：
 
 - `loom_check`
-  - synthetic fixtures 覆盖 4 类 availability 与 3 个 surface 的结果纪律
+  - synthetic fixtures 同时覆盖 `v1`、`v2`、非法 `v2` 输入、4 类 availability 与 3 个 surface 的结果纪律
 - `governance_surface`
   - 负责 companion 机读读面
 - `loom_flow review|merge-ready|closeout`

--- a/plugins/loom/skills/shared/scripts/governance_surface.py
+++ b/plugins/loom/skills/shared/scripts/governance_surface.py
@@ -32,10 +32,22 @@ PLANNED_LOCATORS = {
 REPO_INTERFACE_SURFACES = ("review", "merge_ready", "closeout")
 REPO_INTERFACE_AVAILABILITY = {"absent", "companion_docs_only", "incomplete", "present"}
 REPO_INTERFACE_MANIFEST_SCHEMA = "loom-repo-companion-manifest/v1"
-REPO_INTERFACE_SCHEMA = "loom-repo-interface/v1"
+REPO_INTERFACE_V1_SCHEMA = "loom-repo-interface/v1"
+REPO_INTERFACE_V2_SCHEMA = "loom-repo-interface/v2"
+REPO_INTERFACE_SCHEMAS = {REPO_INTERFACE_V1_SCHEMA, REPO_INTERFACE_V2_SCHEMA}
 REPO_INTERFACE_ENFORCEMENT = {"blocking", "advisory"}
+REPO_INTERFACE_GATE_TYPES = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+}
+REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
-REPO_INTERFACE_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
+REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"metadata_contract", "context_schema"}
 
 
 def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -266,6 +278,80 @@ def validate_specialized_gate(
         missing_inputs.append(f"{prefix} locator must be a non-empty string")
     elif not target.exists():
         missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
+    gate_type = entry.get("gate_type")
+    if gate_type is not None and gate_type not in REPO_INTERFACE_GATE_TYPES:
+        missing_inputs.append(
+            f"{prefix} gate_type must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    return missing_inputs
+
+
+def validate_metadata_contract(
+    *,
+    root: Path,
+    entry: object,
+) -> list[str]:
+    prefix = "metadata_contract"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    fields = entry.get("fields")
+    if not isinstance(fields, list):
+        return [f"{prefix} must include `fields` as a list"]
+    missing_inputs: list[str] = []
+    for index, field in enumerate(fields):
+        field_prefix = f"{prefix}.fields[{index}]"
+        if not isinstance(field, dict):
+            missing_inputs.append(f"{field_prefix} must be an object")
+            continue
+        for required in ("id", "summary", "applicability_locator", "authority_locator", "enforcement"):
+            value = field.get(required)
+            if required == "enforcement":
+                continue
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"{field_prefix} missing `{required}`")
+        enforcement = field.get("enforcement")
+        if enforcement not in REPO_INTERFACE_ENFORCEMENT:
+            missing_inputs.append(f"{field_prefix} enforcement must be `blocking` or `advisory`")
+        for locator_field in ("applicability_locator", "authority_locator"):
+            locator, target = resolve_locator(root, field.get(locator_field))
+            if locator is None or target is None:
+                missing_inputs.append(f"{field_prefix} `{locator_field}` must be a non-empty string")
+            elif not target.exists():
+                missing_inputs.append(f"{field_prefix} `{locator_field}` points to missing path `{locator}`")
+    return missing_inputs
+
+
+def validate_context_schema(
+    *,
+    root: Path,
+    entry: object,
+) -> list[str]:
+    prefix = "context_schema"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    fields = entry.get("fields")
+    if not isinstance(fields, list):
+        return [f"{prefix} must include `fields` as a list"]
+    missing_inputs: list[str] = []
+    for index, field in enumerate(fields):
+        field_prefix = f"{prefix}.fields[{index}]"
+        if not isinstance(field, dict):
+            missing_inputs.append(f"{field_prefix} must be an object")
+            continue
+        for required in ("id", "summary", "type", "mapping_rule_locator"):
+            value = field.get(required)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"{field_prefix} missing `{required}`")
+        field_type = field.get("type")
+        if field_type not in REPO_INTERFACE_CONTEXT_TYPES:
+            missing_inputs.append(f"{field_prefix} type must be one of `string`, `integer`, `number`, `boolean`")
+        if not isinstance(field.get("required"), bool):
+            missing_inputs.append(f"{field_prefix} `required` must be a boolean")
+        locator, target = resolve_locator(root, field.get("mapping_rule_locator"))
+        if locator is None or target is None:
+            missing_inputs.append(f"{field_prefix} `mapping_rule_locator` must be a non-empty string")
+        elif not target.exists():
+            missing_inputs.append(f"{field_prefix} `mapping_rule_locator` points to missing path `{locator}`")
     return missing_inputs
 
 
@@ -345,9 +431,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         if interface_payload is None:
             missing_inputs.append("repo companion interface is unreadable")
         else:
-            if interface_payload.get("schema_version") != REPO_INTERFACE_SCHEMA:
-                missing_inputs.append(f"repo companion interface schema must be `{REPO_INTERFACE_SCHEMA}`")
-            extra_interface_keys = sorted(set(interface_payload.keys()) - REPO_INTERFACE_KEYS)
+            interface_schema = interface_payload.get("schema_version")
+            if interface_schema not in REPO_INTERFACE_SCHEMAS:
+                missing_inputs.append(
+                    "repo companion interface schema must be `loom-repo-interface/v1` or `loom-repo-interface/v2`"
+                )
+            allowed_interface_keys = (
+                REPO_INTERFACE_V2_KEYS if interface_schema == REPO_INTERFACE_V2_SCHEMA else REPO_INTERFACE_V1_KEYS
+            )
+            extra_interface_keys = sorted(set(interface_payload.keys()) - allowed_interface_keys)
             if extra_interface_keys:
                 missing_inputs.append(
                     "repo companion interface contains unexpected top-level fields: "
@@ -394,6 +486,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             root=root,
                             entry=entry,
                             index=index,
+                        )
+                    )
+
+            if interface_schema == REPO_INTERFACE_V2_SCHEMA:
+                metadata_contract = interface_payload.get("metadata_contract")
+                if metadata_contract is not None:
+                    missing_inputs.extend(
+                        validate_metadata_contract(
+                            root=root,
+                            entry=metadata_contract,
+                        )
+                    )
+                context_schema = interface_payload.get("context_schema")
+                if context_schema is not None:
+                    missing_inputs.extend(
+                        validate_context_schema(
+                            root=root,
+                            entry=context_schema,
                         )
                     )
 

--- a/plugins/loom/skills/shared/scripts/loom_check.py
+++ b/plugins/loom/skills/shared/scripts/loom_check.py
@@ -3966,7 +3966,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             (companion_dir / "README.md").write_text("# Legacy Companion Docs\n", encoding="utf-8")
             return
         (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
-        for doc in ("review.md", "merge-ready.md", "closeout.md", "specialized-gates.md"):
+        for doc in (
+            "review.md",
+            "merge-ready.md",
+            "closeout.md",
+            "specialized-gates.md",
+            "checkpoints.md",
+            "metadata-contract.md",
+            "context-schema.md",
+        ):
             (companion_dir / doc).write_text(f"# {doc}\n", encoding="utf-8")
         if manifest is not None:
             write_json(companion_dir / "manifest.json", manifest)
@@ -3978,7 +3986,7 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         "companion_entry": ".loom/companion/README.md",
         "repo_interface": ".loom/companion/repo-interface.json",
     }
-    valid_interface = {
+    valid_interface_v1 = {
         "schema_version": "loom-repo-interface/v1",
         "companion_entry": ".loom/companion/README.md",
         "repo_specific_requirements": {
@@ -4014,6 +4022,41 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "locator": ".loom/companion/specialized-gates.md",
             }
         ],
+    }
+    valid_interface_v2 = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": valid_interface_v1["repo_specific_requirements"],
+        "specialized_gates": [
+            {
+                "id": "specialized-review-gate",
+                "summary": "Companion-owned review specialization.",
+                "locator": ".loom/companion/specialized-gates.md",
+                "gate_type": "review",
+            }
+        ],
+        "metadata_contract": {
+            "fields": [
+                {
+                    "id": "integration_check",
+                    "summary": "Declare repo-specific integration metadata.",
+                    "applicability_locator": ".loom/companion/metadata-contract.md",
+                    "authority_locator": ".loom/companion/review.md",
+                    "enforcement": "blocking",
+                }
+            ]
+        },
+        "context_schema": {
+            "fields": [
+                {
+                    "id": "item_key",
+                    "summary": "Repo-native item key.",
+                    "type": "string",
+                    "required": True,
+                    "mapping_rule_locator": ".loom/companion/context-schema.md",
+                }
+            ]
+        },
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -4100,23 +4143,93 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interface, dict) or invalid_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid repo companion interface sample must report `availability: incomplete`"))
 
-        present_target = base / "present"
+        invalid_v2_target = base / "invalid-v2-interface"
+        shutil.copytree(example_target, invalid_v2_target)
+        install_companion(
+            invalid_v2_target,
+            manifest=valid_manifest,
+            repo_interface={
+                "schema_version": "loom-repo-interface/v2",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_specific_requirements": valid_interface_v1["repo_specific_requirements"],
+                "specialized_gates": [
+                    {
+                        "id": "bad-gate-type",
+                        "summary": "Broken gate type",
+                        "locator": ".loom/companion/specialized-gates.md",
+                        "gate_type": "guardian",
+                    }
+                ],
+                "metadata_contract": {
+                    "fields": [
+                        {
+                            "id": "bad-metadata",
+                            "summary": "Broken metadata field",
+                            "applicability_locator": ".loom/companion/metadata-contract.md",
+                            "authority_locator": ".loom/companion/review.md",
+                            "enforcement": "required",
+                        }
+                    ]
+                },
+                "context_schema": {
+                    "fields": [
+                        {
+                            "id": "bad-context",
+                            "summary": "Broken context field",
+                            "type": "object",
+                            "required": "yes",
+                            "mapping_rule_locator": ".loom/companion/context-schema.md",
+                        }
+                    ]
+                },
+            },
+        )
+        invalid_v2_surface = build_governance_surface(invalid_v2_target)
+        invalid_v2_interface = invalid_v2_surface.get("repo_interface")
+        require_repo_interface_payload(
+            failures,
+            category="repo-companion",
+            context="invalid v2 repo companion interface",
+            payload=invalid_v2_interface,
+        )
+        if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        present_v1_target = base / "present-v1"
+        shutil.copytree(example_target, present_v1_target)
+        install_companion(
+            present_v1_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v1,
+        )
+        present_v1_surface = build_governance_surface(present_v1_target)
+        present_v1_interface = present_v1_surface.get("repo_interface")
+        require_repo_interface_payload(
+            failures,
+            category="repo-companion",
+            context="present v1 repo companion",
+            payload=present_v1_interface,
+        )
+        if not isinstance(present_v1_interface, dict) or present_v1_interface.get("availability") != "present":
+            failures.append(Failure("repo-companion", "present v1 repo companion sample must report `availability: present`"))
+
+        present_target = base / "present-v2"
         shutil.copytree(example_target, present_target)
         install_companion(
             present_target,
             manifest=valid_manifest,
-            repo_interface=valid_interface,
+            repo_interface=valid_interface_v2,
         )
         present_surface = build_governance_surface(present_target)
         present_interface = present_surface.get("repo_interface")
         require_repo_interface_payload(
             failures,
             category="repo-companion",
-            context="present repo companion",
+            context="present v2 repo companion",
             payload=present_interface,
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
-            failures.append(Failure("repo-companion", "present repo companion sample must report `availability: present`"))
+            failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -32,10 +32,22 @@ PLANNED_LOCATORS = {
 REPO_INTERFACE_SURFACES = ("review", "merge_ready", "closeout")
 REPO_INTERFACE_AVAILABILITY = {"absent", "companion_docs_only", "incomplete", "present"}
 REPO_INTERFACE_MANIFEST_SCHEMA = "loom-repo-companion-manifest/v1"
-REPO_INTERFACE_SCHEMA = "loom-repo-interface/v1"
+REPO_INTERFACE_V1_SCHEMA = "loom-repo-interface/v1"
+REPO_INTERFACE_V2_SCHEMA = "loom-repo-interface/v2"
+REPO_INTERFACE_SCHEMAS = {REPO_INTERFACE_V1_SCHEMA, REPO_INTERFACE_V2_SCHEMA}
 REPO_INTERFACE_ENFORCEMENT = {"blocking", "advisory"}
+REPO_INTERFACE_GATE_TYPES = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+}
+REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
-REPO_INTERFACE_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
+REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"metadata_contract", "context_schema"}
 
 
 def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -266,6 +278,80 @@ def validate_specialized_gate(
         missing_inputs.append(f"{prefix} locator must be a non-empty string")
     elif not target.exists():
         missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
+    gate_type = entry.get("gate_type")
+    if gate_type is not None and gate_type not in REPO_INTERFACE_GATE_TYPES:
+        missing_inputs.append(
+            f"{prefix} gate_type must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    return missing_inputs
+
+
+def validate_metadata_contract(
+    *,
+    root: Path,
+    entry: object,
+) -> list[str]:
+    prefix = "metadata_contract"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    fields = entry.get("fields")
+    if not isinstance(fields, list):
+        return [f"{prefix} must include `fields` as a list"]
+    missing_inputs: list[str] = []
+    for index, field in enumerate(fields):
+        field_prefix = f"{prefix}.fields[{index}]"
+        if not isinstance(field, dict):
+            missing_inputs.append(f"{field_prefix} must be an object")
+            continue
+        for required in ("id", "summary", "applicability_locator", "authority_locator", "enforcement"):
+            value = field.get(required)
+            if required == "enforcement":
+                continue
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"{field_prefix} missing `{required}`")
+        enforcement = field.get("enforcement")
+        if enforcement not in REPO_INTERFACE_ENFORCEMENT:
+            missing_inputs.append(f"{field_prefix} enforcement must be `blocking` or `advisory`")
+        for locator_field in ("applicability_locator", "authority_locator"):
+            locator, target = resolve_locator(root, field.get(locator_field))
+            if locator is None or target is None:
+                missing_inputs.append(f"{field_prefix} `{locator_field}` must be a non-empty string")
+            elif not target.exists():
+                missing_inputs.append(f"{field_prefix} `{locator_field}` points to missing path `{locator}`")
+    return missing_inputs
+
+
+def validate_context_schema(
+    *,
+    root: Path,
+    entry: object,
+) -> list[str]:
+    prefix = "context_schema"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    fields = entry.get("fields")
+    if not isinstance(fields, list):
+        return [f"{prefix} must include `fields` as a list"]
+    missing_inputs: list[str] = []
+    for index, field in enumerate(fields):
+        field_prefix = f"{prefix}.fields[{index}]"
+        if not isinstance(field, dict):
+            missing_inputs.append(f"{field_prefix} must be an object")
+            continue
+        for required in ("id", "summary", "type", "mapping_rule_locator"):
+            value = field.get(required)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"{field_prefix} missing `{required}`")
+        field_type = field.get("type")
+        if field_type not in REPO_INTERFACE_CONTEXT_TYPES:
+            missing_inputs.append(f"{field_prefix} type must be one of `string`, `integer`, `number`, `boolean`")
+        if not isinstance(field.get("required"), bool):
+            missing_inputs.append(f"{field_prefix} `required` must be a boolean")
+        locator, target = resolve_locator(root, field.get("mapping_rule_locator"))
+        if locator is None or target is None:
+            missing_inputs.append(f"{field_prefix} `mapping_rule_locator` must be a non-empty string")
+        elif not target.exists():
+            missing_inputs.append(f"{field_prefix} `mapping_rule_locator` points to missing path `{locator}`")
     return missing_inputs
 
 
@@ -345,9 +431,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         if interface_payload is None:
             missing_inputs.append("repo companion interface is unreadable")
         else:
-            if interface_payload.get("schema_version") != REPO_INTERFACE_SCHEMA:
-                missing_inputs.append(f"repo companion interface schema must be `{REPO_INTERFACE_SCHEMA}`")
-            extra_interface_keys = sorted(set(interface_payload.keys()) - REPO_INTERFACE_KEYS)
+            interface_schema = interface_payload.get("schema_version")
+            if interface_schema not in REPO_INTERFACE_SCHEMAS:
+                missing_inputs.append(
+                    "repo companion interface schema must be `loom-repo-interface/v1` or `loom-repo-interface/v2`"
+                )
+            allowed_interface_keys = (
+                REPO_INTERFACE_V2_KEYS if interface_schema == REPO_INTERFACE_V2_SCHEMA else REPO_INTERFACE_V1_KEYS
+            )
+            extra_interface_keys = sorted(set(interface_payload.keys()) - allowed_interface_keys)
             if extra_interface_keys:
                 missing_inputs.append(
                     "repo companion interface contains unexpected top-level fields: "
@@ -394,6 +486,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             root=root,
                             entry=entry,
                             index=index,
+                        )
+                    )
+
+            if interface_schema == REPO_INTERFACE_V2_SCHEMA:
+                metadata_contract = interface_payload.get("metadata_contract")
+                if metadata_contract is not None:
+                    missing_inputs.extend(
+                        validate_metadata_contract(
+                            root=root,
+                            entry=metadata_contract,
+                        )
+                    )
+                context_schema = interface_payload.get("context_schema")
+                if context_schema is not None:
+                    missing_inputs.extend(
+                        validate_context_schema(
+                            root=root,
+                            entry=context_schema,
                         )
                     )
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3966,7 +3966,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             (companion_dir / "README.md").write_text("# Legacy Companion Docs\n", encoding="utf-8")
             return
         (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
-        for doc in ("review.md", "merge-ready.md", "closeout.md", "specialized-gates.md"):
+        for doc in (
+            "review.md",
+            "merge-ready.md",
+            "closeout.md",
+            "specialized-gates.md",
+            "checkpoints.md",
+            "metadata-contract.md",
+            "context-schema.md",
+        ):
             (companion_dir / doc).write_text(f"# {doc}\n", encoding="utf-8")
         if manifest is not None:
             write_json(companion_dir / "manifest.json", manifest)
@@ -3978,7 +3986,7 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         "companion_entry": ".loom/companion/README.md",
         "repo_interface": ".loom/companion/repo-interface.json",
     }
-    valid_interface = {
+    valid_interface_v1 = {
         "schema_version": "loom-repo-interface/v1",
         "companion_entry": ".loom/companion/README.md",
         "repo_specific_requirements": {
@@ -4014,6 +4022,41 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "locator": ".loom/companion/specialized-gates.md",
             }
         ],
+    }
+    valid_interface_v2 = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": valid_interface_v1["repo_specific_requirements"],
+        "specialized_gates": [
+            {
+                "id": "specialized-review-gate",
+                "summary": "Companion-owned review specialization.",
+                "locator": ".loom/companion/specialized-gates.md",
+                "gate_type": "review",
+            }
+        ],
+        "metadata_contract": {
+            "fields": [
+                {
+                    "id": "integration_check",
+                    "summary": "Declare repo-specific integration metadata.",
+                    "applicability_locator": ".loom/companion/metadata-contract.md",
+                    "authority_locator": ".loom/companion/review.md",
+                    "enforcement": "blocking",
+                }
+            ]
+        },
+        "context_schema": {
+            "fields": [
+                {
+                    "id": "item_key",
+                    "summary": "Repo-native item key.",
+                    "type": "string",
+                    "required": True,
+                    "mapping_rule_locator": ".loom/companion/context-schema.md",
+                }
+            ]
+        },
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -4100,23 +4143,93 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interface, dict) or invalid_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid repo companion interface sample must report `availability: incomplete`"))
 
-        present_target = base / "present"
+        invalid_v2_target = base / "invalid-v2-interface"
+        shutil.copytree(example_target, invalid_v2_target)
+        install_companion(
+            invalid_v2_target,
+            manifest=valid_manifest,
+            repo_interface={
+                "schema_version": "loom-repo-interface/v2",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_specific_requirements": valid_interface_v1["repo_specific_requirements"],
+                "specialized_gates": [
+                    {
+                        "id": "bad-gate-type",
+                        "summary": "Broken gate type",
+                        "locator": ".loom/companion/specialized-gates.md",
+                        "gate_type": "guardian",
+                    }
+                ],
+                "metadata_contract": {
+                    "fields": [
+                        {
+                            "id": "bad-metadata",
+                            "summary": "Broken metadata field",
+                            "applicability_locator": ".loom/companion/metadata-contract.md",
+                            "authority_locator": ".loom/companion/review.md",
+                            "enforcement": "required",
+                        }
+                    ]
+                },
+                "context_schema": {
+                    "fields": [
+                        {
+                            "id": "bad-context",
+                            "summary": "Broken context field",
+                            "type": "object",
+                            "required": "yes",
+                            "mapping_rule_locator": ".loom/companion/context-schema.md",
+                        }
+                    ]
+                },
+            },
+        )
+        invalid_v2_surface = build_governance_surface(invalid_v2_target)
+        invalid_v2_interface = invalid_v2_surface.get("repo_interface")
+        require_repo_interface_payload(
+            failures,
+            category="repo-companion",
+            context="invalid v2 repo companion interface",
+            payload=invalid_v2_interface,
+        )
+        if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        present_v1_target = base / "present-v1"
+        shutil.copytree(example_target, present_v1_target)
+        install_companion(
+            present_v1_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v1,
+        )
+        present_v1_surface = build_governance_surface(present_v1_target)
+        present_v1_interface = present_v1_surface.get("repo_interface")
+        require_repo_interface_payload(
+            failures,
+            category="repo-companion",
+            context="present v1 repo companion",
+            payload=present_v1_interface,
+        )
+        if not isinstance(present_v1_interface, dict) or present_v1_interface.get("availability") != "present":
+            failures.append(Failure("repo-companion", "present v1 repo companion sample must report `availability: present`"))
+
+        present_target = base / "present-v2"
         shutil.copytree(example_target, present_target)
         install_companion(
             present_target,
             manifest=valid_manifest,
-            repo_interface=valid_interface,
+            repo_interface=valid_interface_v2,
         )
         present_surface = build_governance_surface(present_target)
         present_interface = present_surface.get("repo_interface")
         require_repo_interface_payload(
             failures,
             category="repo-companion",
-            context="present repo companion",
+            context="present v2 repo companion",
             payload=present_interface,
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
-            failures.append(Failure("repo-companion", "present repo companion sample must report `availability: present`"))
+            failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,


### PR DESCRIPTION
## Summary
- 扩展 `.loom/companion/repo-interface.json` 到 `loom-repo-interface/v2`，并保留 `v1` 兼容读取
- 为 typed specialized gates、metadata contract、context schema 补齐 adoption 合同、参考样本与 synthetic validation
- 更新 `governance_surface` 与 `loom_check`，同步插件镜像

## Validation
- python3 tools/loom_check.py
- python3 -m py_compile skills/shared/scripts/governance_surface.py skills/shared/scripts/loom_check.py plugins/loom/skills/shared/scripts/governance_surface.py plugins/loom/skills/shared/scripts/loom_check.py tools/loom_check.py tools/loom_flow.py tools/loom_init.py
- git diff --check

Closes #245