### PR TITLE
feat: 增加 npm Node installer 与发布门禁

### DIFF
--- a/.github/workflows/loom-check.yml
+++ b/.github/workflows/loom-check.yml
@@ -63,5 +63,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
       - name: Run loom check
         run: make loom-check

--- a/.github/workflows/node-installer-pr.yml
+++ b/.github/workflows/node-installer-pr.yml
@@ -61,4 +61,4 @@ jobs:
         run: npm pack --dry-run
 
       - name: Run loom check
-        run: python3 skills/shared/scripts/loom_check.py
+        run: make loom-check

--- a/.github/workflows/node-installer-pr.yml
+++ b/.github/workflows/node-installer-pr.yml
@@ -1,0 +1,64 @@
+name: node-installer-pr-gate
+
+on:
+  pull_request:
+    paths:
+      - 'packages/loom-installer/**'
+      - 'plugins/loom/**'
+      - 'packages/skills/**'
+      - 'README.md'
+      - 'skills/README.md'
+      - 'skills/distribution-and-adapter-contract.md'
+      - 'skills/shared/scripts/loom_check.py'
+      - 'plugins/loom/skills/README.md'
+      - 'plugins/loom/skills/distribution-and-adapter-contract.md'
+      - 'plugins/loom/skills/shared/scripts/loom_check.py'
+      - '.github/workflows/node-installer-pr.yml'
+      - '.github/workflows/node-installer-release.yml'
+      - '.github/workflows/loom-check.yml'
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin "${{ github.base_ref }}" --depth=1
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install installer dependencies
+        run: npm ci --prefix packages/loom-installer
+
+      - name: Check version bump
+        run: node packages/loom-installer/scripts/check-version-bump.mjs --base "origin/${{ github.base_ref }}"
+
+      - name: Check doc sync
+        run: npm --prefix packages/loom-installer run check:docs
+
+      - name: Check payload drift
+        run: npm --prefix packages/loom-installer run check:payload
+
+      - name: Run installer tests
+        run: npm --prefix packages/loom-installer test
+
+      - name: Run installer pack smoke
+        working-directory: packages/loom-installer
+        run: npm pack --dry-run
+
+      - name: Run loom check
+        run: python3 skills/shared/scripts/loom_check.py

--- a/.github/workflows/node-installer-release.yml
+++ b/.github/workflows/node-installer-release.yml
@@ -1,0 +1,162 @@
+name: node-installer-release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/loom-installer/**'
+      - 'plugins/loom/**'
+      - 'packages/skills/**'
+      - 'README.md'
+      - 'skills/README.md'
+      - 'skills/distribution-and-adapter-contract.md'
+      - 'skills/shared/scripts/loom_check.py'
+      - 'plugins/loom/skills/README.md'
+      - 'plugins/loom/skills/distribution-and-adapter-contract.md'
+      - 'plugins/loom/skills/shared/scripts/loom_check.py'
+      - '.github/workflows/node-installer-release.yml'
+      - '.github/workflows/loom-check.yml'
+
+concurrency:
+  group: node-installer-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      PACKAGE_NAME: '@mc-and-his-agents/loom-installer'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install installer dependencies
+        run: npm ci --prefix packages/loom-installer
+
+      - name: Check doc sync
+        run: npm --prefix packages/loom-installer run check:docs
+
+      - name: Check payload drift
+        run: npm --prefix packages/loom-installer run check:payload
+
+      - name: Run installer tests
+        run: npm --prefix packages/loom-installer test
+
+      - name: Run installer pack smoke
+        working-directory: packages/loom-installer
+        run: npm pack --dry-run
+
+      - name: Run loom check
+        run: python3 skills/shared/scripts/loom_check.py
+
+      - name: Resolve release state
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/loom-installer/package.json', 'utf8')).version)")
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
+          if printf '%s\n' "$CHANGED_FILES" | grep -E '^(packages/loom-installer/src/|packages/loom-installer/scripts/|packages/loom-installer/package.json|plugins/loom/|packages/skills/)' >/dev/null; then
+            echo "behavior_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "behavior_changed=false" >> "$GITHUB_OUTPUT"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "create_release=false" >> "$GITHUB_OUTPUT"
+            echo "reason=no-behavior-change" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            PUBLISHED=true
+          else
+            PUBLISHED=false
+          fi
+
+          TAG_EXISTS=false
+          TAG_MATCHES=false
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            TAG_EXISTS=true
+            TAG_SHA=$(git rev-list -n 1 "refs/tags/${TAG}")
+            if [ "$TAG_SHA" = "${{ github.sha }}" ]; then
+              TAG_MATCHES=true
+            fi
+          fi
+
+          RELEASE_EXISTS=false
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            RELEASE_EXISTS=true
+          fi
+
+          if [ "$PUBLISHED" = false ]; then
+            if [ "$TAG_EXISTS" = true ] || [ "$RELEASE_EXISTS" = true ]; then
+              echo "release state is inconsistent: unpublished npm version already has git tag or GitHub release" >&2
+              exit 1
+            fi
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "create_release=true" >> "$GITHUB_OUTPUT"
+            echo "reason=publish-required" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$TAG_EXISTS" != true ]; then
+            echo "release state is inconsistent: npm version ${VERSION} already exists but git tag ${TAG} is missing" >&2
+            exit 1
+          fi
+          if [ "$TAG_MATCHES" != true ]; then
+            echo "release state is inconsistent: git tag ${TAG} does not point to ${{ github.sha }}" >&2
+            exit 1
+          fi
+
+          echo "published=true" >> "$GITHUB_OUTPUT"
+          echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          if [ "$RELEASE_EXISTS" = true ]; then
+            echo "create_release=false" >> "$GITHUB_OUTPUT"
+            echo "reason=already-published-and-released" >> "$GITHUB_OUTPUT"
+          else
+            echo "create_release=true" >> "$GITHUB_OUTPUT"
+            echo "reason=release-missing" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish npm package
+        if: steps.state.outputs.should_publish == 'true'
+        working-directory: packages/loom-installer
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          LOOM_INSTALLER_BUILD_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
+        run: npm publish --access public
+
+      - name: Create git tag
+        if: steps.state.outputs.should_publish == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "${{ steps.state.outputs.tag }}" -m "Release ${{ steps.state.outputs.tag }}"
+          git push origin "${{ steps.state.outputs.tag }}"
+
+      - name: Create GitHub release
+        if: steps.state.outputs.create_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ steps.state.outputs.tag }}" --title "${{ steps.state.outputs.tag }}" --generate-notes

--- a/.github/workflows/node-installer-release.yml
+++ b/.github/workflows/node-installer-release.yml
@@ -64,7 +64,7 @@ jobs:
         run: npm pack --dry-run
 
       - name: Run loom check
-        run: python3 skills/shared/scripts/loom_check.py
+        run: make loom-check
 
       - name: Resolve release state
         id: state

--- a/README.md
+++ b/README.md
@@ -32,6 +32,37 @@ Loom 面向的是 Agent 执行路径，不要求人类用户手工编排每一�
 
 当接入流程在目标仓库写入 `.loom/` 产物时，会默认把 `.loom/` 追加到 `.gitignore`。
 
+### 用 `npx` 直接接入
+
+如果当前 Agent 环境允许直接执行本地安装命令，可以直接使用 Loom 的 Node installer：
+
+```bash
+npx @mc-and-his-agents/loom-installer add plugin --host codex
+npx @mc-and-his-agents/loom-installer add plugin --host claude
+npx @mc-and-his-agents/loom-installer add skill loom-init --host codex
+npx @mc-and-his-agents/loom-installer add skill loom-init --host claude
+```
+
+运行前提：
+
+- Node `>=20`
+- Python `>=3.10`，推荐 `3.11+`
+
+这条 `npx` 入口只负责安装、发现和验证。
+Loom 当前真实执行面仍然是仓库里的 Python runtime。
+
+### 用 `npm` 安装后再接入
+
+如果你希望先把 installer 固定到当前项目，也可以先安装再执行：
+
+```bash
+npm install -D @mc-and-his-agents/loom-installer
+npx loom-installer add plugin --host codex
+npx loom-installer add plugin --host claude
+npx loom-installer add skill loom-init --host codex
+npx loom-installer add skill loom-init --host claude
+```
+
 ### 完整接入 Loom Plugin
 
 适合场景：

--- a/packages/loom-installer/.gitignore
+++ b/packages/loom-installer/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+payload/
+*.tgz

--- a/packages/loom-installer/README.md
+++ b/packages/loom-installer/README.md
@@ -1,0 +1,47 @@
+# @mc-and-his-agents/loom-installer
+
+Loom 的 npm / npx 安装入口。
+
+它负责两件事：
+
+- 把 Loom 作为完整 plugin 接到 Codex 或 Claude
+- 把某个单独 Loom skill 接到对应宿主
+
+它不替代 Loom 当前的 Python runtime；真正的执行面仍然是仓库里的 Python 脚本与已发布的 skill / plugin 产物。
+
+## 命令面
+
+```bash
+npx @mc-and-his-agents/loom-installer add plugin
+npx @mc-and-his-agents/loom-installer add skill loom-init
+```
+
+也可以先安装再执行：
+
+```bash
+npm install -D @mc-and-his-agents/loom-installer
+npx loom-installer add plugin
+npx loom-installer add skill loom-init
+```
+
+可选参数：
+
+- `--host codex|claude|auto`
+- `--target <repo-root>`
+- `--force`
+- `--json`
+
+## 运行时要求
+
+- Node `>=20`
+- Python `>=3.10`，推荐 `3.11+`
+
+## 发布说明
+
+本包支持 `npm publish`，但发布只在 `main` 上进行。
+
+发布模型：
+
+- PR 只做门禁，不直接发布 npm
+- `main` 是唯一发布真相源
+- publish 成功后再创建同版本 git tag

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,0 +1,54 @@
+{
+  "name": "@mc-and-his-agents/loom-installer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mc-and-his-agents/loom-installer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "loom-installer": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^24.6.0",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@mc-and-his-agents/loom-installer",
+  "version": "0.1.0",
+  "description": "Node installer for Loom plugin and single-skill installation surfaces.",
+  "type": "module",
+  "bin": {
+    "loom-installer": "dist/cli.js"
+  },
+  "files": [
+    "dist",
+    "payload",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "node ./scripts/build-payload.mjs && tsc -p tsconfig.json",
+    "check:docs": "node ./scripts/check-doc-sync.mjs",
+    "check:payload": "node ./scripts/check-payload-drift.mjs",
+    "check:release": "npm run check:docs && npm run check:payload",
+    "prepack": "npm run build",
+    "prepublishOnly": "npm test && npm run check:release",
+    "test": "npm run build && node --test dist/test/**/*.test.js"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.9.3"
+  },
+  "keywords": [
+    "loom",
+    "installer",
+    "skills",
+    "codex",
+    "claude"
+  ],
+  "license": "MIT"
+}

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -24,7 +24,7 @@
     "check:release": "npm run check:docs && npm run check:payload",
     "prepack": "npm run build",
     "prepublishOnly": "npm test && npm run check:release",
