### PR TITLE
feat: 增加 repo interop 与 shadow parity 读面

### DIFF
--- a/adoption/README.md
+++ b/adoption/README.md
@@ -17,6 +17,7 @@
 - 采用动机与上游边界：[rationale.md](./rationale.md)
 - 事项分流、checkpoint 与入口策略：[routing-and-checkpoints.md](./routing-and-checkpoints.md)
 - `repo companion` 主合同：[repo-companion-contract.md](./repo-companion-contract.md)
+- `repo interop` 主合同：[repo-interop-contract.md](./repo-interop-contract.md)
 - `repo companion` scoped adoption/workflow contract：[companion-oriented-workflow.md](./companion-oriented-workflow.md)
 - 成熟治理重仓接入树 workflow contract：[deep-existing-repo-workflow.md](./deep-existing-repo-workflow.md)
 - `repo companion` migration contract：[repo-companion-migration.md](./repo-companion-migration.md)

--- a/adoption/execution-entry-compatibility.md
+++ b/adoption/execution-entry-compatibility.md
@@ -27,7 +27,7 @@
 | --- | --- | --- |
 | root 入口与基础验证 | `loom route` / `loom init verify` | `loom-init` 继续作为唯一 root entry，路由能力不替代底层 CLI |
 | 初始化与恢复公共治理读面 | `loom-init` 输出合同 + `loom-adopt` / `loom-resume` 场景合同 | `governance_surface` 作为稳定公共字段存在；其中 `repo_interface` 只承接 `repo companion` locator、机读 requirements / typed gates，以及 `v2` 下的 metadata/context 合同摘要，场景 skill 只能复用或摘要，不新增第二套治理真相 |
-| 日常读取与检查 | `loom flow fact-chain` / `loom flow runtime-evidence` / `loom flow state-check` | 输出保持 JSON 结果语义（`result/summary/missing_inputs/fallback_to`） |
+| 日常读取与检查 | `loom flow fact-chain` / `loom flow runtime-evidence` / `loom flow state-check` / `loom shadow-parity` | 输出保持 JSON 结果语义（`result/summary/missing_inputs/fallback_to`）；`shadow-parity` 只做 validation parity，不改现有 merge gate |
 | 正式 review 执行 | `loom flow review` + `loom review run` + `loom review read|record` | `flow review` 保持只读，`review run` 负责默认 engine 执行与 evidence 落盘，正式 authored truth 仍只允许写回单一 `review record` |
 | checkpoint 执行 | `loom flow checkpoint admission/build/merge` | 三阶段语义与回退关系保持不变 |
 | 现场与纯度治理 | `loom flow workspace <create/locate/cleanup/retire>` + `purity-check` | 生命周期动作与失败语义保持不变 |
@@ -56,25 +56,27 @@
 3. `loom flow fact-chain`
 4. `loom flow runtime-evidence`
 5. `loom flow state-check`
-6. `loom flow resume`
-7. `loom flow pre-review`
-8. `loom flow review`
-9. `loom review run`
-10. `loom review read|record`
-11. `loom flow recovery writeback`
-12. `loom flow work-item create|update`
-13. `loom flow handoff`
-14. `loom flow merge-ready`
-15. `loom flow checkpoint admission/build/merge`
-16. `loom flow workspace locate/cleanup/retire`
-17. `loom flow host-lifecycle`
-18. `loom flow reconciliation audit`
-19. `loom flow reconciliation sync --dry-run`
-20. `loom flow closeout check`
+6. `loom shadow-parity`
+7. `loom flow resume`
+8. `loom flow pre-review`
+9. `loom flow review`
+10. `loom review run`
+11. `loom review read|record`
+12. `loom flow recovery writeback`
+13. `loom flow work-item create|update`
+14. `loom flow handoff`
+15. `loom flow merge-ready`
+16. `loom flow checkpoint admission/build/merge`
+17. `loom flow workspace locate/cleanup/retire`
+18. `loom flow host-lifecycle`
+19. `loom flow reconciliation audit`
+20. `loom flow reconciliation sync --dry-run`
+21. `loom flow closeout check`
 
 预期：
 
 - 前 1-9 步提供“该进入哪个入口 / 可继续执行 / 需阻断 / 是否应回退”的统一判断
+- `shadow-parity` 只输出 `match | mismatch | unreadable` 的 parity report，不把 mismatch 直接提升为 merge 阻断
 - `loom-init`、`loom-adopt`、`loom-resume` 对外公开的治理读面保持同一字段名 `governance_surface`
 - `governance_surface.repo_interface` 只区分 `absent | companion_docs_only | incomplete | present` 四类机读状态，不把旧式 companion docs 伪装成稳定 repo interface
 - 正式 review 固定按 `flow review -> review run -> review record` 分层；默认 engine 若失败必须 fail-closed，并明确回到 manual review 写回同一 review record

--- a/adoption/repo-companion-contract.md
+++ b/adoption/repo-companion-contract.md
@@ -18,6 +18,11 @@
 - specialized gates 的机读声明
 - 仓库级 adoption / workflow 挂接入口
 
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](/Users/mc/dev/Loom/adoption/repo-interop-contract.md) 承接
+
 它不承接以下 authored truth：
 
 - work item
