### PR TITLE
docs: 明确 npm 与仓库接入路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ Loom 面向的是 Agent 执行路径，不要求人类用户手工编排每一�
 
 当接入流程在目标仓库写入 `.loom/` 产物时，会默认把 `.loom/` 追加到 `.gitignore`。
 
+Loom 当前有两条明确的接入路径：
+
+- 通过 npm 安装
+  - 面向“我要在别的项目里使用 Loom”
+  - 使用已发布的 `@mc-and-his-agents/loom-installer`
+  - 这是默认推荐路径
+- 通过 Loom 仓库接入
+  - 面向“我要让 Agent 直接基于这个 Loom 仓库完成接入”
+  - 适合还没准备 npm 安装面、或希望 Agent 按仓库 truth 直接接入的场景
+  - 这不是另一种 npm 命令，而是让 Agent 以仓库地址作为接入来源
+
+如果你只是想把 Loom 接到自己的项目里，优先用 npm 路径。
+如果你正在调试、验证、演示，或希望 Agent 直接以 Loom 仓库为来源完成接入，再使用仓库路径。
+
 ### 用 `npx` 直接接入
 
 如果当前 Agent 环境允许直接执行本地安装命令，可以直接使用 Loom 的 Node installer：
@@ -62,6 +76,23 @@ npx loom-installer add plugin --host claude
 npx loom-installer add skill loom-init --host codex
 npx loom-installer add skill loom-init --host claude
 ```
+
+以上两种都属于“通过 npm 安装”。
+
+### 通过 Loom 仓库接入
+
+如果你不打算先走已发布 npm 包，而是希望 Agent 直接以 Loom 仓库作为接入来源，可以把 Loom 仓库地址直接交给 Agent：
+
+- Loom 仓库：`https://github.com/MC-and-his-Agents/Loom`
+
+这种方式适合：
+
+- 你要按仓库当前 truth 直接接入，而不是依赖已发布版本
+- 你在验证、调试或演示 Loom
+- 你希望 Agent 自己判断当前环境更适合 plugin 还是 single-skill 接入
+
+这种方式不等于已经通过 npm 安装 `@mc-and-his-agents/loom-installer`。
+它表达的是“把 Loom 仓库作为接入来源”，而不是“从 npm 获取 Loom 安装器”。
 
 ### 完整接入 Loom Plugin
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/plugins/loom/skills/README.md
+++ b/plugins/loom/skills/README.md
@@ -33,12 +33,28 @@ Loom 在 `skills` 层固定承认两类对象：
 
 ## 安装入口
 
+Loom 在安装层固定区分两条路径：
+
+- 通过 npm 安装
+  - 面向“在别的项目里使用 Loom”
+  - 使用已发布的 `@mc-and-his-agents/loom-installer`
+  - 这是默认推荐路径
+- 通过 Loom 仓库接入
+  - 面向“让 Agent 直接以 Loom 仓库作为接入来源”
+  - 适合调试、验证、演示，或希望按仓库当前 truth 直接接入的场景
+  - 这不是另一种 npm 命令，而是把 Loom 仓库地址交给 Agent 作为安装来源
+
+如果目标是把 Loom 稳定接到别的项目里，优先走 npm 路径。
+如果目标是验证仓库 truth、调试接入链，或让 Agent 直接按仓库当前状态完成接入，再走仓库路径。
+
+### 通过 npm 安装
+
 Loom 当前正式承认一条 npm / `npx` 安装入口：
 
 - `npx @mc-and-his-agents/loom-installer add plugin`
 - `npx @mc-and-his-agents/loom-installer add skill <skill-id>`
 
-这条入口负责安装、发现与验证，不替代 Python runtime。
+这条 npm 入口负责安装、发现与验证，不替代 Python runtime。
 
 运行前提：
 