-    "test": "npm run build && node --test dist/test/**/*.test.js"
+    "test": "npm run build && node --test dist/test/*.test.js"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",

--- a/packages/loom-installer/scripts/build-payload.mjs
+++ b/packages/loom-installer/scripts/build-payload.mjs
@@ -1,0 +1,136 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname, join, relative } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(scriptDir, '..');
+const repoRoot = join(packageRoot, '..', '..');
+const payloadRoot = join(packageRoot, 'payload');
+const pluginSource = join(repoRoot, 'plugins', 'loom');
+const skillsSourceRoot = join(repoRoot, 'packages', 'skills');
+const pluginManifestPath = join(pluginSource, '.codex-plugin', 'plugin.json');
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function sha256(path) {
+  const hash = createHash('sha256');
+  hash.update(readFileSync(path));
+  return hash.digest('hex');
+}
+
+function collectFiles(baseDir, relativeBase = '') {
+  const files = [];
+  for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+    const entryPath = join(baseDir, entry.name);
+    const entryRelative = relativeBase ? join(relativeBase, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(entryPath, entryRelative));
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    files.push({
+      path: entryRelative.replaceAll('\\', '/'),
+      bytes: statSync(entryPath).size,
+      sha256: sha256(entryPath),
+    });
+  }
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function shouldIgnore(name) {
+  return name === '__pycache__' || name.endsWith('.pyc');
+}
+
+function copyDirectoryFiltered(sourceDir, targetDir) {
+  mkdirSync(targetDir, { recursive: true });
+  for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+    if (shouldIgnore(entry.name)) {
+      continue;
+    }
+    const sourcePath = join(sourceDir, entry.name);
+    const targetPath = join(targetDir, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectoryFiltered(sourcePath, targetPath);
+      continue;
+    }
+    if (entry.isFile()) {
+      cpSync(sourcePath, targetPath, { force: true });
+    }
+  }
+}
+
+function gitValue(args, fallback) {
+  try {
+    return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim() || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+if (!existsSync(pluginSource)) {
+  throw new Error(`missing plugin source: ${pluginSource}`);
+}
+if (!existsSync(skillsSourceRoot)) {
+  throw new Error(`missing skills source root: ${skillsSourceRoot}`);
+}
+
+rmSync(payloadRoot, { recursive: true, force: true });
+mkdirSync(payloadRoot, { recursive: true });
+mkdirSync(join(payloadRoot, 'plugin'), { recursive: true });
+mkdirSync(join(payloadRoot, 'skills'), { recursive: true });
+
+copyDirectoryFiltered(pluginSource, join(payloadRoot, 'plugin', 'loom'));
+
+const skillDirs = readdirSync(skillsSourceRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const skills = [];
+for (const skillDir of skillDirs) {
+  const sourceDir = join(skillsSourceRoot, skillDir);
+  const contractPath = join(sourceDir, 'contract.json');
+  const contract = readJson(contractPath);
+  copyDirectoryFiltered(sourceDir, join(payloadRoot, 'skills', skillDir));
+  skills.push({
+    id: contract.id,
+    display_name: contract.display_name,
+    contract_version: contract.contract_version,
+    relative_path: `skills/${skillDir}`,
+  });
+}
+
+const pluginManifest = readJson(pluginManifestPath);
+const files = collectFiles(payloadRoot)
+  .filter((entry) => entry.path !== 'manifest.json');
+
+const manifest = {
+  schema_version: 'loom-installer-payload/v1',
+  loom_version: pluginManifest.version,
+  source_repository: 'https://github.com/MC-and-his-Agents/Loom',
+  source_commit: gitValue(['rev-parse', 'HEAD'], 'unknown'),
+  source_ref: gitValue(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown'),
+  built_at: process.env.LOOM_INSTALLER_BUILD_TIMESTAMP ?? new Date().toISOString(),
+  runtime: {
+    python_minimum: '3.10',
+    python_recommended: '3.11+'
+  },
+  plugin: {
+    name: pluginManifest.name,
+    version: pluginManifest.version,
+    relative_path: 'plugin/loom'
+  },
+  skills,
+  files
+};
+
+writeFileSync(join(payloadRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+console.log(`payload ready: ${relative(repoRoot, payloadRoot)}`);
+console.log(`skills bundled: ${skills.map((skill) => skill.id).join(', ')}`);

--- a/packages/loom-installer/scripts/check-doc-sync.mjs
+++ b/packages/loom-installer/scripts/check-doc-sync.mjs
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(scriptDir, '..');
+const repoRoot = join(packageRoot, '..', '..');
+
+const mirroredPairs = [
+  ['skills/README.md', 'plugins/loom/skills/README.md'],
+  ['skills/distribution-and-adapter-contract.md', 'plugins/loom/skills/distribution-and-adapter-contract.md'],
+  ['skills/shared/scripts/loom_check.py', 'plugins/loom/skills/shared/scripts/loom_check.py'],
+];
+
+const requiredNeedles = [
+  {
+    path: 'README.md',
+    needles: [
+      'npx @mc-and-his-agents/loom-installer add plugin --host codex',
+      'npm install -D @mc-and-his-agents/loom-installer',
+      'Node `>=20`',
+      'Python `>=3.10`，推荐 `3.11+`',
+      'Loom 当前真实执行面仍然是仓库里的 Python runtime。',
+    ],
+  },
+  {
+    path: 'skills/README.md',
+    needles: [
+      'npx @mc-and-his-agents/loom-installer add plugin',
+      '安装成功不等于已经执行 Loom runtime',
+    ],
+  },
+  {
+    path: 'skills/distribution-and-adapter-contract.md',
+    needles: [
+      '@mc-and-his-agents/loom-installer',
+      'main 分支是真相源',
+      'publish 成功后再创建同版本 git tag',
+    ],
+  },
+  {
+    path: 'packages/loom-installer/README.md',
+    needles: [
+      'npm install -D @mc-and-his-agents/loom-installer',
+      'Node `>=20`',
+      'Python `>=3.10`，推荐 `3.11+`',
+      '发布只在 `main` 上进行',
+    ],
+  },
+];
+
+function readRepoFile(relativePath) {
+  return readFileSync(join(repoRoot, relativePath), 'utf8');
+}
+
+for (const [sourcePath, mirrorPath] of mirroredPairs) {
+  const source = readRepoFile(sourcePath);
+  const mirror = readRepoFile(mirrorPath);
+  if (source !== mirror) {
+    console.error(`doc sync check failed: ${mirrorPath} drifted from ${sourcePath}`);
+    process.exit(1);
+  }
+}
+
+for (const entry of requiredNeedles) {
+  const content = readRepoFile(entry.path);
+  for (const needle of entry.needles) {
+    if (!content.includes(needle)) {
+      console.error(`doc sync check failed: ${entry.path} is missing ${JSON.stringify(needle)}`);
+      process.exit(1);
+    }
+  }
+}
+
+console.log('doc sync check: OK');

--- a/packages/loom-installer/scripts/check-payload-drift.mjs
+++ b/packages/loom-installer/scripts/check-payload-drift.mjs
@@ -1,0 +1,75 @@
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(scriptDir, '..');
+const payloadRoot = join(packageRoot, 'payload');
+const fixedTimestamp = process.env.LOOM_INSTALLER_BUILD_TIMESTAMP ?? '2026-01-01T00:00:00.000Z';
+
+function runBuild() {
+  const result = spawnSync('node', ['./scripts/build-payload.mjs'], {
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      LOOM_INSTALLER_BUILD_TIMESTAMP: fixedTimestamp,
+    },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.status !== 0) {
+    throw new Error((result.stderr || result.stdout || 'build-payload failed').trim());
+  }
+}
+
+function walk(dir, base = dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walk(entryPath, base));
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    const rel = relative(base, entryPath).replaceAll('\\', '/');
+    const fileBytes = readFileSync(entryPath).byteLength;
+    const sha = createHash('sha256').update(readFileSync(entryPath)).digest('hex');
+    files.push(`${rel}:${fileBytes}:${sha}`);
+  }
+  return files.sort();
+}
+
+function fingerprint() {
+  const files = walk(payloadRoot);
+  return createHash('sha256').update(files.join('\n')).digest('hex');
+}
+
+function main() {
+  runBuild();
+  const firstManifest = JSON.parse(readFileSync(join(payloadRoot, 'manifest.json'), 'utf8'));
+  if (firstManifest.built_at !== fixedTimestamp) {
+    throw new Error(`payload manifest built_at must equal ${fixedTimestamp}`);
+  }
+  const first = fingerprint();
+  runBuild();
+  const secondManifest = JSON.parse(readFileSync(join(payloadRoot, 'manifest.json'), 'utf8'));
+  if (secondManifest.built_at !== fixedTimestamp) {
+    throw new Error(`second payload manifest built_at must equal ${fixedTimestamp}`);
+  }
+  const second = fingerprint();
+  if (first !== second) {
+    throw new Error('payload rebuild drift detected');
+  }
+  console.log(`payload drift check: OK (${first})`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`payload drift check failed: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+}

--- a/packages/loom-installer/scripts/check-version-bump.mjs
+++ b/packages/loom-installer/scripts/check-version-bump.mjs
@@ -1,0 +1,67 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(scriptDir, '..');
+const repoRoot = join(packageRoot, '..', '..');
+const packageJsonPath = join(packageRoot, 'package.json');
+const baseArgIndex = process.argv.indexOf('--base');
+const baseRef = baseArgIndex >= 0 ? process.argv[baseArgIndex + 1] : 'origin/main';
+
+const behaviorPrefixes = [
+  'packages/loom-installer/src/',
+  'packages/loom-installer/scripts/',
+  'packages/loom-installer/package.json',
+  'plugins/loom/',
+  'packages/skills/',
+];
+
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function readCurrentVersion() {
+  return JSON.parse(readFileSync(packageJsonPath, 'utf8')).version;
+}
+
+function readBaseVersion() {
+  try {
+    return JSON.parse(git(['show', `${baseRef}:packages/loom-installer/package.json`])).version;
+  } catch {
+    return null;
+  }
+}
+
+function changedFiles() {
+  const output = git(['diff', '--name-only', `${baseRef}...HEAD`]);
+  return output ? output.split('\n').filter(Boolean) : [];
+}
+
+const changed = changedFiles();
+const behaviorChanged = changed.some((path) => behaviorPrefixes.some((prefix) => path === prefix || path.startsWith(prefix)));
+const currentVersion = readCurrentVersion();
+const baseVersion = readBaseVersion();
+
+if (!behaviorChanged) {
+  console.log(`version bump check: OK (no installer behavior changes against ${baseRef})`);
+  process.exit(0);
+}
+
+if (baseVersion === null) {
+  console.log(`version bump check: OK (no base installer package at ${baseRef})`);
+  process.exit(0);
+}
+
+if (baseVersion === currentVersion) {
+  console.error(`version bump check failed: installer behavior changed but version stayed ${currentVersion}`);
+  console.error(`changed files:\n${changed.join('\n')}`);
+  process.exit(1);
+}
+
+console.log(`version bump check: OK (${baseVersion} -> ${currentVersion})`);

--- a/packages/loom-installer/src/claude.ts
+++ b/packages/loom-installer/src/claude.ts
@@ -1,0 +1,193 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { InstallResult, PayloadManifest, PayloadSkillRecord, ResolvedEnv } from './types.js';
+import { InstallerError, copyTree, dirExists, ensureDirectory, fileExists, readJson, replaceTree, runCommand, writeJson } from './utils.js';
+
+function claudeEnv(env: ResolvedEnv): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CLAUDE_CONFIG_DIR: env.claudeConfigDir,
+  };
+}
+
+function claudeMarketplaceRoot(targetRoot: string): string {
+  return join(targetRoot, '.claude', 'marketplaces', 'loom-local');
+}
+
+function claudeMarketplaceManifest() {
+  return {
+    $schema: 'https://anthropic.com/claude-code/marketplace.schema.json',
+    name: 'loom-local',
+    description: 'Repo-local Loom marketplace for plugin installation.',
+    owner: {
+      name: 'MC and his Agents',
+      email: 'opensource@mc-and-his-agents.dev',
+    },
+    plugins: [
+      {
+        name: 'loom',
+        description: 'Loom repo-local plugin entry',
+        source: './plugins/loom',
+        category: 'productivity',
+        homepage: 'https://github.com/MC-and-his-Agents/Loom',
+      },
+    ],
+  };
+}
+
+function runClaude(env: ResolvedEnv, args: string[]): { stdout: string; stderr: string; status: number | null } {
+  return runCommand(env.claudeBin, args, claudeEnv(env));
+}
+
+function synthesizeClaudePluginManifest(pluginTarget: string): string {
+  const codexManifestPath = join(pluginTarget, '.codex-plugin', 'plugin.json');
+  if (!fileExists(codexManifestPath)) {
+    throw new InstallerError(`Claude plugin install is missing source plugin manifest: ${codexManifestPath}`);
+  }
+  const codexManifest = readJson<{
+    name: string;
+    description?: string;
+    version?: string;
+    author?: { name?: string; email?: string };
+  }>(codexManifestPath);
+  const claudeManifestPath = join(pluginTarget, '.claude-plugin', 'plugin.json');
+  writeJson(claudeManifestPath, {
+    name: codexManifest.name,
+    description: codexManifest.description ?? 'Loom repo-local plugin entry',
+    version: codexManifest.version ?? '0.0.0',
+    author: codexManifest.author ?? {
+      name: 'MC and his Agents',
+      email: 'opensource@mc-and-his-agents.dev',
+    },
+  });
+  return claudeManifestPath;
+}
+
+function verifyClaudePluginInstalled(env: ResolvedEnv): void {
+  const result = runClaude(env, ['plugin', 'list', '--json']);
+  if (result.status !== 0) {
+    throw new InstallerError(`claude plugin list failed: ${result.stderr || result.stdout}`.trim());
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(result.stdout || '[]');
+  } catch {
+    throw new InstallerError('claude plugin list --json returned invalid JSON');
+  }
+  if (!Array.isArray(payload)) {
+    throw new InstallerError('claude plugin list --json must return an array');
+  }
+  const found = payload.some((entry) => {
+    if (typeof entry === 'string') {
+      return entry === 'loom';
+    }
+    if (typeof entry !== 'object' || entry === null) {
+      return false;
+    }
+    return (entry as { name?: string }).name === 'loom';
+  });
+  if (!found) {
+    throw new InstallerError('claude plugin verify failed: loom is not listed as installed');
+  }
+}
+
+export function installClaudePlugin(
+  env: ResolvedEnv,
+  targetRoot: string,
+  packageRoot: string,
+  manifest: PayloadManifest,
+  force: boolean,
+): InstallResult {
+  const marketplaceRoot = claudeMarketplaceRoot(targetRoot);
+  const marketplaceManifestPath = join(marketplaceRoot, '.claude-plugin', 'marketplace.json');
+  const pluginTarget = join(marketplaceRoot, 'plugins', 'loom');
+  const pluginSource = join(packageRoot, 'payload', manifest.plugin.relative_path);
+
+  ensureDirectory(join(marketplaceRoot, '.claude-plugin'));
+  ensureDirectory(join(marketplaceRoot, 'plugins'));
+  if (dirExists(pluginTarget)) {
+    if (!force && !fileExists(join(pluginTarget, '.codex-plugin', 'plugin.json'))) {
+      throw new InstallerError(
+        `existing Claude marketplace plugin is not Loom-managed: ${pluginTarget}`,
+        `refusing to take over non-Loom Claude marketplace plugin: ${pluginTarget}`,
+      );
+    }
+    replaceTree(pluginSource, pluginTarget);
+  } else {
+    copyTree(pluginSource, pluginTarget, true);
+  }
+  const claudePluginManifestPath = synthesizeClaudePluginManifest(pluginTarget);
+  writeJson(marketplaceManifestPath, claudeMarketplaceManifest());
+
+  const addResult = runClaude(env, ['plugin', 'marketplace', 'add', marketplaceRoot]);
+  const addOutput = `${addResult.stdout}\n${addResult.stderr}`;
+  if (addResult.status !== 0 && !/already exists|already added|already configured/i.test(addOutput)) {
+    throw new InstallerError(`claude plugin marketplace add failed: ${addOutput.trim()}`);
+  }
+
+  const installResult = runClaude(env, ['plugin', 'install', 'loom@loom-local']);
+  const installOutput = `${installResult.stdout}\n${installResult.stderr}`;
+  if (installResult.status !== 0 && !/already installed/i.test(installOutput)) {
+    throw new InstallerError(`claude plugin install failed: ${installOutput.trim()}`);
+  }
+
+  verifyClaudePluginInstalled(env);
+
+  return {
+    mode: 'plugin',
+    host: 'claude',
+    status: /already installed/i.test(installOutput) ? 'already-installed' : 'installed',
+    installed_paths: [marketplaceRoot, marketplaceManifestPath, pluginTarget, claudePluginManifestPath],
+    verification: [
+      `verified marketplace source at ${marketplaceRoot}`,
+      `verified Claude plugin manifest at ${claudePluginManifestPath}`,
+      'verified `claude plugin list --json` contains loom',
+    ],
+    warnings: ['Claude plugin install goes through the official CLI and does not replace the Python runtime.'],
+    fail_closed_reason: null,
+  };
+}
+
+export function installClaudeSkill(
+  targetRoot: string,
+  packageRoot: string,
+  skill: PayloadSkillRecord,
+  force: boolean,
+): InstallResult {
+  const sourceDir = join(packageRoot, 'payload', skill.relative_path);
+  const targetDir = join(targetRoot, '.claude', 'skills', skill.id);
+  const skillMarkdownPath = join(targetDir, 'SKILL.md');
+
+  ensureDirectory(join(targetRoot, '.claude', 'skills'));
+  if (dirExists(targetDir)) {
+    if (!force && !fileExists(skillMarkdownPath)) {
+      throw new InstallerError(
+        `existing Claude skill directory is not Loom-managed: ${targetDir}`,
+        `refusing to take over non-Loom Claude skill directory: ${targetDir}`,
+      );
+    }
+    replaceTree(sourceDir, targetDir);
+  } else {
+    copyTree(sourceDir, targetDir, true);
+  }
+
+  if (!fileExists(skillMarkdownPath)) {
+    throw new InstallerError(`Claude skill install is missing SKILL.md: ${skillMarkdownPath}`);
+  }
+  if (!readFileSync(skillMarkdownPath, 'utf8').startsWith('---\n')) {
+    throw new InstallerError(`Claude skill install must keep YAML frontmatter in ${skillMarkdownPath}`);
+  }
+
+  return {
+    mode: 'skill',
+    host: 'claude',
+    status: 'installed',
+    installed_paths: [targetDir],
+    verification: [
+      `verified skill payload at ${targetDir}`,
+      `verified discoverable SKILL.md at ${skillMarkdownPath}`,
+    ],
+    warnings: ['Claude single-skill install relies on project-level `.claude/skills` discovery and does not expose the full Loom plugin surface.'],
+    fail_closed_reason: null,
+  };
+}

--- a/packages/loom-installer/src/cli.ts
+++ b/packages/loom-installer/src/cli.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import { formatResult, parseCli, runInstaller } from './index.js';
+import { InstallerError } from './utils.js';
+import type { InstallResult } from './types.js';
+
+function errorResult(message: string): InstallResult {
+  return {
+    mode: 'plugin',
+    host: 'codex',
+    status: 'installed',
+    installed_paths: [],
+    verification: [],
+    warnings: [],
+    fail_closed_reason: message,
+  };
+}
+
+try {
+  const parsed = parseCli(process.argv.slice(2));
+  const result = runInstaller(parsed);
+  if (parsed.options.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatResult(result)}\n`);
+  }
+} catch (error) {
+  const message = error instanceof InstallerError ? error.failClosedReason : error instanceof Error ? error.message : String(error);
+  const parsedJson = process.argv.includes('--json');
+  if (parsedJson) {
+    process.stdout.write(`${JSON.stringify(errorResult(message), null, 2)}\n`);
+  } else {
+    process.stderr.write(`loom-installer: ${message}\n`);
+  }
+  process.exit(1);
+}

--- a/packages/loom-installer/src/codex.ts
+++ b/packages/loom-installer/src/codex.ts
@@ -1,0 +1,238 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { InstallResult, PayloadManifest, PayloadSkillRecord, ResolvedEnv } from './types.js';
+import { InstallerError, copyTree, dirExists, ensureDirectory, fileExists, readJson, replaceTree, writeJson } from './utils.js';
+
+interface CodexSkillBlock {
+  raw: string;
+  path: string | null;
+  enabled: boolean | null;
+}
+
+function codexMarketplacePath(targetRoot: string): string {
+  return join(targetRoot, '.agents', 'plugins', 'marketplace.json');
+}
+
+function parseMarketplace(path: string): Record<string, unknown> | null {
+  if (!fileExists(path)) {
+    return null;
+  }
+  return readJson<Record<string, unknown>>(path);
+}
+
+function defaultMarketplace() {
+  return {
+    name: 'loom-local',
+    interface: {
+      displayName: 'Loom Local Plugins',
+    },
+    plugins: [],
+  };
+}
+
+function loomMarketplaceEntry() {
+  return {
+    name: 'loom',
+    source: {
+      source: 'local',
+      path: './plugins/loom',
+    },
+    policy: {
+      installation: 'AVAILABLE',
+      authentication: 'ON_INSTALL',
+    },
+    category: 'Productivity',
+  };
+}
+
+function ensureMarketplace(targetRoot: string, force: boolean): string[] {
+  const marketplacePath = codexMarketplacePath(targetRoot);
+  const marketplace = parseMarketplace(marketplacePath) ?? defaultMarketplace();
+  if (!Array.isArray(marketplace.plugins)) {
+    throw new InstallerError('Codex marketplace.json must contain a plugins array');
+  }
+  const expectedPath = './plugins/loom';
+  const existing = marketplace.plugins.find(
+    (entry) => typeof entry === 'object' && entry !== null && (entry as { name?: string }).name === 'loom',
+  ) as { name?: string; source?: { path?: string } } | undefined;
+  if (existing && existing.source?.path && existing.source.path !== expectedPath) {
+    throw new InstallerError(
+      `Codex marketplace already declares loom from a different path: ${existing.source.path}`,
+      `refusing to take over non-Loom marketplace entry for loom: ${existing.source.path}`,
+    );
+  }
+  if (!existing) {
+    marketplace.plugins.push(loomMarketplaceEntry());
+  } else if (force) {
+    const index = marketplace.plugins.indexOf(existing as never);
+    marketplace.plugins[index] = loomMarketplaceEntry() as never;
+  }
+  writeJson(marketplacePath, marketplace);
+  return [marketplacePath];
+}
+
+function parseSkillBlocks(content: string): CodexSkillBlock[] {
+  const lines = content.split('\n');
+  const blocks: CodexSkillBlock[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    if (lines[index].trim() !== '[[skills.config]]') {
+      continue;
+    }
+    const blockLines = [lines[index]];
+    index += 1;
+    while (index < lines.length && !lines[index].trim().startsWith('[[')) {
+      blockLines.push(lines[index]);
+      index += 1;
+    }
+    index -= 1;
+    const raw = blockLines.join('\n');
+    const pathMatch = raw.match(/^path\s*=\s*"([^"]+)"/m);
+    const enabledMatch = raw.match(/^enabled\s*=\s*(true|false)/m);
+    blocks.push({
+      raw,
+      path: pathMatch?.[1] ?? null,
+      enabled: enabledMatch ? enabledMatch[1] === 'true' : null,
+    });
+  }
+  return blocks;
+}
+
+function upsertSkillBlock(configPath: string, desiredSkillPath: string, skillId: string, force: boolean): void {
+  const content = fileExists(configPath) ? readFileSync(configPath, 'utf8') : '';
+  const blocks = parseSkillBlocks(content);
+  const skillDir = skillId.startsWith('loom-') ? skillId : `loom-${skillId}`;
+  const conflicting = blocks.filter((block) => {
+    if (!block.path) {
+      return false;
+    }
+    return block.path.endsWith(`/${skillDir}/SKILL.md`) && block.path !== desiredSkillPath;
+  });
+  if (conflicting.length > 0 && !force) {
+    throw new InstallerError(
+      `Codex already has ${skillId} from a different path`,
+      `Codex already has ${skillId} from a different path`,
+    );
+  }
+
+  let nextContent = content;
+  for (const block of conflicting) {
+    nextContent = nextContent.replace(`${block.raw}\n`, '').replace(block.raw, '');
+  }
+
+  const existingBlock = parseSkillBlocks(nextContent).find((block) => block.path === desiredSkillPath);
+  if (existingBlock) {
+    const enabledBlock = existingBlock.raw.match(/^enabled\s*=\s*false/m)
+      ? existingBlock.raw.replace(/^enabled\s*=\s*false/m, 'enabled = true')
+      : existingBlock.enabled === null
+        ? `${existingBlock.raw}\nenabled = true`
+        : existingBlock.raw;
+    nextContent = nextContent.replace(existingBlock.raw, enabledBlock);
+  } else {
+    if (nextContent && !nextContent.endsWith('\n')) {
+      nextContent += '\n';
+    }
+    nextContent += `\n[[skills.config]]\npath = ${JSON.stringify(desiredSkillPath)}\nenabled = true\n`;
+  }
+
+  ensureDirectory(join(configPath, '..'));
+  writeFileSync(configPath, nextContent.replace(/^\n+/, ''), 'utf8');
+}
+
+function verifySkillEnabled(configPath: string, desiredSkillPath: string): boolean {
+  const content = fileExists(configPath) ? readFileSync(configPath, 'utf8') : '';
+  return parseSkillBlocks(content).some((block) => block.path === desiredSkillPath && block.enabled !== false);
+}
+
+export function installCodexPlugin(
+  targetRoot: string,
+  packageRoot: string,
+  manifest: PayloadManifest,
+  force: boolean,
+): InstallResult {
+  const pluginSource = join(packageRoot, 'payload', manifest.plugin.relative_path);
+  const pluginTarget = join(targetRoot, 'plugins', 'loom');
+  const pluginManifestPath = join(pluginTarget, '.codex-plugin', 'plugin.json');
+  const installedPaths: string[] = [];
+  const warnings: string[] = [];
+
+  if (dirExists(pluginTarget) && !force) {
+    if (!fileExists(pluginManifestPath)) {
+      throw new InstallerError(
+        `target already contains plugins/loom but it is not a Loom plugin: ${pluginTarget}`,
+        `refusing to take over non-Loom plugin directory: ${pluginTarget}`,
+      );
+    }
+  }
+
+  if (dirExists(pluginTarget)) {
+    replaceTree(pluginSource, pluginTarget);
+  } else {
+    copyTree(pluginSource, pluginTarget, true);
+  }
+  installedPaths.push(pluginTarget);
+  installedPaths.push(...ensureMarketplace(targetRoot, force));
+
+  const pluginManifest = readJson<{ name?: string }>(pluginManifestPath);
+  if (pluginManifest.name !== 'loom') {
+    throw new InstallerError('Codex plugin installation drifted: plugin name must stay `loom`');
+  }
+  warnings.push('Codex plugin install remains repo-local; it does not replace the Python runtime.');
+
+  return {
+    mode: 'plugin',
+    host: 'codex',
+    status: 'installed',
+    installed_paths: installedPaths,
+    verification: [
+      `verified plugin payload at ${pluginTarget}`,
+      `verified marketplace entry at ${codexMarketplacePath(targetRoot)}`,
+    ],
+    warnings,
+    fail_closed_reason: null,
+  };
+}
+
+export function installCodexSkill(
+  env: ResolvedEnv,
+  packageRoot: string,
+  skill: PayloadSkillRecord,
+  force: boolean,
+): InstallResult {
+  const skillDirName = skill.id.startsWith('loom-') ? skill.id : `loom-${skill.id}`;
+  const sourceDir = join(packageRoot, 'payload', skill.relative_path);
+  const targetDir = join(env.codexHome, 'skills', skillDirName);
+  const skillMarkdownPath = join(targetDir, 'SKILL.md');
+  const configPath = join(env.codexHome, 'config.toml');
+
+  ensureDirectory(join(env.codexHome, 'skills'));
+  if (dirExists(targetDir)) {
+    if (!force && !fileExists(skillMarkdownPath)) {
+      throw new InstallerError(
+        `existing Codex skill directory is not Loom-managed: ${targetDir}`,
+        `refusing to take over non-Loom Codex skill directory: ${targetDir}`,
+      );
+    }
+    replaceTree(sourceDir, targetDir);
+  } else {
+    copyTree(sourceDir, targetDir, true);
+  }
+
+  ensureDirectory(env.codexHome);
+  upsertSkillBlock(configPath, skillMarkdownPath, skill.id, force);
+  if (!verifySkillEnabled(configPath, skillMarkdownPath)) {
+    throw new InstallerError(`Codex config did not enable ${skill.id}`);
+  }
+
+  return {
+    mode: 'skill',
+    host: 'codex',
+    status: 'installed',
+    installed_paths: [targetDir, configPath],
+    verification: [
+      `verified skill payload at ${targetDir}`,
+      `verified skills.config entry for ${skill.id}`,
+    ],
+    warnings: ['Codex single-skill install exposes only the named skill, not the full Loom plugin surface.'],
+    fail_closed_reason: null,
+  };
+}

--- a/packages/loom-installer/src/index.ts
+++ b/packages/loom-installer/src/index.ts
@@ -1,0 +1,207 @@
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Host, CliOptions, InstallResult, Mode, PayloadManifest, ResolvedEnv } from './types.js';
+import { InstallerError, assert, dirExists, ensureTargetWritable, runCommand } from './utils.js';
+import { loadPayloadManifest, resolveSkillRecord, verifyPayload } from './payload.js';
+import { installCodexPlugin, installCodexSkill } from './codex.js';
+import { installClaudePlugin, installClaudeSkill } from './claude.js';
+
+const DEFAULT_OPTIONS: CliOptions = {
+  host: 'auto',
+  target: '.',
+  force: false,
+  json: false,
+};
+
+export interface ParsedCommand {
+  mode: Mode;
+  skillId?: string;
+  options: CliOptions;
+}
+
+export function packageRootFromUrl(moduleUrl: string): string {
+  return resolve(dirname(fileURLToPath(moduleUrl)), '..', '..');
+}
+
+export function resolveEnvironment(env: NodeJS.ProcessEnv = process.env): ResolvedEnv {
+  const homeDir = env.HOME ?? '';
+  assert(homeDir, 'HOME is required');
+  return {
+    homeDir,
+    codexHome: env.CODEX_HOME ?? join(homeDir, '.codex'),
+    claudeConfigDir: env.CLAUDE_CONFIG_DIR ?? join(homeDir, '.claude'),
+    pythonBin: env.LOOM_INSTALLER_PYTHON_BIN ?? 'python3',
+    claudeBin: env.LOOM_INSTALLER_CLAUDE_BIN ?? 'claude',
+  };
+}
+
+export function detectHosts(env: ResolvedEnv): Host[] {
+  const hosts: Host[] = [];
+  if (dirExists(env.codexHome)) {
+    hosts.push('codex');
+  }
+  if (dirExists(env.claudeConfigDir)) {
+    hosts.push('claude');
+  }
+  return hosts;
+}
+
+export function selectHost(requested: CliOptions['host'], env: ResolvedEnv): Host {
+  if (requested !== 'auto') {
+    return requested;
+  }
+  const detected = detectHosts(env);
+  if (detected.length === 1) {
+    return detected[0];
+  }
+  if (detected.length === 0) {
+    throw new InstallerError('auto host detection failed: no supported host was detected');
+  }
+  throw new InstallerError('auto host detection found both Codex and Claude; pass --host explicitly');
+}
+
+export function parseCli(argv: string[]): ParsedCommand {
+  const command = argv[0];
+  const subject = argv[1];
+  const third = argv[2];
+  const rest = subject === 'plugin' ? argv.slice(2) : argv.slice(3);
+  if (command !== 'add') {
+    throw new InstallerError('usage: loom-installer add plugin|skill <skill-id> [--host ...] [--target ...] [--force] [--json]');
+  }
+  const options: CliOptions = { ...DEFAULT_OPTIONS };
+  for (let index = 0; index < rest.length; index += 1) {
+    const token = rest[index];
+    if (token === '--host') {
+      const next = rest[index + 1];
+      if (next !== 'auto' && next !== 'codex' && next !== 'claude') {
+        throw new InstallerError(`unsupported --host value: ${String(next)}`);
+      }
+      options.host = next;
+      index += 1;
+      continue;
+    }
+    if (token === '--target') {
+      const next = rest[index + 1];
+      if (!next) {
+        throw new InstallerError('--target requires a value');
+      }
+      options.target = next;
+      index += 1;
+      continue;
+    }
+    if (token === '--force') {
+      options.force = true;
+      continue;
+    }
+    if (token === '--json') {
+      options.json = true;
+      continue;
+    }
+    throw new InstallerError(`unknown option: ${token}`);
+  }
+
+  if (subject === 'plugin') {
+    return {
+      mode: 'plugin',
+      options,
+    };
+  }
+  if (subject === 'skill') {
+    if (!third) {
+      throw new InstallerError('usage: loom-installer add skill <skill-id>');
+    }
+    return {
+      mode: 'skill',
+      skillId: third,
+      options,
+    };
+  }
+  throw new InstallerError(`unknown add target: ${String(subject)}`);
+}
+
+export function checkPython(env: ResolvedEnv): string[] {
+  const result = runCommand(
+    env.pythonBin,
+    ['-c', 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}.{sys.version_info[2]}")'],
+    process.env,
+  );
+  if (result.status !== 0) {
+    throw new InstallerError(`python preflight failed: ${result.stderr || result.stdout}`.trim());
+  }
+  const match = result.stdout.trim().match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new InstallerError(`python preflight returned an invalid version: ${result.stdout.trim()}`);
+  }
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  if (major < 3 || (major === 3 && minor < 10)) {
+    throw new InstallerError(`python ${result.stdout.trim()} is unsupported; require >= 3.10`);
+  }
+  const warnings: string[] = [];
+  if (major === 3 && minor < 11) {
+    warnings.push(`python ${result.stdout.trim()} is supported, but 3.11+ is recommended`);
+  }
+  return warnings;
+}
+
+export function ensureClaudeCliWhenNeeded(host: Host, mode: Mode, env: ResolvedEnv): void {
+  if (host !== 'claude' || mode !== 'plugin') {
+    return;
+  }
+  const result = runCommand(env.claudeBin, ['--version'], process.env);
+  if (result.status !== 0) {
+    throw new InstallerError(`claude CLI preflight failed: ${result.stderr || result.stdout}`.trim());
+  }
+}
+
+export function formatResult(result: InstallResult): string {
+  return [
+    `${result.host} ${result.mode}: ${result.status}`,
+    ...result.verification.map((line) => `- ${line}`),
+    ...result.warnings.map((line) => `! ${line}`),
+  ].join('\n');
+}
+
+export function runInstaller(parsed: ParsedCommand, envSource: NodeJS.ProcessEnv = process.env, packageRoot?: string): InstallResult {
+  const resolvedEnv = resolveEnvironment(envSource);
+  const host = selectHost(parsed.options.host, resolvedEnv);
+  const resolvedPackageRoot = packageRoot ?? packageRootFromUrl(import.meta.url);
+  const targetRoot = resolve(parsed.options.target);
+  ensureTargetWritable(targetRoot);
+
+  const manifest = loadPayloadManifest(resolvedPackageRoot);
+  verifyPayload(resolvedPackageRoot, manifest);
+  const warnings = checkPython(resolvedEnv);
+  ensureClaudeCliWhenNeeded(host, parsed.mode, resolvedEnv);
+
+  const result = installForHost({
+    host,
+    parsed,
+    env: resolvedEnv,
+    packageRoot: resolvedPackageRoot,
+    targetRoot,
+    manifest,
+  });
+  result.warnings.unshift(...warnings);
+  return result;
+}
+
+function installForHost(input: {
+  host: Host;
+  parsed: ParsedCommand;
+  env: ResolvedEnv;
+  packageRoot: string;
+  targetRoot: string;
+  manifest: PayloadManifest;
+}): InstallResult {
+  const { host, parsed, env, packageRoot, targetRoot, manifest } = input;
+  if (parsed.mode === 'plugin') {
+    return host === 'codex'
+      ? installCodexPlugin(targetRoot, packageRoot, manifest, parsed.options.force)
+      : installClaudePlugin(env, targetRoot, packageRoot, manifest, parsed.options.force);
+  }
+  const skill = resolveSkillRecord(manifest, parsed.skillId ?? '');
+  return host === 'codex'
+    ? installCodexSkill(env, packageRoot, skill, parsed.options.force)
+    : installClaudeSkill(targetRoot, packageRoot, skill, parsed.options.force);
+}