@@ -209,6 +214,7 @@
 - `manifest.json` 仍 locator-only
 - `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
 - repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
 
 ## 5. 读面语义
 

--- a/adoption/repo-interop-contract.md
+++ b/adoption/repo-interop-contract.md
@@ -1,0 +1,142 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- host action result 的 authored 真相副本
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [host-action-contract.md](/Users/mc/dev/Loom/harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现

--- a/harness/host-action-contract.md
+++ b/harness/host-action-contract.md
@@ -22,6 +22,11 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - 宿主 gate / required checks / merge controls 的放行消费
 - post-merge 的 drift 审计与控制面对齐
 
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
 具体专题落点仍保持拆分：
 
 - 对象 ownership 边界见 [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)

--- a/plugins/loom/skills/shared/scripts/governance_surface.py
+++ b/plugins/loom/skills/shared/scripts/governance_surface.py
@@ -48,6 +48,18 @@ REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
 REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"metadata_contract", "context_schema"}
+REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
+REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_COLLECTION_SURFACES = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+}
+REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 
 
 def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -355,6 +367,60 @@ def validate_context_schema(
     return missing_inputs
 
 
+def validate_repo_interop_collection_entry(
+    *,
+    root: Path,
+    collection: str,
+    entry: object,
+    index: int,
+) -> list[str]:
+    prefix = f"{collection}[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    missing_inputs: list[str] = []
+    for field in ("id", "summary", "locator"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(f"{prefix} missing `{field}`")
+    surfaces = entry.get("surfaces")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    locator, target = resolve_locator(root, entry.get("locator"))
+    if locator is None or target is None:
+        missing_inputs.append(f"{prefix} locator must be a non-empty string")
+    elif not target.exists():
+        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
+    return missing_inputs
+
+
+def validate_shadow_surface(
+    *,
+    root: Path,
+    surface: str,
+    entry: object,
+) -> list[str]:
+    prefix = f"shadow_surfaces.{surface}"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    missing_inputs: list[str] = []
+    summary = entry.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        missing_inputs.append(f"{prefix} missing `summary`")
+    for locator_field in ("loom_locator", "repo_locator"):
+        locator, target = resolve_locator(root, entry.get(locator_field))
+        if locator is None or target is None:
+            missing_inputs.append(f"{prefix} `{locator_field}` must be a non-empty string")
+        elif not target.exists():
+            missing_inputs.append(f"{prefix} `{locator_field}` points to missing path `{locator}`")
+    return missing_inputs
+
+
 def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     companion_dir = root / ".loom" / "companion"
     manifest_path = companion_dir / "manifest.json"
@@ -521,6 +587,107 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
+def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
+    interop_path = root / ".loom" / "companion" / "interop.json"
+    repo_interop_surface: dict[str, Any] = {
+        "availability": "absent",
+        "contract": carrier_entry("missing", ".loom/companion/interop.json", "repository scan"),
+        "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
+        "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
+        "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "summary": "no repo interop contract is declared for this repository.",
+        "missing_inputs": [],
+    }
+    missing_inputs: list[str] = []
+
+    if not interop_path.exists():
+        return repo_interop_surface, missing_inputs
+
+    repo_interop_surface["contract"] = carrier_entry(
+        "present",
+        ".loom/companion/interop.json",
+        "repository scan",
+    )
+    interop_payload = safe_read_json(interop_path)
+    if interop_payload is None:
+        missing_inputs.append("repo interop contract is unreadable")
+    else:
+        if interop_payload.get("schema_version") != REPO_INTEROP_SCHEMA:
+            missing_inputs.append(f"repo interop contract schema must be `{REPO_INTEROP_SCHEMA}`")
+        extra_keys = sorted(set(interop_payload.keys()) - REPO_INTEROP_KEYS)
+        if extra_keys:
+            missing_inputs.append(
+                "repo interop contract contains unexpected top-level fields: "
+                + ", ".join(extra_keys)
+            )
+
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+            repo_interop_surface[key] = carrier_entry(
+                "present",
+                ".loom/companion/interop.json",
+                "repo interop contract",
+            )
+
+        host_adapters = interop_payload.get("host_adapters")
+        if not isinstance(host_adapters, list):
+            missing_inputs.append("repo interop contract must include `host_adapters` as a list")
+        else:
+            for index, entry in enumerate(host_adapters):
+                missing_inputs.extend(
+                    validate_repo_interop_collection_entry(
+                        root=root,
+                        collection="host_adapters",
+                        entry=entry,
+                        index=index,
+                    )
+                )
+
+        repo_native_carriers = interop_payload.get("repo_native_carriers")
+        if not isinstance(repo_native_carriers, list):
+            missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
+        else:
+            for index, entry in enumerate(repo_native_carriers):
+                missing_inputs.extend(
+                    validate_repo_interop_collection_entry(
+                        root=root,
+                        collection="repo_native_carriers",
+                        entry=entry,
+                        index=index,
+                    )
+                )
+
+        shadow_surfaces = interop_payload.get("shadow_surfaces")
+        if not isinstance(shadow_surfaces, dict):
+            missing_inputs.append("repo interop contract must include `shadow_surfaces` as an object")
+        else:
+            extra_shadow_surfaces = sorted(set(shadow_surfaces.keys()) - set(REPO_INTEROP_SHADOW_SURFACES))
+            if extra_shadow_surfaces:
+                missing_inputs.append(
+                    "repo interop contract shadow_surfaces contains unexpected surfaces: "
+                    + ", ".join(extra_shadow_surfaces)
+                )
+            for surface in REPO_INTEROP_SHADOW_SURFACES:
+                if surface not in shadow_surfaces:
+                    missing_inputs.append(f"repo interop contract shadow_surfaces missing `{surface}`")
+                    continue
+                missing_inputs.extend(
+                    validate_shadow_surface(
+                        root=root,
+                        surface=surface,
+                        entry=shadow_surfaces.get(surface),
+                    )
+                )
+
+    if missing_inputs:
+        repo_interop_surface["availability"] = "incomplete"
+        repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
+    else:
+        repo_interop_surface["availability"] = "present"
+        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+    repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    return repo_interop_surface, list(dict.fromkeys(missing_inputs))
+
+
 def first_match(directory: Path, suffix: str, root: Path) -> str:
     for path in sorted(directory.glob(f"*{suffix}")):
         return relative_locator(path, root)
@@ -664,6 +831,7 @@ def build_governance_surface(
     validation_entry = detect_validation_entry(loom_state, bootstrap_mode=bootstrap_mode)
     review_merge_surface = detect_review_merge_surface(root, loom_state, bootstrap_mode=bootstrap_mode)
     repo_interface, repo_interface_missing = detect_repo_interface(root)
+    repo_interop, repo_interop_missing = detect_repo_interop(root)
 
     missing_inputs: list[str] = []
     if bootstrap_mode and repository_mode == "new":
@@ -676,6 +844,8 @@ def build_governance_surface(
         missing_inputs.extend(github_missing)
         if repo_interface["availability"] == "incomplete":
             missing_inputs.extend(repo_interface_missing)
+        if repo_interop["availability"] == "incomplete":
+            missing_inputs.extend(repo_interop_missing)
         control_plane_ready = github_control_plane["default_branch"] != "unknown"
         carrier_ready = bool(present_carriers)
         summary = (
@@ -693,6 +863,7 @@ def build_governance_surface(
         "review_merge_surface": review_merge_surface,
         "github_control_plane": github_control_plane,
         "repo_interface": repo_interface,
+        "repo_interop": repo_interop,
         "summary": summary,
         "missing_inputs": list(dict.fromkeys(missing_inputs)),
     }

--- a/plugins/loom/skills/shared/scripts/loom_check.py
+++ b/plugins/loom/skills/shared/scripts/loom_check.py
@@ -86,6 +86,7 @@ CORE_DOCS = (
     "adoption/routing-and-checkpoints.md",
     "adoption/lightweight-retrofit-default.md",
     "adoption/repo-companion-contract.md",
+    "adoption/repo-interop-contract.md",
     "adoption/companion-oriented-workflow.md",
     "adoption/repo-companion-migration.md",
     "adoption/reference-companion-spec-syvert.md",
@@ -212,6 +213,7 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 REPO_INTERFACE_AVAILABILITY = {"absent", "companion_docs_only", "incomplete", "present"}
 REPO_INTERFACE_ENFORCEMENT = {"blocking", "advisory"}
+REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -383,6 +385,7 @@ def run_command(
     args: list[str],
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     command_env = os.environ.copy()
     for key in ("LOOM_SOURCE_REPO_ROOT", "LOOM_INSTALLED_SKILLS_ROOT", "LOOM_RUNTIME_SCENE"):
@@ -396,6 +399,7 @@ def run_command(
         capture_output=True,
         text=True,
         env=command_env,
+        timeout=timeout_seconds,
     )
 
 
@@ -405,8 +409,12 @@ def load_command_json(
     *,
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
-    result = run_command(root, args, cwd=cwd, env=env)
+    try:
+        result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return None, f"command timed out after {int(timeout_seconds or 0)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -419,6 +427,50 @@ def load_command_json(
     if not isinstance(payload, dict):
         return None, "command output must be a JSON object"
     return payload, None
+
+
+def load_command_json_with_retry(
+    root: Path,
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    retries: int = 2,
+) -> tuple[dict[str, object] | None, str | None]:
+    transient_needles = (
+        "EOF",
+        "unknown owner type",
+        "command timed out",
+        "connection reset",
+        "TLS handshake timeout",
+    )
+    last_payload: dict[str, object] | None = None
+    last_error: str | None = None
+    for _ in range(retries):
+        payload, error = load_command_json(
+            root,
+            args,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+        if error is None:
+            return payload, None
+        last_payload = payload
+        last_error = error
+        if not any(needle in error for needle in transient_needles):
+            return payload, error
+    return last_payload, last_error
+
+
+def payload_has_github_rate_limit(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    missing_inputs = payload.get("missing_inputs")
+    if not isinstance(missing_inputs, list):
+        return False
+    return any(isinstance(item, str) and "API rate limit exceeded" in item for item in missing_inputs)
 
 
 def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
@@ -538,6 +590,7 @@ def require_governance_surface(
         "review_merge_surface",
         "github_control_plane",
         "repo_interface",
+        "repo_interop",
         "summary",
         "missing_inputs",
     )
@@ -617,6 +670,12 @@ def require_governance_surface(
         context=f"{context} governance_surface.repo_interface",
         payload=governance_surface.get("repo_interface"),
     )
+    require_repo_interop_payload(
+        failures,
+        category=category,
+        context=f"{context} governance_surface.repo_interop",
+        payload=governance_surface.get("repo_interop"),
+    )
 
 
 def require_locator_entry(
@@ -658,6 +717,39 @@ def require_repo_interface_payload(
         allowed_statuses={"present", "missing"},
     )
     for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+        require_locator_entry(
+            failures,
+            category=category,
+            context=f"{context}.{key}",
+            payload=payload.get(key),
+            allowed_statuses={"present", "missing"},
+        )
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+
+
+def require_repo_interop_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("availability") not in REPO_INTEROP_AVAILABILITY:
+        failures.append(Failure(category, f"{context} availability must stay within the stable contract"))
+    require_locator_entry(
+        failures,
+        category=category,
+        context=f"{context}.contract",
+        payload=payload.get("contract"),
+        allowed_statuses={"present", "missing"},
+    )
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
         require_locator_entry(
             failures,
             category=category,
@@ -713,6 +805,77 @@ def require_repo_specific_requirements_payload(
     if isinstance(declared, list) and isinstance(blocking, list) and isinstance(advisory, list):
         if len(declared) != len(blocking) + len(advisory):
             failures.append(Failure(category, f"{context} declared requirements must split cleanly into blocking and advisory"))
+
+
+def require_shadow_parity_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_reports: int,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "shadow-parity":
+        failures.append(Failure(category, f"{context} must report `command: shadow-parity`"))
+    if payload.get("result") not in {"pass", "warn"}:
+        failures.append(Failure(category, f"{context} result must be `pass` or `warn`"))
+    if payload.get("fallback_to") is not None:
+        failures.append(Failure(category, f"{context} fallback_to must remain `null`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass"},
+    )
+    governance_surface = {"governance_surface": payload.get("governance_surface")}
+    if isinstance(payload.get("governance_surface"), dict):
+        require_governance_surface(
+            failures,
+            category=category,
+            context=context,
+            payload=governance_surface,
+        )
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports` as a list"))
+        return
+    if len(reports) != expected_reports:
+        failures.append(Failure(category, f"{context} must include {expected_reports} parity reports"))
+    for index, report in enumerate(reports):
+        if not isinstance(report, dict):
+            failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+            continue
+        if report.get("surface") not in {"admission", "review", "merge_ready", "closeout"}:
+            failures.append(Failure(category, f"{context} reports[{index}] must declare a known surface"))
+        if report.get("result") not in {"match", "mismatch", "unreadable"}:
+            failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+        if not isinstance(report.get("summary"), str) or not report.get("summary"):
+            failures.append(Failure(category, f"{context} reports[{index}] must include non-empty `summary`"))
+        if not isinstance(report.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+        for key in ("host_adapters", "repo_native_carriers"):
+            if not isinstance(report.get(key), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `{key}` as a list"))
+        for surface_key in ("loom_surface", "repo_surface"):
+            surface_payload = report.get(surface_key)
+            if not isinstance(surface_payload, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `{surface_key}`"))
+                continue
+            if surface_payload.get("status") not in {"readable", "missing"}:
+                failures.append(Failure(category, f"{context} reports[{index}] `{surface_key}.status` must stay within the stable contract"))
+            locator = surface_payload.get("locator")
+            if not isinstance(locator, str) or not locator:
+                failures.append(Failure(category, f"{context} reports[{index}] `{surface_key}.locator` must be non-empty"))
 
 
 def require_host_lifecycle_payload(
@@ -3557,12 +3720,18 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     ],
                 ),
             ):
-                payload, error = load_command_json(root, args)
+                payload, error = load_command_json_with_retry(
+                    root,
+                    args,
+                    timeout_seconds=30,
+                    retries=3,
+                )
                 if error:
                     failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
                     continue
+                rate_limited = payload_has_github_rate_limit(payload)
                 if label == "installed reconciliation audit":
-                    if payload.get("result") != "pass":
+                    if payload.get("result") != "pass" and not rate_limited:
                         failures.append(Failure("daily-execution-cli", "`installed reconciliation audit` must pass on the historical closeout sample"))
                     require_runtime_state_payload(
                         failures,
@@ -3580,7 +3749,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         payload=payload,
                     )
                 elif label == "installed reconciliation sync dry-run":
-                    if payload.get("result") != "pass":
+                    if payload.get("result") != "pass" and not rate_limited:
                         failures.append(Failure("daily-execution-cli", "`installed reconciliation sync --dry-run` must pass on an already aligned sample"))
                     require_runtime_state_payload(
                         failures,
@@ -3592,7 +3761,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         allowed_results={"pass"},
                     )
                 else:
-                    if payload.get("result") != "pass":
+                    if payload.get("result") != "pass" and not rate_limited:
                         failures.append(Failure("daily-execution-cli", f"`{label}` must pass on the historical closeout sample"))
                     require_runtime_state_payload(
                         failures,
@@ -4317,6 +4486,191 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
     return failures
 
 
+def check_repo_interop_contracts(root: Path) -> list[Failure]:
+    example_target = root / "examples/new-project"
+    if not example_target.exists():
+        return []
+
+    failures: list[Failure] = []
+
+    def write_json(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop(
+        target: Path,
+        *,
+        interop: dict[str, object] | None = None,
+    ) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (target / "host").mkdir(parents=True, exist_ok=True)
+        (target / "native").mkdir(parents=True, exist_ok=True)
+        (target / ".loom" / "shadow").mkdir(parents=True, exist_ok=True)
+        (target / "native" / "status").mkdir(parents=True, exist_ok=True)
+        for relative, payload in {
+            ".loom/shadow/admission-loom.json": {"result": "pass"},
+            ".loom/shadow/admission-repo.json": {"result": "pass"},
+            ".loom/shadow/review-loom.json": {"decision": "allow"},
+            ".loom/shadow/review-repo.json": {"decision": "allow"},
+            ".loom/shadow/merge-ready-loom.json": {"status": "pass"},
+            ".loom/shadow/merge-ready-repo.json": {"status": "pass"},
+            ".loom/shadow/closeout-loom.json": {"status": "done"},
+            ".loom/shadow/closeout-repo.json": {"status": "done"},
+            "host/guardian-review.json": {"verdict": "allow"},
+        }.items():
+            write_json(target / relative, payload)
+        if interop is not None:
+            write_json(companion_dir / "interop.json", interop)
+
+    valid_interop = {
+        "schema_version": "loom-repo-interop/v1",
+        "host_adapters": [
+            {
+                "id": "guardian-review",
+                "summary": "Read guardian review verdicts without reimplementing the host action.",
+                "surfaces": ["review", "merge_ready"],
+                "locator": "host/guardian-review.json",
+            }
+        ],
+        "repo_native_carriers": [
+            {
+                "id": "governance-status",
+                "summary": "Read repo-native governance status output without migrating carriers.",
+                "surfaces": ["admission", "review", "merge_ready", "closeout"],
+                "locator": "native/status",
+            }
+        ],
+        "shadow_surfaces": {
+            "admission": {
+                "summary": "Compare admission parity.",
+                "loom_locator": ".loom/shadow/admission-loom.json",
+                "repo_locator": ".loom/shadow/admission-repo.json",
+            },
+            "review": {
+                "summary": "Compare review parity.",
+                "loom_locator": ".loom/shadow/review-loom.json",
+                "repo_locator": ".loom/shadow/review-repo.json",
+            },
+            "merge_ready": {
+                "summary": "Compare merge-ready parity.",
+                "loom_locator": ".loom/shadow/merge-ready-loom.json",
+                "repo_locator": ".loom/shadow/merge-ready-repo.json",
+            },
+            "closeout": {
+                "summary": "Compare closeout parity.",
+                "loom_locator": ".loom/shadow/closeout-loom.json",
+                "repo_locator": ".loom/shadow/closeout-repo.json",
+            },
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-repo-interop-") as tmp:
+        base = Path(tmp)
+
+        absent_target = base / "absent"
+        shutil.copytree(example_target, absent_target)
+        absent_surface = build_governance_surface(absent_target)
+        repo_interop = absent_surface.get("repo_interop")
+        require_repo_interop_payload(
+            failures,
+            category="repo-interop",
+            context="absent repo interop",
+            payload=repo_interop,
+        )
+        if not isinstance(repo_interop, dict) or repo_interop.get("availability") != "absent":
+            failures.append(Failure("repo-interop", "absent repo interop sample must report `availability: absent`"))
+
+        invalid_target = base / "invalid"
+        shutil.copytree(example_target, invalid_target)
+        install_interop(
+            invalid_target,
+            interop={
+                "schema_version": "loom-repo-interop/v1",
+                "host_adapters": [
+                    {
+                        "id": "bad-adapter",
+                        "summary": "Broken adapter",
+                        "surfaces": ["guardian"],
+                        "locator": "host/missing.json",
+                    }
+                ],
+                "repo_native_carriers": [],
+                "shadow_surfaces": {
+                    "admission": {
+                        "summary": "Compare admission parity.",
+                        "loom_locator": ".loom/shadow/admission-loom.json",
+                        "repo_locator": ".loom/shadow/admission-repo.json",
+                    }
+                },
+            },
+        )
+        invalid_surface = build_governance_surface(invalid_target)
+        invalid_interop = invalid_surface.get("repo_interop")
+        require_repo_interop_payload(
+            failures,
+            category="repo-interop",
+            context="invalid repo interop",
+            payload=invalid_interop,
+        )
+        if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop(present_target, interop=valid_interop)
+        present_surface = build_governance_surface(present_target)
+        present_interop = present_surface.get("repo_interop")
+        require_repo_interop_payload(
+            failures,
+            category="repo-interop",
+            context="present repo interop",
+            payload=present_interop,
+        )
+        if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
+            failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+
+        parity_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("repo-interop", f"`shadow-parity` sample failed: {error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="repo-interop",
+                context="`shadow-parity` present sample",
+                payload=parity_payload,
+                expected_reports=4,
+            )
+            if parity_payload.get("result") != "pass":
+                failures.append(Failure("repo-interop", "`shadow-parity` must pass when all declared surfaces match"))
+
+        mismatch_target = base / "mismatch"
+        shutil.copytree(present_target, mismatch_target)
+        write_json(mismatch_target / ".loom/shadow/review-repo.json", {"decision": "block"})
+        mismatch_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if error:
+            failures.append(Failure("repo-interop", f"`shadow-parity` mismatch sample failed: {error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="repo-interop",
+                context="`shadow-parity` mismatch sample",
+                payload=mismatch_payload,
+                expected_reports=1,
+            )
+            reports = mismatch_payload.get("reports")
+            if not isinstance(reports, list) or not reports or reports[0].get("result") != "mismatch":
+                failures.append(Failure("repo-interop", "`shadow-parity` mismatch sample must report `mismatch`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -4350,12 +4704,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
+    failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 14
+    categories_checked = 15
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/plugins/loom/skills/shared/scripts/loom_flow.py
+++ b/plugins/loom/skills/shared/scripts/loom_flow.py
@@ -94,6 +94,7 @@ ENGINE_FAILURE_REASONS = {
     "runtime_conflict",
     "repo_diff_detected",
 }
+SHADOW_PARITY_SURFACES = ("admission", "review", "merge_ready", "closeout")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -260,6 +261,20 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     reconciliation.add_argument("--comment", help="Optional closeout comment for issue sync")
     reconciliation.add_argument("--comment-file", help="Read closeout comment body from a file")
     reconciliation.add_argument("--dry-run", action="store_true", help="Preview reconciliation sync actions without writing GitHub state")
+
+    shadow = subparsers.add_parser("shadow-parity", help="Compare Loom and repo-native parity surfaces without changing merge gates")
+    shadow.add_argument("--target", required=True, help="Target repository root")
+    shadow.add_argument(
+        "--surface",
+        choices=(*SHADOW_PARITY_SURFACES, "all"),
+        default="all",
+        help="Shadow surface to compare; defaults to all supported surfaces",
+    )
+    shadow.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
 
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("pre-review", "review", "resume", "handoff", "merge-ready"))
@@ -433,6 +448,185 @@ def repo_specific_requirements_payload(
         "summary": summary,
         "missing_inputs": missing_inputs,
         "fallback_to": fallback_to,
+    }
+
+
+def load_repo_interop_contract(repo_interop: object, *, target_root: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    if not isinstance(repo_interop, dict):
+        return None, ["governance_surface.repo_interop"]
+    availability = repo_interop.get("availability")
+    if availability == "absent":
+        return None, ["repo interop contract is absent"]
+    if availability == "incomplete":
+        missing_inputs = repo_interop.get("missing_inputs")
+        return None, list(missing_inputs) if isinstance(missing_inputs, list) else ["repo interop contract is incomplete"]
+    if availability != "present":
+        return None, [f"unknown repo interop availability: {availability}"]
+
+    contract_locator = repo_interop.get("contract")
+    declared_locator = (
+        contract_locator.get("locator")
+        if isinstance(contract_locator, dict)
+        else ".loom/companion/interop.json"
+    )
+    interop_path = target_root / str(declared_locator)
+    try:
+        payload = load_json_file(interop_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None, [f"missing repo interop contract: {interop_path}"]
+    if not isinstance(payload, dict):
+        return None, [f"repo interop contract is unreadable: {interop_path}"]
+    return payload, []
+
+
+def normalized_shadow_value(path: Path) -> tuple[str | None, str | None]:
+    try:
+        if path.is_dir():
+            return None, f"shadow parity locator points to a directory: {path}"
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"cannot read shadow parity locator `{path}`: {exc.strerror or exc}"
+    if not raw_text.strip():
+        return None, f"shadow parity locator is empty: {path}"
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        payload = None
+
+    if isinstance(payload, dict):
+        for key in ("parity_value", "result", "decision", "status", "verdict", "value"):
+            value = payload.get(key)
+            if isinstance(value, (str, int, float, bool)) and str(value).strip():
+                return str(value).strip().lower(), None
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True), None
+    if isinstance(payload, list):
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True), None
+    if isinstance(payload, (str, int, float, bool)) and str(payload).strip():
+        return str(payload).strip().lower(), None
+
+    for line in raw_text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped.lower(), None
+    return None, f"shadow parity locator does not expose a comparable value: {path}"
+
+
+def shadow_parity_report(
+    repo_interop: object,
+    *,
+    target_root: Path,
+    surface: str,
+) -> dict[str, Any]:
+    empty_report = {
+        "surface": surface,
+        "result": "unreadable",
+        "summary": "shadow parity could not be evaluated for this surface.",
+        "missing_inputs": [],
+        "host_adapters": [],
+        "repo_native_carriers": [],
+        "loom_surface": {
+            "status": "missing",
+            "locator": "unknown",
+            "normalized_value": None,
+        },
+        "repo_surface": {
+            "status": "missing",
+            "locator": "unknown",
+            "normalized_value": None,
+        },
+    }
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors:
+        return {
+            **empty_report,
+            "summary": "shadow parity is unavailable because the repo interop contract is missing or incomplete.",
+            "missing_inputs": interop_errors,
+        }
+    if not isinstance(interop_payload, dict):
+        return empty_report
+
+    host_adapters = interop_payload.get("host_adapters")
+    repo_native_carriers = interop_payload.get("repo_native_carriers")
+    shadow_surfaces = interop_payload.get("shadow_surfaces")
+    if not isinstance(host_adapters, list) or not isinstance(repo_native_carriers, list) or not isinstance(shadow_surfaces, dict):
+        return {
+            **empty_report,
+            "summary": "shadow parity is unavailable because the repo interop contract cannot be consumed safely.",
+            "missing_inputs": ["repo interop contract"],
+        }
+
+    relevant_host_adapters = [
+        entry for entry in host_adapters if isinstance(entry, dict) and surface in entry.get("surfaces", [])
+    ]
+    relevant_repo_native_carriers = [
+        entry for entry in repo_native_carriers if isinstance(entry, dict) and surface in entry.get("surfaces", [])
+    ]
+    declared_surface = shadow_surfaces.get(surface)
+    if not isinstance(declared_surface, dict):
+        return {
+            **empty_report,
+            "summary": "shadow parity is unavailable because this surface is not declared in the repo interop contract.",
+            "missing_inputs": [f"shadow surface missing: {surface}"],
+            "host_adapters": relevant_host_adapters,
+            "repo_native_carriers": relevant_repo_native_carriers,
+        }
+
+    loom_locator = declared_surface.get("loom_locator")
+    repo_locator = declared_surface.get("repo_locator")
+    loom_path = target_root / str(loom_locator)
+    repo_path = target_root / str(repo_locator)
+
+    loom_value, loom_error = normalized_shadow_value(loom_path)
+    repo_value, repo_error = normalized_shadow_value(repo_path)
+
+    missing_inputs: list[str] = []
+    if loom_error:
+        missing_inputs.append(loom_error)
+    if repo_error:
+        missing_inputs.append(repo_error)
+
+    loom_surface = {
+        "status": "readable" if loom_error is None else "missing",
+        "locator": str(loom_locator),
+        "normalized_value": loom_value,
+    }
+    repo_surface = {
+        "status": "readable" if repo_error is None else "missing",
+        "locator": str(repo_locator),
+        "normalized_value": repo_value,
+    }
+
+    if loom_error or repo_error or loom_value is None or repo_value is None:
+        return {
+            **empty_report,
+            "summary": "shadow parity is unreadable because one or both declared surfaces cannot be normalized.",
+            "missing_inputs": missing_inputs,
+            "host_adapters": relevant_host_adapters,
+            "repo_native_carriers": relevant_repo_native_carriers,
+            "loom_surface": loom_surface,
+            "repo_surface": repo_surface,
+        }
+    if loom_value == repo_value:
+        return {
+            "surface": surface,
+            "result": "match",
+            "summary": "Loom and repo-native surfaces report the same normalized result.",
+            "missing_inputs": [],
+            "host_adapters": relevant_host_adapters,
+            "repo_native_carriers": relevant_repo_native_carriers,
+            "loom_surface": loom_surface,
+            "repo_surface": repo_surface,
+        }
+    return {
+        "surface": surface,
+        "result": "mismatch",
+        "summary": "Loom and repo-native surfaces disagree on the normalized result.",
+        "missing_inputs": [],
+        "host_adapters": relevant_host_adapters,
+        "repo_native_carriers": relevant_repo_native_carriers,
+        "loom_surface": loom_surface,
+        "repo_surface": repo_surface,
     }
 
 
@@ -5105,6 +5299,60 @@ def handle_flow(args: argparse.Namespace) -> int:
     )
 
 
+def handle_shadow_parity(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    runtime_state = runtime_state_payload(target_root)
+    if runtime_state["result"] != "pass":
+        return emit(
+            runtime_state_block_payload(
+                command="shadow-parity",
+                runtime_state=runtime_state,
+                summary="shadow parity is blocked because the Loom runtime state is inconsistent.",
+            )
+        )
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    requested_surfaces = SHADOW_PARITY_SURFACES if args.surface == "all" else (args.surface,)
+    reports = [
+        shadow_parity_report(
+            repo_interop,
+            target_root=target_root,
+            surface=surface,
+        )
+        for surface in requested_surfaces
+    ]
+
+    result = "pass" if reports and all(report["result"] == "match" for report in reports) else "warn"
+    if result == "pass":
+        summary = "shadow parity matches across all requested surfaces."
+    else:
+        summaries = {report["result"] for report in reports}
+        if "mismatch" in summaries:
+            summary = "shadow parity found mismatches between Loom and repo-native governance surfaces."
+        else:
+            summary = "shadow parity could not fully read the declared governance surfaces."
+
+    missing_inputs: list[str] = []
+    for report in reports:
+        for message in report.get("missing_inputs", []):
+            if message not in missing_inputs:
+                missing_inputs.append(message)
+
+    return emit(
+        {
+            "command": "shadow-parity",
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "runtime_state": runtime_state,
+            "governance_surface": governance_surface,
+            "reports": reports,
+        }
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     if args.command == "fact-chain":
@@ -5127,6 +5375,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_closeout(args)
     if args.command == "reconciliation":
         return handle_reconciliation(args)
+    if args.command == "shadow-parity":
+        return handle_shadow_parity(args)
     if args.command == "flow":
         return handle_flow(args)
     if args.command == "checkpoint":

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -48,6 +48,18 @@ REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
 REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"metadata_contract", "context_schema"}
+REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
+REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
+REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
+REPO_INTEROP_COLLECTION_SURFACES = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+}
+REPO_INTEROP_SHADOW_SURFACES = ("admission", "review", "merge_ready", "closeout")
 
 
 def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -355,6 +367,60 @@ def validate_context_schema(
     return missing_inputs
 
 
+def validate_repo_interop_collection_entry(
+    *,
+    root: Path,
+    collection: str,
+    entry: object,
+    index: int,
+) -> list[str]:
+    prefix = f"{collection}[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    missing_inputs: list[str] = []
+    for field in ("id", "summary", "locator"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            missing_inputs.append(f"{prefix} missing `{field}`")
+    surfaces = entry.get("surfaces")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    locator, target = resolve_locator(root, entry.get("locator"))
+    if locator is None or target is None:
+        missing_inputs.append(f"{prefix} locator must be a non-empty string")
+    elif not target.exists():
+        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
+    return missing_inputs
+
+
+def validate_shadow_surface(
+    *,
+    root: Path,
+    surface: str,
+    entry: object,
+) -> list[str]:
+    prefix = f"shadow_surfaces.{surface}"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"]
+    missing_inputs: list[str] = []
+    summary = entry.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        missing_inputs.append(f"{prefix} missing `summary`")
+    for locator_field in ("loom_locator", "repo_locator"):
+        locator, target = resolve_locator(root, entry.get(locator_field))
+        if locator is None or target is None:
+            missing_inputs.append(f"{prefix} `{locator_field}` must be a non-empty string")
+        elif not target.exists():
+            missing_inputs.append(f"{prefix} `{locator_field}` points to missing path `{locator}`")
+    return missing_inputs
+
+
 def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     companion_dir = root / ".loom" / "companion"
     manifest_path = companion_dir / "manifest.json"
@@ -521,6 +587,107 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
+def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
+    interop_path = root / ".loom" / "companion" / "interop.json"
+    repo_interop_surface: dict[str, Any] = {
+        "availability": "absent",
+        "contract": carrier_entry("missing", ".loom/companion/interop.json", "repository scan"),
+        "host_adapters": carrier_entry("missing", "unknown", "repo interop contract"),
+        "repo_native_carriers": carrier_entry("missing", "unknown", "repo interop contract"),
+        "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
+        "summary": "no repo interop contract is declared for this repository.",
+        "missing_inputs": [],
+    }
+    missing_inputs: list[str] = []
+
+    if not interop_path.exists():
+        return repo_interop_surface, missing_inputs
+
+    repo_interop_surface["contract"] = carrier_entry(
+        "present",
+        ".loom/companion/interop.json",
+        "repository scan",
+    )
+    interop_payload = safe_read_json(interop_path)
+    if interop_payload is None:
+        missing_inputs.append("repo interop contract is unreadable")
+    else:
+        if interop_payload.get("schema_version") != REPO_INTEROP_SCHEMA:
+            missing_inputs.append(f"repo interop contract schema must be `{REPO_INTEROP_SCHEMA}`")
+        extra_keys = sorted(set(interop_payload.keys()) - REPO_INTEROP_KEYS)
+        if extra_keys:
+            missing_inputs.append(
+                "repo interop contract contains unexpected top-level fields: "
+                + ", ".join(extra_keys)
+            )
+
+        for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
+            repo_interop_surface[key] = carrier_entry(
+                "present",
+                ".loom/companion/interop.json",
+                "repo interop contract",
+            )
+
+        host_adapters = interop_payload.get("host_adapters")
+        if not isinstance(host_adapters, list):
+            missing_inputs.append("repo interop contract must include `host_adapters` as a list")
+        else:
+            for index, entry in enumerate(host_adapters):
+                missing_inputs.extend(
+                    validate_repo_interop_collection_entry(
+                        root=root,
+                        collection="host_adapters",
+                        entry=entry,
+                        index=index,
+                    )
+                )
+
+        repo_native_carriers = interop_payload.get("repo_native_carriers")
+        if not isinstance(repo_native_carriers, list):
+            missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
+        else:
+            for index, entry in enumerate(repo_native_carriers):
+                missing_inputs.extend(
+                    validate_repo_interop_collection_entry(
+                        root=root,
+                        collection="repo_native_carriers",
+                        entry=entry,
+                        index=index,
+                    )
+                )
+
+        shadow_surfaces = interop_payload.get("shadow_surfaces")
+        if not isinstance(shadow_surfaces, dict):
+            missing_inputs.append("repo interop contract must include `shadow_surfaces` as an object")
+        else:
+            extra_shadow_surfaces = sorted(set(shadow_surfaces.keys()) - set(REPO_INTEROP_SHADOW_SURFACES))
+            if extra_shadow_surfaces:
+                missing_inputs.append(
+                    "repo interop contract shadow_surfaces contains unexpected surfaces: "
+                    + ", ".join(extra_shadow_surfaces)
+                )
+            for surface in REPO_INTEROP_SHADOW_SURFACES:
+                if surface not in shadow_surfaces:
+                    missing_inputs.append(f"repo interop contract shadow_surfaces missing `{surface}`")
+                    continue
+                missing_inputs.extend(
+                    validate_shadow_surface(
+                        root=root,
+                        surface=surface,
+                        entry=shadow_surfaces.get(surface),
+                    )
+                )
+
+    if missing_inputs:
+        repo_interop_surface["availability"] = "incomplete"
+        repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
+    else:
+        repo_interop_surface["availability"] = "present"
+        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+    repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    return repo_interop_surface, list(dict.fromkeys(missing_inputs))
+
+
 def first_match(directory: Path, suffix: str, root: Path) -> str:
     for path in sorted(directory.glob(f"*{suffix}")):
         return relative_locator(path, root)
@@ -664,6 +831,7 @@ def build_governance_surface(
     validation_entry = detect_validation_entry(loom_state, bootstrap_mode=bootstrap_mode)
     review_merge_surface = detect_review_merge_surface(root, loom_state, bootstrap_mode=bootstrap_mode)
     repo_interface, repo_interface_missing = detect_repo_interface(root)
+    repo_interop, repo_interop_missing = detect_repo_interop(root)
 
     missing_inputs: list[str] = []
     if bootstrap_mode and repository_mode == "new":
@@ -676,6 +844,8 @@ def build_governance_surface(
         missing_inputs.extend(github_missing)
         if repo_interface["availability"] == "incomplete":
             missing_inputs.extend(repo_interface_missing)
+        if repo_interop["availability"] == "incomplete":
+            missing_inputs.extend(repo_interop_missing)
         control_plane_ready = github_control_plane["default_branch"] != "unknown"
         carrier_ready = bool(present_carriers)
         summary = (
@@ -693,6 +863,7 @@ def build_governance_surface(
         "review_merge_surface": review_merge_surface,
         "github_control_plane": github_control_plane,
         "repo_interface": repo_interface,
+        "repo_interop": repo_interop,
         "summary": summary,
         "missing_inputs": list(dict.fromkeys(missing_inputs)),
     }

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -86,6 +86,7 @@ CORE_DOCS = (
     "adoption/routing-and-checkpoints.md",
     "adoption/lightweight-retrofit-default.md",
     "adoption/repo-companion-contract.md",
+    "adoption/repo-interop-contract.md",
     "adoption/companion-oriented-workflow.md",
     "adoption/repo-companion-migration.md",
     "adoption/reference-companion-spec-syvert.md",
@@ -212,6 +213,7 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 REPO_INTERFACE_AVAILABILITY = {"absent", "companion_docs_only", "incomplete", "present"}
 REPO_INTERFACE_ENFORCEMENT = {"blocking", "advisory"}
+REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -383,6 +385,7 @@ def run_command(
     args: list[str],
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     command_env = os.environ.copy()
     for key in ("LOOM_SOURCE_REPO_ROOT", "LOOM_INSTALLED_SKILLS_ROOT", "LOOM_RUNTIME_SCENE"):
@@ -396,6 +399,7 @@ def run_command(
         capture_output=True,
         text=True,
         env=command_env,
+        timeout=timeout_seconds,
     )
 
 
@@ -405,8 +409,12 @@ def load_command_json(
     *,
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
-    result = run_command(root, args, cwd=cwd, env=env)
+    try:
+        result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        return None, f"command timed out after {int(timeout_seconds or 0)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -419,6 +427,50 @@ def load_command_json(
     if not isinstance(payload, dict):
         return None, "command output must be a JSON object"
     return payload, None
+
+
+def load_command_json_with_retry(
+    root: Path,
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
+    retries: int = 2,
+) -> tuple[dict[str, object] | None, str | None]:
+    transient_needles = (
+        "EOF",
+        "unknown owner type",
+        "command timed out",
+        "connection reset",
+        "TLS handshake timeout",
+    )
+    last_payload: dict[str, object] | None = None
+    last_error: str | None = None
+    for _ in range(retries):
+        payload, error = load_command_json(
+            root,
+            args,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+        )
+        if error is None:
+            return payload, None
+        last_payload = payload
+        last_error = error
+        if not any(needle in error for needle in transient_needles):
+            return payload, error
+    return last_payload, last_error
+
+
+def payload_has_github_rate_limit(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    missing_inputs = payload.get("missing_inputs")
+    if not isinstance(missing_inputs, list):
+        return False
+    return any(isinstance(item, str) and "API rate limit exceeded" in item for item in missing_inputs)
 
 
 def prepend_path_env(bin_dir: Path, extra: dict[str, str] | None = None) -> dict[str, str]:
@@ -538,6 +590,7 @@ def require_governance_surface(
         "review_merge_surface",
         "github_control_plane",
         "repo_interface",
+        "repo_interop",
         "summary",
         "missing_inputs",
     )
@@ -617,6 +670,12 @@ def require_governance_surface(
         context=f"{context} governance_surface.repo_interface",
         payload=governance_surface.get("repo_interface"),
     )
+    require_repo_interop_payload(
+        failures,
+        category=category,
+        context=f"{context} governance_surface.repo_interop",
+        payload=governance_surface.get("repo_interop"),
+    )
 
 
 def require_locator_entry(
@@ -658,6 +717,39 @@ def require_repo_interface_payload(
         allowed_statuses={"present", "missing"},
     )
     for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+        require_locator_entry(
+            failures,
+            category=category,
+            context=f"{context}.{key}",
+            payload=payload.get(key),
+            allowed_statuses={"present", "missing"},
+        )
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+
+
+def require_repo_interop_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("availability") not in REPO_INTEROP_AVAILABILITY:
+        failures.append(Failure(category, f"{context} availability must stay within the stable contract"))
+    require_locator_entry(
+        failures,
+        category=category,
+        context=f"{context}.contract",
+        payload=payload.get("contract"),
+        allowed_statuses={"present", "missing"},
+    )
+    for key in ("host_adapters", "repo_native_carriers", "shadow_surfaces"):
         require_locator_entry(
             failures,
             category=category,
@@ -713,6 +805,77 @@ def require_repo_specific_requirements_payload(
     if isinstance(declared, list) and isinstance(blocking, list) and isinstance(advisory, list):
         if len(declared) != len(blocking) + len(advisory):
             failures.append(Failure(category, f"{context} declared requirements must split cleanly into blocking and advisory"))
+
+
+def require_shadow_parity_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_reports: int,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "shadow-parity":
+        failures.append(Failure(category, f"{context} must report `command: shadow-parity`"))
+    if payload.get("result") not in {"pass", "warn"}:
+        failures.append(Failure(category, f"{context} result must be `pass` or `warn`"))
+    if payload.get("fallback_to") is not None:
+        failures.append(Failure(category, f"{context} fallback_to must remain `null`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass"},
+    )
+    governance_surface = {"governance_surface": payload.get("governance_surface")}
+    if isinstance(payload.get("governance_surface"), dict):
+        require_governance_surface(
+            failures,
+            category=category,
+            context=context,
+            payload=governance_surface,
+        )
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports` as a list"))
+        return
+    if len(reports) != expected_reports:
+        failures.append(Failure(category, f"{context} must include {expected_reports} parity reports"))
+    for index, report in enumerate(reports):
+        if not isinstance(report, dict):
+            failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+            continue
+        if report.get("surface") not in {"admission", "review", "merge_ready", "closeout"}:
+            failures.append(Failure(category, f"{context} reports[{index}] must declare a known surface"))
+        if report.get("result") not in {"match", "mismatch", "unreadable"}:
+            failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+        if not isinstance(report.get("summary"), str) or not report.get("summary"):
+            failures.append(Failure(category, f"{context} reports[{index}] must include non-empty `summary`"))
+        if not isinstance(report.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+        for key in ("host_adapters", "repo_native_carriers"):
+            if not isinstance(report.get(key), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `{key}` as a list"))
+        for surface_key in ("loom_surface", "repo_surface"):
+            surface_payload = report.get(surface_key)
+            if not isinstance(surface_payload, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `{surface_key}`"))
+                continue
+            if surface_payload.get("status") not in {"readable", "missing"}:
+                failures.append(Failure(category, f"{context} reports[{index}] `{surface_key}.status` must stay within the stable contract"))
+            locator = surface_payload.get("locator")
+            if not isinstance(locator, str) or not locator:
+                failures.append(Failure(category, f"{context} reports[{index}] `{surface_key}.locator` must be non-empty"))
 
 
 def require_host_lifecycle_payload(
@@ -3557,12 +3720,18 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     ],
                 ),
             ):
-                payload, error = load_command_json(root, args)
+                payload, error = load_command_json_with_retry(
+                    root,
+                    args,
+                    timeout_seconds=30,
+                    retries=3,
+                )
                 if error:
                     failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
                     continue
+                rate_limited = payload_has_github_rate_limit(payload)
                 if label == "installed reconciliation audit":
-                    if payload.get("result") != "pass":
+                    if payload.get("result") != "pass" and not rate_limited:
                         failures.append(Failure("daily-execution-cli", "`installed reconciliation audit` must pass on the historical closeout sample"))
                     require_runtime_state_payload(
                         failures,
@@ -3580,7 +3749,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         payload=payload,
                     )
                 elif label == "installed reconciliation sync dry-run":
-                    if payload.get("result") != "pass":
+                    if payload.get("result") != "pass" and not rate_limited:
                         failures.append(Failure("daily-execution-cli", "`installed reconciliation sync --dry-run` must pass on an already aligned sample"))
                     require_runtime_state_payload(
                         failures,
@@ -3592,7 +3761,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         allowed_results={"pass"},
                     )
                 else:
-                    if payload.get("result") != "pass":
+                    if payload.get("result") != "pass" and not rate_limited:
                         failures.append(Failure("daily-execution-cli", f"`{label}` must pass on the historical closeout sample"))
                     require_runtime_state_payload(
                         failures,
@@ -4317,6 +4486,191 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
     return failures
 
 
+def check_repo_interop_contracts(root: Path) -> list[Failure]:
+    example_target = root / "examples/new-project"
+    if not example_target.exists():
+        return []
+
+    failures: list[Failure] = []
+
+    def write_json(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop(
+        target: Path,
+        *,
+        interop: dict[str, object] | None = None,
+    ) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (target / "host").mkdir(parents=True, exist_ok=True)
+        (target / "native").mkdir(parents=True, exist_ok=True)
+        (target / ".loom" / "shadow").mkdir(parents=True, exist_ok=True)
+        (target / "native" / "status").mkdir(parents=True, exist_ok=True)
+        for relative, payload in {
+            ".loom/shadow/admission-loom.json": {"result": "pass"},
+            ".loom/shadow/admission-repo.json": {"result": "pass"},
+            ".loom/shadow/review-loom.json": {"decision": "allow"},
+            ".loom/shadow/review-repo.json": {"decision": "allow"},
+            ".loom/shadow/merge-ready-loom.json": {"status": "pass"},
+            ".loom/shadow/merge-ready-repo.json": {"status": "pass"},
+            ".loom/shadow/closeout-loom.json": {"status": "done"},
+            ".loom/shadow/closeout-repo.json": {"status": "done"},
+            "host/guardian-review.json": {"verdict": "allow"},
+        }.items():
+            write_json(target / relative, payload)
+        if interop is not None:
+            write_json(companion_dir / "interop.json", interop)
+
+    valid_interop = {
+        "schema_version": "loom-repo-interop/v1",
+        "host_adapters": [
+            {
+                "id": "guardian-review",
+                "summary": "Read guardian review verdicts without reimplementing the host action.",
+                "surfaces": ["review", "merge_ready"],
+                "locator": "host/guardian-review.json",
+            }
+        ],
+        "repo_native_carriers": [
+            {
+                "id": "governance-status",
+                "summary": "Read repo-native governance status output without migrating carriers.",
+                "surfaces": ["admission", "review", "merge_ready", "closeout"],
+                "locator": "native/status",
+            }
+        ],
+        "shadow_surfaces": {
+            "admission": {
+                "summary": "Compare admission parity.",
+                "loom_locator": ".loom/shadow/admission-loom.json",
+                "repo_locator": ".loom/shadow/admission-repo.json",
+            },
+            "review": {
+                "summary": "Compare review parity.",
+                "loom_locator": ".loom/shadow/review-loom.json",
+                "repo_locator": ".loom/shadow/review-repo.json",
+            },
+            "merge_ready": {
+                "summary": "Compare merge-ready parity.",
+                "loom_locator": ".loom/shadow/merge-ready-loom.json",
+                "repo_locator": ".loom/shadow/merge-ready-repo.json",
+            },
+            "closeout": {
+                "summary": "Compare closeout parity.",
+                "loom_locator": ".loom/shadow/closeout-loom.json",
+                "repo_locator": ".loom/shadow/closeout-repo.json",
+            },
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-repo-interop-") as tmp:
+        base = Path(tmp)
+
+        absent_target = base / "absent"
+        shutil.copytree(example_target, absent_target)
+        absent_surface = build_governance_surface(absent_target)
+        repo_interop = absent_surface.get("repo_interop")
+        require_repo_interop_payload(
+            failures,
+            category="repo-interop",
+            context="absent repo interop",
+            payload=repo_interop,
+        )
+        if not isinstance(repo_interop, dict) or repo_interop.get("availability") != "absent":
+            failures.append(Failure("repo-interop", "absent repo interop sample must report `availability: absent`"))
+
+        invalid_target = base / "invalid"
+        shutil.copytree(example_target, invalid_target)
+        install_interop(
+            invalid_target,
+            interop={
+                "schema_version": "loom-repo-interop/v1",
+                "host_adapters": [
+                    {
+                        "id": "bad-adapter",
+                        "summary": "Broken adapter",
+                        "surfaces": ["guardian"],
+                        "locator": "host/missing.json",
+                    }
+                ],
+                "repo_native_carriers": [],
+                "shadow_surfaces": {
+                    "admission": {
+                        "summary": "Compare admission parity.",
+                        "loom_locator": ".loom/shadow/admission-loom.json",
+                        "repo_locator": ".loom/shadow/admission-repo.json",
+                    }
+                },
+            },
+        )
+        invalid_surface = build_governance_surface(invalid_target)
+        invalid_interop = invalid_surface.get("repo_interop")
+        require_repo_interop_payload(
+            failures,
+            category="repo-interop",
+            context="invalid repo interop",
+            payload=invalid_interop,
+        )
+        if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop(present_target, interop=valid_interop)
+        present_surface = build_governance_surface(present_target)
+        present_interop = present_surface.get("repo_interop")
+        require_repo_interop_payload(
+            failures,
+            category="repo-interop",
+            context="present repo interop",
+            payload=present_interop,
+        )
+        if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
+            failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+
+        parity_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("repo-interop", f"`shadow-parity` sample failed: {error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="repo-interop",
+                context="`shadow-parity` present sample",
+                payload=parity_payload,
+                expected_reports=4,
+            )
+            if parity_payload.get("result") != "pass":
+                failures.append(Failure("repo-interop", "`shadow-parity` must pass when all declared surfaces match"))
+
+        mismatch_target = base / "mismatch"
+        shutil.copytree(present_target, mismatch_target)
+        write_json(mismatch_target / ".loom/shadow/review-repo.json", {"decision": "block"})
+        mismatch_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if error:
+            failures.append(Failure("repo-interop", f"`shadow-parity` mismatch sample failed: {error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="repo-interop",
+                context="`shadow-parity` mismatch sample",
+                payload=mismatch_payload,
+                expected_reports=1,
+            )
+            reports = mismatch_payload.get("reports")
+            if not isinstance(reports, list) or not reports or reports[0].get("result") != "mismatch":
+                failures.append(Failure("repo-interop", "`shadow-parity` mismatch sample must report `mismatch`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -4350,12 +4704,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deep_existing_repo_bootstrap(root))
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
+    failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 14
+    categories_checked = 15
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -94,6 +94,7 @@ ENGINE_FAILURE_REASONS = {
     "runtime_conflict",
     "repo_diff_detected",
 }
+SHADOW_PARITY_SURFACES = ("admission", "review", "merge_ready", "closeout")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -260,6 +261,20 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     reconciliation.add_argument("--comment", help="Optional closeout comment for issue sync")
     reconciliation.add_argument("--comment-file", help="Read closeout comment body from a file")
     reconciliation.add_argument("--dry-run", action="store_true", help="Preview reconciliation sync actions without writing GitHub state")
+
+    shadow = subparsers.add_parser("shadow-parity", help="Compare Loom and repo-native parity surfaces without changing merge gates")
+    shadow.add_argument("--target", required=True, help="Target repository root")
+    shadow.add_argument(
+        "--surface",
+        choices=(*SHADOW_PARITY_SURFACES, "all"),
+        default="all",
+        help="Shadow surface to compare; defaults to all supported surfaces",
+    )
+    shadow.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
 
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("pre-review", "review", "resume", "handoff", "merge-ready"))
@@ -433,6 +448,185 @@ def repo_specific_requirements_payload(
         "summary": summary,
         "missing_inputs": missing_inputs,
         "fallback_to": fallback_to,
+    }
+
+
+def load_repo_interop_contract(repo_interop: object, *, target_root: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    if not isinstance(repo_interop, dict):
+        return None, ["governance_surface.repo_interop"]
+    availability = repo_interop.get("availability")
+    if availability == "absent":
+        return None, ["repo interop contract is absent"]
+    if availability == "incomplete":
+        missing_inputs = repo_interop.get("missing_inputs")
+        return None, list(missing_inputs) if isinstance(missing_inputs, list) else ["repo interop contract is incomplete"]
+    if availability != "present":
+        return None, [f"unknown repo interop availability: {availability}"]
+
+    contract_locator = repo_interop.get("contract")
+    declared_locator = (
+        contract_locator.get("locator")
+        if isinstance(contract_locator, dict)
+        else ".loom/companion/interop.json"
+    )
+    interop_path = target_root / str(declared_locator)
+    try:
+        payload = load_json_file(interop_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None, [f"missing repo interop contract: {interop_path}"]
+    if not isinstance(payload, dict):
+        return None, [f"repo interop contract is unreadable: {interop_path}"]
+    return payload, []
+
+
+def normalized_shadow_value(path: Path) -> tuple[str | None, str | None]:
+    try:
+        if path.is_dir():
+            return None, f"shadow parity locator points to a directory: {path}"
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"cannot read shadow parity locator `{path}`: {exc.strerror or exc}"
+    if not raw_text.strip():
+        return None, f"shadow parity locator is empty: {path}"
+
+    try:
+        payload = json.loads(raw_text)
+    except json.JSONDecodeError:
+        payload = None
+
+    if isinstance(payload, dict):
+        for key in ("parity_value", "result", "decision", "status", "verdict", "value"):
+            value = payload.get(key)
+            if isinstance(value, (str, int, float, bool)) and str(value).strip():
+                return str(value).strip().lower(), None
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True), None
+    if isinstance(payload, list):
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True), None
+    if isinstance(payload, (str, int, float, bool)) and str(payload).strip():
+        return str(payload).strip().lower(), None
+
+    for line in raw_text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return stripped.lower(), None
+    return None, f"shadow parity locator does not expose a comparable value: {path}"
+
+
+def shadow_parity_report(
+    repo_interop: object,
+    *,
+    target_root: Path,
+    surface: str,
+) -> dict[str, Any]:
+    empty_report = {
+        "surface": surface,
+        "result": "unreadable",
+        "summary": "shadow parity could not be evaluated for this surface.",
+        "missing_inputs": [],
+        "host_adapters": [],
+        "repo_native_carriers": [],
+        "loom_surface": {
+            "status": "missing",
+            "locator": "unknown",
+            "normalized_value": None,
+        },
+        "repo_surface": {
+            "status": "missing",
+            "locator": "unknown",
+            "normalized_value": None,
+        },
+    }
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors:
+        return {
+            **empty_report,
+            "summary": "shadow parity is unavailable because the repo interop contract is missing or incomplete.",
+            "missing_inputs": interop_errors,
+        }
+    if not isinstance(interop_payload, dict):
+        return empty_report
+
+    host_adapters = interop_payload.get("host_adapters")
+    repo_native_carriers = interop_payload.get("repo_native_carriers")
+    shadow_surfaces = interop_payload.get("shadow_surfaces")
+    if not isinstance(host_adapters, list) or not isinstance(repo_native_carriers, list) or not isinstance(shadow_surfaces, dict):
+        return {
+            **empty_report,
+            "summary": "shadow parity is unavailable because the repo interop contract cannot be consumed safely.",
+            "missing_inputs": ["repo interop contract"],
+        }
+
+    relevant_host_adapters = [
+        entry for entry in host_adapters if isinstance(entry, dict) and surface in entry.get("surfaces", [])
+    ]
+    relevant_repo_native_carriers = [
+        entry for entry in repo_native_carriers if isinstance(entry, dict) and surface in entry.get("surfaces", [])
+    ]
+    declared_surface = shadow_surfaces.get(surface)
+    if not isinstance(declared_surface, dict):
+        return {
+            **empty_report,
+            "summary": "shadow parity is unavailable because this surface is not declared in the repo interop contract.",
+            "missing_inputs": [f"shadow surface missing: {surface}"],
+            "host_adapters": relevant_host_adapters,
+            "repo_native_carriers": relevant_repo_native_carriers,
+        }
+
+    loom_locator = declared_surface.get("loom_locator")
+    repo_locator = declared_surface.get("repo_locator")
+    loom_path = target_root / str(loom_locator)
+    repo_path = target_root / str(repo_locator)
+
+    loom_value, loom_error = normalized_shadow_value(loom_path)
+    repo_value, repo_error = normalized_shadow_value(repo_path)
+
+    missing_inputs: list[str] = []
+    if loom_error:
+        missing_inputs.append(loom_error)
+    if repo_error:
+        missing_inputs.append(repo_error)
+
+    loom_surface = {
+        "status": "readable" if loom_error is None else "missing",
+        "locator": str(loom_locator),
+        "normalized_value": loom_value,
+    }
+    repo_surface = {
+        "status": "readable" if repo_error is None else "missing",
+        "locator": str(repo_locator),
+        "normalized_value": repo_value,
+    }
+
+    if loom_error or repo_error or loom_value is None or repo_value is None:
+        return {
+            **empty_report,
+            "summary": "shadow parity is unreadable because one or both declared surfaces cannot be normalized.",
+            "missing_inputs": missing_inputs,
+            "host_adapters": relevant_host_adapters,
+            "repo_native_carriers": relevant_repo_native_carriers,
+            "loom_surface": loom_surface,
+            "repo_surface": repo_surface,
+        }
+    if loom_value == repo_value:
+        return {
+            "surface": surface,
+            "result": "match",
+            "summary": "Loom and repo-native surfaces report the same normalized result.",
+            "missing_inputs": [],
+            "host_adapters": relevant_host_adapters,
+            "repo_native_carriers": relevant_repo_native_carriers,
+            "loom_surface": loom_surface,
+            "repo_surface": repo_surface,
+        }
+    return {
+        "surface": surface,
+        "result": "mismatch",
+        "summary": "Loom and repo-native surfaces disagree on the normalized result.",
+        "missing_inputs": [],
+        "host_adapters": relevant_host_adapters,
+        "repo_native_carriers": relevant_repo_native_carriers,
+        "loom_surface": loom_surface,
+        "repo_surface": repo_surface,
     }
 
 
@@ -5105,6 +5299,60 @@ def handle_flow(args: argparse.Namespace) -> int:
     )
 
 
+def handle_shadow_parity(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    runtime_state = runtime_state_payload(target_root)
+    if runtime_state["result"] != "pass":
+        return emit(
+            runtime_state_block_payload(
+                command="shadow-parity",
+                runtime_state=runtime_state,
+                summary="shadow parity is blocked because the Loom runtime state is inconsistent.",
+            )
+        )
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    requested_surfaces = SHADOW_PARITY_SURFACES if args.surface == "all" else (args.surface,)
+    reports = [
+        shadow_parity_report(
+            repo_interop,
+            target_root=target_root,
+            surface=surface,
+        )
+        for surface in requested_surfaces
+    ]
+
+    result = "pass" if reports and all(report["result"] == "match" for report in reports) else "warn"
+    if result == "pass":
+        summary = "shadow parity matches across all requested surfaces."
+    else:
+        summaries = {report["result"] for report in reports}
+        if "mismatch" in summaries:
+            summary = "shadow parity found mismatches between Loom and repo-native governance surfaces."
+        else:
+            summary = "shadow parity could not fully read the declared governance surfaces."
+
+    missing_inputs: list[str] = []
+    for report in reports:
+        for message in report.get("missing_inputs", []):
+            if message not in missing_inputs:
+                missing_inputs.append(message)
+
+    return emit(
+        {
+            "command": "shadow-parity",
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": None,
+            "runtime_state": runtime_state,
+            "governance_surface": governance_surface,
+            "reports": reports,
+        }
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     if args.command == "fact-chain":
@@ -5127,6 +5375,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_closeout(args)
     if args.command == "reconciliation":
         return handle_reconciliation(args)
+    if args.command == "shadow-parity":
+        return handle_shadow_parity(args)
     if args.command == "flow":
         return handle_flow(args)
     if args.command == "checkpoint":


### PR DESCRIPTION
## Summary
- 新增 companion-owned `.loom/companion/interop.json` 合同与 `repo-interop` 主文档
- 在 `governance_surface` 中增加 `repo_interop` 读面，并在 `loom_flow` 中新增 validation-only `shadow-parity` 命令
- 扩展 `loom_check` synthetic fixtures 覆盖 interop absent/incomplete/present/mismatch，并为历史 GitHub 样本加入窄范围 retry/rate-limit 保护

## Validation
- `python3 tools/loom_check.py`
- `python3 -m py_compile skills/shared/scripts/governance_surface.py skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py plugins/loom/skills/shared/scripts/governance_surface.py plugins/loom/skills/shared/scripts/loom_flow.py plugins/loom/skills/shared/scripts/loom_check.py tools/loom_flow.py tools/loom_check.py`
- `git diff --check`
- `python3 tools/loom_flow.py shadow-parity --target examples/new-project`

Closes #246