@@ -50,6 +66,22 @@ Loom 当前正式承认一条 npm / `npx` 安装入口：
 - `add plugin` 承诺完整 Loom 入口面
 - `add skill <skill-id>` 只承诺对应标准 skill
 - 安装成功不等于已经执行 Loom runtime，只代表安装 / 发现 / 验证链成立
+
+### 通过 Loom 仓库接入
+
+如果不走已发布 npm 包，也可以把 Loom 仓库直接交给 Agent 作为接入来源：
+
+- Loom 仓库：`https://github.com/MC-and-his-Agents/Loom`
+
+这种方式表达的是“按仓库当前 truth 直接接入 Loom”，而不是“通过 npm 获取 installer”。
+它适合：
+
+- 验证仓库当前 truth 是否可被直接接入
+- 调试、演示或本地试装 Loom
+- 让 Agent 在当前环境里自行判断更适合 plugin 还是 single-skill 接入
+
+这条路径不等于已经安装 `@mc-and-his-agents/loom-installer`。
+如果用户需要稳定、可复用、面向已发布版本的安装面，应回到 npm 路径。
 
 ## 用户会看到哪些入口
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,12 +33,28 @@ Loom 在 `skills` 层固定承认两类对象：
 
 ## 安装入口
 
+Loom 在安装层固定区分两条路径：
+
+- 通过 npm 安装
+  - 面向“在别的项目里使用 Loom”
+  - 使用已发布的 `@mc-and-his-agents/loom-installer`
+  - 这是默认推荐路径
+- 通过 Loom 仓库接入
+  - 面向“让 Agent 直接以 Loom 仓库作为接入来源”
+  - 适合调试、验证、演示，或希望按仓库当前 truth 直接接入的场景
+  - 这不是另一种 npm 命令，而是把 Loom 仓库地址交给 Agent 作为安装来源
+
+如果目标是把 Loom 稳定接到别的项目里，优先走 npm 路径。
+如果目标是验证仓库 truth、调试接入链，或让 Agent 直接按仓库当前状态完成接入，再走仓库路径。
+
+### 通过 npm 安装
+
 Loom 当前正式承认一条 npm / `npx` 安装入口：
 
 - `npx @mc-and-his-agents/loom-installer add plugin`
 - `npx @mc-and-his-agents/loom-installer add skill <skill-id>`
 
-这条入口负责安装、发现与验证，不替代 Python runtime。
+这条 npm 入口负责安装、发现与验证，不替代 Python runtime。
 
 运行前提：
 
@@ -50,6 +66,22 @@ Loom 当前正式承认一条 npm / `npx` 安装入口：
 - `add plugin` 承诺完整 Loom 入口面
 - `add skill <skill-id>` 只承诺对应标准 skill
 - 安装成功不等于已经执行 Loom runtime，只代表安装 / 发现 / 验证链成立
+
+### 通过 Loom 仓库接入
+
+如果不走已发布 npm 包，也可以把 Loom 仓库直接交给 Agent 作为接入来源：
+
+- Loom 仓库：`https://github.com/MC-and-his-Agents/Loom`
+
+这种方式表达的是“按仓库当前 truth 直接接入 Loom”，而不是“通过 npm 获取 installer”。
+它适合：
+
+- 验证仓库当前 truth 是否可被直接接入
+- 调试、演示或本地试装 Loom
+- 让 Agent 在当前环境里自行判断更适合 plugin 还是 single-skill 接入
+
+这条路径不等于已经安装 `@mc-and-his-agents/loom-installer`。
+如果用户需要稳定、可复用、面向已发布版本的安装面，应回到 npm 路径。
 
 ## 用户会看到哪些入口
 


### PR DESCRIPTION
## 变更
- 在根 README 明确区分通过 npm 安装与通过 Loom 仓库接入两条路径
- 在 skills README 明确相同边界
- 同步 plugin 镜像 README，避免文档漂移

## 验证
- npm --prefix packages/loom-installer run check:docs