--- a/packages/loom-installer/src/payload.ts
+++ b/packages/loom-installer/src/payload.ts
@@ -1,0 +1,46 @@
+import { join } from 'node:path';
+import { PayloadManifest } from './types.js';
+import { InstallerError, dirExists, fileExists, readJson, sha256 } from './utils.js';
+
+export function loadPayloadManifest(packageRoot: string): PayloadManifest {
+  const manifestPath = join(packageRoot, 'payload', 'manifest.json');
+  if (!fileExists(manifestPath)) {
+    throw new InstallerError(`payload manifest is missing: ${manifestPath}`);
+  }
+  return readJson<PayloadManifest>(manifestPath);
+}
+
+export function verifyPayload(packageRoot: string, manifest: PayloadManifest): void {
+  if (manifest.schema_version !== 'loom-installer-payload/v1') {
+    throw new InstallerError(`unsupported payload schema: ${manifest.schema_version}`);
+  }
+  const payloadRoot = join(packageRoot, 'payload');
+  const pluginPath = join(payloadRoot, manifest.plugin.relative_path);
+  if (!dirExists(pluginPath)) {
+    throw new InstallerError(`plugin payload is missing: ${pluginPath}`);
+  }
+  for (const skill of manifest.skills) {
+    const skillPath = join(payloadRoot, skill.relative_path);
+    if (!dirExists(skillPath)) {
+      throw new InstallerError(`skill payload is missing: ${skillPath}`);
+    }
+  }
+  for (const file of manifest.files) {
+    const absolute = join(payloadRoot, file.path);
+    if (!fileExists(absolute)) {
+      throw new InstallerError(`payload file is missing: ${file.path}`);
+    }
+    const actualSha = sha256(absolute);
+    if (actualSha !== file.sha256) {
+      throw new InstallerError(`payload checksum drift detected for ${file.path}`);
+    }
+  }
+}
+
+export function resolveSkillRecord(manifest: PayloadManifest, skillId: string) {
+  const skill = manifest.skills.find((candidate) => candidate.id === skillId);
+  if (!skill) {
+    throw new InstallerError(`unknown skill id: ${skillId}`, `unknown skill id: ${skillId}`);
+  }
+  return skill;
+}

--- a/packages/loom-installer/src/types.ts
+++ b/packages/loom-installer/src/types.ts
@@ -1,0 +1,61 @@
+export type Host = 'codex' | 'claude';
+export type Mode = 'plugin' | 'skill';
+export type InstallStatus = 'installed' | 'already-installed';
+
+export interface PayloadFileRecord {
+  path: string;
+  bytes: number;
+  sha256: string;
+}
+
+export interface PayloadSkillRecord {
+  id: string;
+  display_name: string;
+  contract_version: string;
+  relative_path: string;
+}
+
+export interface PayloadManifest {
+  schema_version: 'loom-installer-payload/v1';
+  loom_version: string;
+  source_repository: string;
+  source_commit: string;
+  source_ref: string;
+  built_at: string;
+  runtime: {
+    python_minimum: string;
+    python_recommended: string;
+  };
+  plugin: {
+    name: string;
+    version: string;
+    relative_path: string;
+  };
+  skills: PayloadSkillRecord[];
+  files: PayloadFileRecord[];
+}
+
+export interface InstallResult {
+  mode: Mode;
+  host: Host;
+  status: InstallStatus;
+  installed_paths: string[];
+  verification: string[];
+  warnings: string[];
+  fail_closed_reason: string | null;
+}
+
+export interface CliOptions {
+  host: Host | 'auto';
+  target: string;
+  force: boolean;
+  json: boolean;
+}
+
+export interface ResolvedEnv {
+  homeDir: string;
+  codexHome: string;
+  claudeConfigDir: string;
+  pythonBin: string;
+  claudeBin: string;
+}

--- a/packages/loom-installer/src/utils.ts
+++ b/packages/loom-installer/src/utils.ts
@@ -1,0 +1,102 @@
+import { accessSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { constants } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export class InstallerError extends Error {
+  readonly failClosedReason: string;
+
+  constructor(message: string, failClosedReason?: string) {
+    super(message);
+    this.name = 'InstallerError';
+    this.failClosedReason = failClosedReason ?? message;
+  }
+}
+
+export function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new InstallerError(message);
+  }
+}
+
+export function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+export function writeJson(path: string, value: unknown): void {
+  ensureDirectory(dirname(path));
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export function ensureDirectory(path: string): void {
+  mkdirSync(path, { recursive: true });
+}
+
+export function ensureTargetWritable(path: string): void {
+  if (!existsSync(path)) {
+    throw new InstallerError(`target path does not exist: ${path}`);
+  }
+  try {
+    accessSync(path, constants.W_OK);
+  } catch {
+    throw new InstallerError(`target path is not writable: ${path}`);
+  }
+}
+
+export function copyTree(source: string, target: string, force: boolean): void {
+  if (existsSync(target)) {
+    if (!force) {
+      throw new InstallerError(`target already exists: ${target}`, `existing Loom-managed install requires --force: ${target}`);
+    }
+    rmSync(target, { recursive: true, force: true });
+  }
+  ensureDirectory(dirname(target));
+  cpSync(source, target, { recursive: true, force: true });
+}
+
+export function replaceTree(source: string, target: string): void {
+  rmSync(target, { recursive: true, force: true });
+  ensureDirectory(dirname(target));
+  cpSync(source, target, { recursive: true, force: true });
+}
+
+export function sha256(path: string): string {
+  const hash = createHash('sha256');
+  hash.update(readFileSync(path));
+  return hash.digest('hex');
+}
+
+export function fileExists(path: string): boolean {
+  return existsSync(path) && statSync(path).isFile();
+}
+
+export function dirExists(path: string): boolean {
+  return existsSync(path) && statSync(path).isDirectory();
+}
+
+export function runCommand(
+  command: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  cwd?: string,
+): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(command, args, {
+    cwd,
+    env,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (result.error) {
+    throw new InstallerError(`failed to execute ${command}: ${result.error.message}`);
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+export function resolveAbsolute(path: string): string {
+  return resolve(path);
+}

--- a/packages/loom-installer/test/installer.test.ts
+++ b/packages/loom-installer/test/installer.test.ts
@@ -1,0 +1,180 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { detectHosts, parseCli, resolveEnvironment, runInstaller, selectHost } from '../src/index.js';
+import type { ParsedCommand } from '../src/index.js';
+
+function fixtureRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'loom-installer-'));
+}
+
+function packageRoot(): string {
+  return process.cwd();
+}
+
+function resolveTestPython(): string {
+  if (process.env.LOOM_INSTALLER_TEST_PYTHON_BIN) {
+    return process.env.LOOM_INSTALLER_TEST_PYTHON_BIN;
+  }
+  for (const candidate of ['python3.11', 'python3.12', 'python3.10']) {
+    const result = spawnSync(candidate, ['-c', 'import sys; print(sys.version_info[:2])'], { encoding: 'utf8' });
+    if (result.status === 0) {
+      return candidate;
+    }
+  }
+  throw new Error('tests require python3.10+; set LOOM_INSTALLER_TEST_PYTHON_BIN');
+}
+
+function prepareEnv(base: string): NodeJS.ProcessEnv {
+  const home = join(base, 'home');
+  mkdirSync(home, { recursive: true });
+  return {
+    ...process.env,
+    HOME: home,
+    CODEX_HOME: join(home, '.codex'),
+    CLAUDE_CONFIG_DIR: join(home, '.claude'),
+    LOOM_INSTALLER_PYTHON_BIN: resolveTestPython(),
+  };
+}
+
+function writeFakeClaude(binDir: string, logPath: string): string {
+  const scriptPath = join(binDir, 'claude');
+  writeFileSync(
+    scriptPath,
+    `#!/bin/sh\nset -eu\nprintf '%s\\n' "$*" >> ${JSON.stringify(logPath)}\nif [ "$1" = "--version" ]; then\n  echo '2.1.0'\n  exit 0\nfi\nif [ "$1" = "plugin" ] && [ "$2" = "list" ] && [ "$3" = "--json" ]; then\n  echo '[{"name":"loom"}]'\n  exit 0\nfi\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  return scriptPath;
+}
+
+test('detectHosts and selectHost fail closed on conflicts', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  mkdirSync(envSource.CLAUDE_CONFIG_DIR!, { recursive: true });
+  const env = resolveEnvironment(envSource);
+  assert.deepEqual(detectHosts(env), ['codex', 'claude']);
+  assert.throws(() => selectHost('auto', env), /both Codex and Claude/);
+});
+
+test('parseCli supports plugin and skill flows', () => {
+  const plugin = parseCli(['add', 'plugin', '--host', 'codex', '--json']);
+  assert.equal(plugin.mode, 'plugin');
+  assert.equal(plugin.options.host, 'codex');
+  assert.equal(plugin.options.json, true);
+
+  const skill = parseCli(['add', 'skill', 'loom-review', '--target', '/tmp/repo']);
+  assert.equal(skill.mode, 'skill');
+  assert.equal(skill.skillId, 'loom-review');
+  assert.equal(skill.options.target, '/tmp/repo');
+});
+
+test('payload manifest excludes python cache artifacts', () => {
+  const manifest = JSON.parse(readFileSync(join(packageRoot(), 'payload', 'manifest.json'), 'utf8'));
+  assert.equal(Array.isArray(manifest.files), true);
+  assert.equal(manifest.files.some((entry: { path: string }) => entry.path.includes('__pycache__') || entry.path.endsWith('.pyc')), false);
+});
+
+test('codex plugin install writes marketplace entry', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+
+  const parsed: ParsedCommand = {
+    mode: 'plugin',
+    options: {
+      host: 'codex',
+      target: repoRoot,
+      force: false,
+      json: false,
+    },
+  };
+  const result = runInstaller(parsed, envSource, packageRoot());
+  const marketplace = JSON.parse(readFileSync(join(repoRoot, '.agents', 'plugins', 'marketplace.json'), 'utf8'));
+  assert.equal(result.host, 'codex');
+  assert.equal(marketplace.plugins[0].name, 'loom');
+  assert.equal(marketplace.plugins[0].source.path, './plugins/loom');
+});
+
+test('codex skill install writes skills.config entry', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+  writeFileSync(join(envSource.CODEX_HOME!, 'config.toml'), 'model = "gpt-5"\n', 'utf8');
+
+  const parsed: ParsedCommand = {
+    mode: 'skill',
+    skillId: 'loom-review',
+    options: {
+      host: 'codex',
+      target: repoRoot,
+      force: false,
+      json: false,
+    },
+  };
+  const result = runInstaller(parsed, envSource, packageRoot());
+  const config = readFileSync(join(envSource.CODEX_HOME!, 'config.toml'), 'utf8');
+  assert.equal(result.mode, 'skill');
+  assert.match(config, /\[\[skills\.config\]\]/);
+  assert.match(config, /loom-review\/SKILL\.md/);
+  assert.match(config, /enabled = true/);
+});
+
+test('claude plugin install assembles marketplace and calls claude CLI', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CLAUDE_CONFIG_DIR!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  const binDir = join(base, 'bin');
+  const logPath = join(base, 'claude.log');
+  mkdirSync(repoRoot, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  envSource.LOOM_INSTALLER_CLAUDE_BIN = writeFakeClaude(binDir, logPath);
+
+  const parsed: ParsedCommand = {
+    mode: 'plugin',
+    options: {
+      host: 'claude',
+      target: repoRoot,
+      force: false,
+      json: false,
+    },
+  };
+  const result = runInstaller(parsed, envSource, packageRoot());
+  const marketplace = JSON.parse(readFileSync(join(repoRoot, '.claude', 'marketplaces', 'loom-local', '.claude-plugin', 'marketplace.json'), 'utf8'));
+  const pluginManifest = JSON.parse(readFileSync(join(repoRoot, '.claude', 'marketplaces', 'loom-local', 'plugins', 'loom', '.claude-plugin', 'plugin.json'), 'utf8'));
+  const log = readFileSync(logPath, 'utf8');
+  assert.equal(result.host, 'claude');
+  assert.equal(marketplace.name, 'loom-local');
+  assert.equal(pluginManifest.name, 'loom');
+  assert.match(log, /plugin marketplace add/);
+  assert.match(log, /plugin install loom@loom-local/);
+});
+
+test('cli emits structured json on success', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+  const output = execFileSync(
+    process.execPath,
+    ['dist/src/cli.js', 'add', 'plugin', '--host', 'codex', '--target', repoRoot, '--json'],
+    {
+      cwd: packageRoot(),
+      env: envSource,
+      encoding: 'utf8',
+    },
+  );
+  const payload = JSON.parse(output);
+  assert.equal(payload.host, 'codex');
+  assert.equal(payload.mode, 'plugin');
+  assert.equal(payload.fail_closed_reason, null);
+});

--- a/packages/loom-installer/tsconfig.json
+++ b/packages/loom-installer/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "declaration": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/plugins/loom/skills/README.md
+++ b/plugins/loom/skills/README.md
@@ -31,6 +31,26 @@ Loom 在 `skills` 层固定承认两类对象：
 - 单 skill package 不自动补齐 `loom-init`、其余 scenario skills 或完整 plugin 安装体验
 - 单 skill package 可以复用同一 `loom` CLI 语义，但不会因此升级成整包 Loom 的替身
 
+## 安装入口
+
+Loom 当前正式承认一条 npm / `npx` 安装入口：
+
+- `npx @mc-and-his-agents/loom-installer add plugin`
+- `npx @mc-and-his-agents/loom-installer add skill <skill-id>`
+
+这条入口负责安装、发现与验证，不替代 Python runtime。
+
+运行前提：
+
+- Node `>=20`
+- Python `>=3.10`，推荐 `3.11+`
+
+安装语义必须保持清晰：
+
+- `add plugin` 承诺完整 Loom 入口面
+- `add skill <skill-id>` 只承诺对应标准 skill
+- 安装成功不等于已经执行 Loom runtime，只代表安装 / 发现 / 验证链成立
+
 ## 用户会看到哪些入口
 
 Loom 当前稳定提供 1 个 root entry 和 7 个 scenario skills：

--- a/plugins/loom/skills/distribution-and-adapter-contract.md
+++ b/plugins/loom/skills/distribution-and-adapter-contract.md
@@ -30,6 +30,7 @@ Loom 当前把 `skills` 公开面分成三层：
   - `single-skill standard-skill package` 的命名对象、边界与最小运行切片
 - 宿主 / adapter 首层公开面
   - 本文
+  - `@mc-and-his-agents/loom-installer`
   - `registry.json`
   - `install-layout.json`
   - `upgrade-contract.json`
@@ -91,6 +92,7 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 ### 宿主 / adapter 公开面
 
 - `bootstrap/root contract` 的最小职责
+- npm / `npx` installer surface
 - 安装合同
 - 发现合同
 - 运行态识别合同
@@ -232,7 +234,65 @@ Loom 在此层不规定包管理器、注册中心、目录布局或分发协议
 - 若当前不能继续运行，fail-closed 原因是什么
 - 当前宿主是否识别为可升级状态
 
-## 八、不应进入内核的宿主特定细节
+## 八、Node installer 接入面
+
+Loom 当前为宿主适配固定承认一个 Node installer：
+
+- npm package：`@mc-and-his-agents/loom-installer`
+- 稳定命令面：
+  - `npx @mc-and-his-agents/loom-installer add plugin`
+  - `npx @mc-and-his-agents/loom-installer add skill <skill-id>`
+
+Node installer 的职责边界：
+
+- 负责安装、发现与验证
+- 不替代 `skills/shared/scripts/*` 与各场景 skill 的 Python runtime
+- 不把单 skill 安装伪装成完整 Loom 安装
+- 对安装失败维持 fail-closed
+- main 分支是真相源
+- PR 只做门禁，不直接发布 npm
+- publish 成功后再创建同版本 git tag
+
+Node installer 当前打包的正式安装源：
+
+- plugin payload：`plugins/loom/**`
+- single-skill payload：`packages/skills/<skill-id>/**`
+
+Node installer 的最小 preflight 必须覆盖：
+
+- 目标目录存在且可写
+- package 内 payload 完整且校验不漂移
+- `python3 >= 3.10`，并对 `3.11+` 给出推荐
+- `add skill <skill-id>` 只能接受已登记 skill id
+- Claude plugin 安装必须确认 `claude` CLI 可用
+
+Node installer 的最小 verify 输出必须覆盖：
+
+- `mode`
+- `host`
+- `installed_paths`
+- `verification`
+- `warnings`
+- `fail_closed_reason`
+
+当前宿主映射固定如下：
+
+- Codex plugin
+  - repo-local `plugins/loom/**`
+  - `.agents/plugins/marketplace.json`
+- Codex single-skill
+  - `~/.codex/skills/<skill-id>/`
+  - `~/.codex/config.toml` `[[skills.config]]`
+- Claude plugin
+  - repo-local `.claude/marketplaces/loom-local/`
+  - `claude plugin marketplace add`
+  - `claude plugin install loom@loom-local`
+- Claude single-skill
+  - `<target>/.claude/skills/<skill-id>/`
+
+这些路径与命令属于 adapter surface，不反向提升为 Loom 内核规则。
+
+## 九、不应进入内核的宿主特定细节
 
 以下内容不得直接进入 Loom `skills/` 内核合同：
 
@@ -244,7 +304,7 @@ Loom 在此层不规定包管理器、注册中心、目录布局或分发协议
 
 这些内容可以存在于宿主适配器文档、宿主发行包或宿主实现中，但不应反向污染 Loom 的入口层合同。
 
-## 九、入口层最小验证面
+## 十、入口层最小验证面
 
 对 `skills` 分发与适配合同的验证，至少应覆盖：
 

--- a/plugins/loom/skills/shared/scripts/loom_check.py
+++ b/plugins/loom/skills/shared/scripts/loom_check.py
@@ -50,6 +50,8 @@ AREA_READMES = (
 CORE_DOCS = (
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/workflows/loom-check.yml",
+    ".github/workflows/node-installer-pr.yml",
+    ".github/workflows/node-installer-release.yml",
     "governance/principles.md",
     "governance/review-model.md",
     "governance/maturity-and-closing.md",
@@ -99,6 +101,17 @@ CORE_DOCS = (
     "templates/review-record.md",
     "templates/scaffold/spec.md",
     "templates/scaffold/plan.md",
+    "packages/loom-installer/README.md",
+    "packages/loom-installer/package.json",
+    "packages/loom-installer/package-lock.json",
+    "packages/loom-installer/tsconfig.json",
+    "packages/loom-installer/scripts/build-payload.mjs",
+    "packages/loom-installer/scripts/check-doc-sync.mjs",
+    "packages/loom-installer/scripts/check-payload-drift.mjs",
+    "packages/loom-installer/scripts/check-version-bump.mjs",
+    "packages/loom-installer/src/cli.ts",
+    "packages/loom-installer/src/index.ts",
+    "packages/loom-installer/test/installer.test.ts",
     "tools/loom_init.py",
     "tools/loom_flow.py",
 )
@@ -4612,6 +4625,33 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
     return failures
 
 
+def check_node_installer(root: Path) -> list[Failure]:
+    category = "node-installer"
+    failures: list[Failure] = []
+    package_root = root / "packages/loom-installer"
+    if not package_root.exists():
+        return [Failure(category, "missing `packages/loom-installer`")]
+    npm_bin = shutil.which("npm")
+    if not npm_bin:
+        return [Failure(category, "`npm` is required to validate the Node installer")]
+
+    commands = (
+        ["npm", "ci"],
+        ["npm", "test"],
+        ["npm", "pack", "--dry-run"],
+    )
+    for args in commands:
+        try:
+            result = run_command(root, args, cwd=package_root, timeout_seconds=300)
+        except subprocess.TimeoutExpired:
+            failures.append(Failure(category, f"`{' '.join(args)}` timed out"))
+            continue
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "command failed without output"
+            failures.append(Failure(category, f"`{' '.join(args)}` failed: {detail}"))
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -4646,12 +4686,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_node_installer(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 15
+    categories_checked = 16
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/README.md
+++ b/skills/README.md
@@ -31,6 +31,26 @@ Loom 在 `skills` 层固定承认两类对象：
 - 单 skill package 不自动补齐 `loom-init`、其余 scenario skills 或完整 plugin 安装体验
 - 单 skill package 可以复用同一 `loom` CLI 语义，但不会因此升级成整包 Loom 的替身
 
+## 安装入口
+
+Loom 当前正式承认一条 npm / `npx` 安装入口：
+
+- `npx @mc-and-his-agents/loom-installer add plugin`
+- `npx @mc-and-his-agents/loom-installer add skill <skill-id>`
+
+这条入口负责安装、发现与验证，不替代 Python runtime。
+
+运行前提：
+
+- Node `>=20`
+- Python `>=3.10`，推荐 `3.11+`
+
+安装语义必须保持清晰：
+
+- `add plugin` 承诺完整 Loom 入口面
+- `add skill <skill-id>` 只承诺对应标准 skill
+- 安装成功不等于已经执行 Loom runtime，只代表安装 / 发现 / 验证链成立
+
 ## 用户会看到哪些入口
 
 Loom 当前稳定提供 1 个 root entry 和 7 个 scenario skills：

--- a/skills/distribution-and-adapter-contract.md
+++ b/skills/distribution-and-adapter-contract.md
@@ -30,6 +30,7 @@ Loom 当前把 `skills` 公开面分成三层：
   - `single-skill standard-skill package` 的命名对象、边界与最小运行切片
 - 宿主 / adapter 首层公开面
   - 本文
+  - `@mc-and-his-agents/loom-installer`
   - `registry.json`
   - `install-layout.json`
   - `upgrade-contract.json`
@@ -91,6 +92,7 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 ### 宿主 / adapter 公开面
 
 - `bootstrap/root contract` 的最小职责
+- npm / `npx` installer surface
 - 安装合同
 - 发现合同
 - 运行态识别合同
@@ -232,7 +234,65 @@ Loom 在此层不规定包管理器、注册中心、目录布局或分发协议
 - 若当前不能继续运行，fail-closed 原因是什么
 - 当前宿主是否识别为可升级状态
 
-## 八、不应进入内核的宿主特定细节
+## 八、Node installer 接入面
+
+Loom 当前为宿主适配固定承认一个 Node installer：
+
+- npm package：`@mc-and-his-agents/loom-installer`
+- 稳定命令面：
+  - `npx @mc-and-his-agents/loom-installer add plugin`
+  - `npx @mc-and-his-agents/loom-installer add skill <skill-id>`
+
+Node installer 的职责边界：
+
+- 负责安装、发现与验证
+- 不替代 `skills/shared/scripts/*` 与各场景 skill 的 Python runtime
+- 不把单 skill 安装伪装成完整 Loom 安装
+- 对安装失败维持 fail-closed
+- main 分支是真相源
+- PR 只做门禁，不直接发布 npm
+- publish 成功后再创建同版本 git tag
+
+Node installer 当前打包的正式安装源：
+
+- plugin payload：`plugins/loom/**`
+- single-skill payload：`packages/skills/<skill-id>/**`
+
+Node installer 的最小 preflight 必须覆盖：
+
+- 目标目录存在且可写
+- package 内 payload 完整且校验不漂移
+- `python3 >= 3.10`，并对 `3.11+` 给出推荐
+- `add skill <skill-id>` 只能接受已登记 skill id
+- Claude plugin 安装必须确认 `claude` CLI 可用
+
+Node installer 的最小 verify 输出必须覆盖：
+
+- `mode`
+- `host`
+- `installed_paths`
+- `verification`
+- `warnings`
+- `fail_closed_reason`
+
+当前宿主映射固定如下：
+
+- Codex plugin
+  - repo-local `plugins/loom/**`
+  - `.agents/plugins/marketplace.json`
+- Codex single-skill
+  - `~/.codex/skills/<skill-id>/`
+  - `~/.codex/config.toml` `[[skills.config]]`
+- Claude plugin
+  - repo-local `.claude/marketplaces/loom-local/`
+  - `claude plugin marketplace add`
+  - `claude plugin install loom@loom-local`
+- Claude single-skill
+  - `<target>/.claude/skills/<skill-id>/`
+
+这些路径与命令属于 adapter surface，不反向提升为 Loom 内核规则。
+
+## 九、不应进入内核的宿主特定细节
 
 以下内容不得直接进入 Loom `skills/` 内核合同：
 
@@ -244,7 +304,7 @@ Loom 在此层不规定包管理器、注册中心、目录布局或分发协议
 
 这些内容可以存在于宿主适配器文档、宿主发行包或宿主实现中，但不应反向污染 Loom 的入口层合同。
 
-## 九、入口层最小验证面
+## 十、入口层最小验证面
 
 对 `skills` 分发与适配合同的验证，至少应覆盖：
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -50,6 +50,8 @@ AREA_READMES = (
 CORE_DOCS = (
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".github/workflows/loom-check.yml",
+    ".github/workflows/node-installer-pr.yml",
+    ".github/workflows/node-installer-release.yml",
     "governance/principles.md",
     "governance/review-model.md",
     "governance/maturity-and-closing.md",
@@ -99,6 +101,17 @@ CORE_DOCS = (
     "templates/review-record.md",
     "templates/scaffold/spec.md",
     "templates/scaffold/plan.md",
+    "packages/loom-installer/README.md",
+    "packages/loom-installer/package.json",
+    "packages/loom-installer/package-lock.json",
+    "packages/loom-installer/tsconfig.json",
+    "packages/loom-installer/scripts/build-payload.mjs",
+    "packages/loom-installer/scripts/check-doc-sync.mjs",
+    "packages/loom-installer/scripts/check-payload-drift.mjs",
+    "packages/loom-installer/scripts/check-version-bump.mjs",
+    "packages/loom-installer/src/cli.ts",
+    "packages/loom-installer/src/index.ts",
+    "packages/loom-installer/test/installer.test.ts",
     "tools/loom_init.py",
     "tools/loom_flow.py",
 )
@@ -4612,6 +4625,33 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
     return failures
 
 
+def check_node_installer(root: Path) -> list[Failure]:
+    category = "node-installer"
+    failures: list[Failure] = []
+    package_root = root / "packages/loom-installer"
+    if not package_root.exists():
+        return [Failure(category, "missing `packages/loom-installer`")]
+    npm_bin = shutil.which("npm")
+    if not npm_bin:
+        return [Failure(category, "`npm` is required to validate the Node installer")]
+
+    commands = (
+        ["npm", "ci"],
+        ["npm", "test"],
+        ["npm", "pack", "--dry-run"],
+    )
+    for args in commands:
+        try:
+            result = run_command(root, args, cwd=package_root, timeout_seconds=300)
+        except subprocess.TimeoutExpired:
+            failures.append(Failure(category, f"`{' '.join(args)}` timed out"))
+            continue
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "command failed without output"
+            failures.append(Failure(category, f"`{' '.join(args)}` failed: {detail}"))
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -4646,12 +4686,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_node_installer(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 15
+    categories_checked = 16
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")


### PR DESCRIPTION
## Summary

- 新增 `@mc-and-his-agents/loom-installer`，为 Loom 提供 npm / `npx` 安装入口
- 支持 Codex / Claude 两类宿主，以及 plugin / single-skill 两类安装面
- 增加 installer 的 PR gate 与 main release workflow，固定 publish 后再追认 git tag / GitHub Release
- 更新 README、skills README、distribution contract，并把 installer smoke 纳入 `loom_check`

## Validation

- `cd packages/loom-installer && npm run check:release`
- `cd packages/loom-installer && npm test`
- `cd packages/loom-installer && npm pack --dry-run`
- `python3 skills/shared/scripts/loom_check.py`

## Risks And Follow-ups

- 当前只实现安装、发现与验证入口，不替代 Python runtime
- main release workflow 依赖 `NPM_TOKEN` 与 GitHub 权限配置，仓库侧仍需确保 secrets 已就绪

## Related Work

- Closes #263
