### PR TITLE
feat(skills): 硬化 root route 与安装入口的稳定回归测试

### DIFF
--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/packages/loom-installer/scripts/check-doc-sync.mjs
+++ b/packages/loom-installer/scripts/check-doc-sync.mjs
@@ -17,25 +17,44 @@ const requiredNeedles = [
     path: 'README.md',
     needles: [
       'npx @mc-and-his-agents/loom-installer add plugin --host codex',
+      'npx @mc-and-his-agents/loom-installer add skill loom-init --host codex',
       'npm install -D @mc-and-his-agents/loom-installer',
       'Node `>=20`',
       'Python `>=3.10`，推荐 `3.11+`',
       'Loom 当前真实执行面仍然是仓库里的 Python runtime。',
+      '你希望 Agent 自己判断当前环境更适合 plugin 还是 single-skill 接入',
     ],
   },
   {
     path: 'skills/README.md',
     needles: [
       'npx @mc-and-his-agents/loom-installer add plugin',
+      'npx @mc-and-his-agents/loom-installer add skill <skill-id>',
+      'add plugin` 承诺完整 Loom 入口面',
+      'add skill <skill-id>` 只承诺对应标准 skill',
       '安装成功不等于已经执行 Loom runtime',
+      '单 skill package 不自动补齐 `loom-init`、其余 scenario skills 或完整 plugin 安装体验',
     ],
   },
   {
     path: 'skills/distribution-and-adapter-contract.md',
     needles: [
       '@mc-and-his-agents/loom-installer',
+      '不伪装成 repo-local `loom` plugin 的完整安装成功',
+      '若 shared runtime / resources 缺失、合同漂移或运行态冲突，宿主必须 fail-closed，而不是继续报告“可运行”',
+      '当前入口属于 plugin install、scenario skill 还是单 skill package',
       'main 分支是真相源',
       'publish 成功后再创建同版本 git tag',
+    ],
+  },
+  {
+    path: 'skills/route-matrix.md',
+    needles: [
+      '显式 skill 名称调用优先',
+      '若无显式 skill，则按任务信号做隐式路由',
+      '若无法稳定判断，回退到 `loom-init`，输出最小补充信号',
+      '`selected_skill: "loom-init"`',
+      '`fallback_to: "loom-init"`',
     ],
   },
   {
@@ -44,6 +63,8 @@ const requiredNeedles = [
       'npm install -D @mc-and-his-agents/loom-installer',
       'Node `>=20`',
       'Python `>=3.10`，推荐 `3.11+`',
+      '把某个单独 Loom skill 接到对应宿主',
+      '它不替代 Loom 当前的 Python runtime；真正的执行面仍然是仓库里的 Python 脚本与已发布的 skill / plugin 产物。',
       '发布只在 `main` 上进行',
     ],
   },

--- a/packages/loom-installer/src/codex.ts
+++ b/packages/loom-installer/src/codex.ts
@@ -55,7 +55,7 @@ function ensureMarketplace(targetRoot: string, force: boolean): string[] {
   const existing = marketplace.plugins.find(
     (entry) => typeof entry === 'object' && entry !== null && (entry as { name?: string }).name === 'loom',
   ) as { name?: string; source?: { path?: string } } | undefined;
-  if (existing && existing.source?.path && existing.source.path !== expectedPath) {
+  if (existing && existing.source?.path && existing.source.path !== expectedPath && !force) {
     throw new InstallerError(
       `Codex marketplace already declares loom from a different path: ${existing.source.path}`,
       `refusing to take over non-Loom marketplace entry for loom: ${existing.source.path}`,

--- a/packages/loom-installer/test/installer.test.ts
+++ b/packages/loom-installer/test/installer.test.ts
@@ -40,6 +40,13 @@ function prepareEnv(base: string): NodeJS.ProcessEnv {
   };
 }
 
+function writeCodexMarketplace(repoRoot: string, marketplace: unknown): string {
+  const marketplacePath = join(repoRoot, '.agents', 'plugins', 'marketplace.json');
+  mkdirSync(join(repoRoot, '.agents', 'plugins'), { recursive: true });
+  writeFileSync(marketplacePath, JSON.stringify(marketplace, null, 2));
+  return marketplacePath;
+}
+
 function writeFakeClaude(binDir: string, logPath: string): string {
   const scriptPath = join(binDir, 'claude');
   writeFileSync(
@@ -114,6 +121,73 @@ test('codex plugin install writes marketplace entry', () => {
   assert.equal(marketplace.plugins[0].source.path, './plugins/loom');
 });
 
+test('codex plugin install fails closed on marketplace conflicts without force', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+  writeCodexMarketplace(repoRoot, {
+    name: 'custom-marketplace',
+    plugins: [
+      {
+        name: 'loom',
+        source: {
+          source: 'local',
+          path: './plugins/not-loom',
+        },
+      },
+    ],
+  });
+
+  const parsed: ParsedCommand = {
+    mode: 'plugin',
+    options: {
+      host: 'codex',
+      target: repoRoot,
+      force: false,
+      json: false,
+    },
+  };
+
+  assert.throws(() => runInstaller(parsed, envSource, packageRoot()), /already declares loom from a different path/);
+});
+
+test('codex plugin install lets --force take over conflicting marketplace entry', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+  writeCodexMarketplace(repoRoot, {
+    name: 'custom-marketplace',
+    plugins: [
+      {
+        name: 'loom',
+        source: {
+          source: 'local',
+          path: './plugins/not-loom',
+        },
+      },
+    ],
+  });
+
+  const parsed: ParsedCommand = {
+    mode: 'plugin',
+    options: {
+      host: 'codex',
+      target: repoRoot,
+      force: true,
+      json: false,
+    },
+  };
+
+  const result = runInstaller(parsed, envSource, packageRoot());
+  const marketplace = JSON.parse(readFileSync(join(repoRoot, '.agents', 'plugins', 'marketplace.json'), 'utf8'));
+  assert.equal(result.mode, 'plugin');
+  assert.equal(marketplace.plugins[0].source.path, './plugins/loom');
+});
+
 test('codex skill install writes skills.config entry', () => {
   const base = fixtureRoot();
   const envSource = prepareEnv(base);
@@ -138,6 +212,101 @@ test('codex skill install writes skills.config entry', () => {
   assert.match(config, /\[\[skills\.config\]\]/);
   assert.match(config, /loom-review\/SKILL\.md/);
   assert.match(config, /enabled = true/);
+});
+
+test('codex skill install fails closed on conflicting skills.config entry without force', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+  writeFileSync(
+    join(envSource.CODEX_HOME!, 'config.toml'),
+    [
+      'model = "gpt-5"',
+      '',
+      '[[skills.config]]',
+      'path = "/tmp/other/loom-review/SKILL.md"',
+      'enabled = true',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+
+  const parsed: ParsedCommand = {
+    mode: 'skill',
+    skillId: 'loom-review',
+    options: {
+      host: 'codex',
+      target: repoRoot,
+      force: false,
+      json: false,
+    },
+  };
+
+  assert.throws(() => runInstaller(parsed, envSource, packageRoot()), /already has loom-review from a different path/);
+});
+
+test('codex skill install lets --force take over conflicting skills.config entry', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+  writeFileSync(
+    join(envSource.CODEX_HOME!, 'config.toml'),
+    [
+      'model = "gpt-5"',
+      '',
+      '[[skills.config]]',
+      'path = "/tmp/other/loom-review/SKILL.md"',
+      'enabled = true',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+
+  const parsed: ParsedCommand = {
+    mode: 'skill',
+    skillId: 'loom-review',
+    options: {
+      host: 'codex',
+      target: repoRoot,
+      force: true,
+      json: false,
+    },
+  };
+
+  const result = runInstaller(parsed, envSource, packageRoot());
+  const config = readFileSync(join(envSource.CODEX_HOME!, 'config.toml'), 'utf8');
+  assert.equal(result.mode, 'skill');
+  assert.doesNotMatch(config, /\/tmp\/other\/loom-review\/SKILL\.md/);
+  assert.match(config, /loom-review\/SKILL\.md/);
+});
+
+test('single-skill installs stay scoped to the named skill for codex', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CODEX_HOME!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+
+  const parsed: ParsedCommand = {
+    mode: 'skill',
+    skillId: 'loom-init',
+    options: {
+      host: 'codex',
+      target: repoRoot,
+      force: false,
+      json: false,
+    },
+  };
+
+  const result = runInstaller(parsed, envSource, packageRoot());
+  assert.equal(result.mode, 'skill');
+  assert.match(result.warnings[0] ?? '', /only the named skill, not the full Loom plugin surface/);
+  assert.equal(existsSync(join(repoRoot, 'plugins', 'loom')), false);
+  assert.equal(existsSync(join(repoRoot, '.agents', 'plugins', 'marketplace.json')), false);
 });
 
 test('claude plugin install assembles marketplace and calls claude CLI', () => {
@@ -169,6 +338,31 @@ test('claude plugin install assembles marketplace and calls claude CLI', () => {
   assert.equal(pluginManifest.name, 'loom');
   assert.match(log, /plugin marketplace add/);
   assert.match(log, /plugin install loom@loom-local/);
+});
+
+test('single-skill installs stay scoped to the named skill for claude', () => {
+  const base = fixtureRoot();
+  const envSource = prepareEnv(base);
+  mkdirSync(envSource.CLAUDE_CONFIG_DIR!, { recursive: true });
+  const repoRoot = join(base, 'repo');
+  mkdirSync(repoRoot, { recursive: true });
+
+  const parsed: ParsedCommand = {
+    mode: 'skill',
+    skillId: 'loom-init',
+    options: {
+      host: 'claude',
+      target: repoRoot,
+      force: false,
+      json: false,
+    },
+  };
+
+  const result = runInstaller(parsed, envSource, packageRoot());
+  assert.equal(result.mode, 'skill');
+  assert.match(result.warnings[0] ?? '', /does not expose the full Loom plugin surface/);
+  assert.equal(existsSync(join(repoRoot, '.claude', 'skills', 'loom-init', 'SKILL.md')), true);
+  assert.equal(existsSync(join(repoRoot, '.claude', 'marketplaces', 'loom-local')), false);
 });
 
 test('cli emits structured json on success', () => {

--- a/plugins/loom/skills/shared/scripts/loom_check.py
+++ b/plugins/loom/skills/shared/scripts/loom_check.py
@@ -359,6 +359,10 @@ def load_json_file(path: Path) -> object:
         return json.load(handle)
 
 
+def load_text_file(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 def run_command(
     root: Path,
     args: list[str],
@@ -1200,6 +1204,73 @@ def require_route_payload(
         )
 
 
+def check_root_route_contracts(root: Path) -> list[Failure]:
+    category = "skill-routing-contract"
+    failures: list[Failure] = []
+    readme_path = root / "README.md"
+    skills_readme_path = root / "skills/README.md"
+    route_matrix_path = root / "skills/route-matrix.md"
+    contract_path = root / "skills/loom-init/contract.json"
+
+    try:
+        readme = load_text_file(readme_path)
+        skills_readme = load_text_file(skills_readme_path)
+        route_matrix = load_text_file(route_matrix_path)
+        contract = load_json_file(contract_path)
+    except FileNotFoundError:
+        return failures
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"`skills/loom-init/contract.json` is invalid JSON: {exc.msg}")]
+
+    if not isinstance(contract, dict):
+        return [Failure(category, "`skills/loom-init/contract.json` must be a JSON object")]
+
+    if "### 完整接入 Loom Plugin" not in readme:
+        failures.append(Failure(category, "`README.md` must keep the Loom plugin installation entry section"))
+    if "### `loom-init`" not in readme:
+        failures.append(Failure(category, "`README.md` must keep the single-skill `loom-init` installation section"))
+    if "它是 Loom 唯一的 root entry" not in skills_readme:
+        failures.append(Failure(category, "`skills/README.md` must keep `loom-init` as the unique root entry"))
+    if "显式 skill 名称调用优先" not in route_matrix:
+        failures.append(Failure(category, "`skills/route-matrix.md` must keep explicit routing as the first priority"))
+    if "若无法稳定判断，回退到 `loom-init`" not in route_matrix:
+        failures.append(Failure(category, "`skills/route-matrix.md` must keep fallback-to-loom-init semantics"))
+    if "`plugin` 与 `single-skill` 两类安装结果边界" not in route_matrix and "fallback_to: \"loom-init\"" not in route_matrix:
+        failures.append(Failure(category, "`skills/route-matrix.md` must keep the stable fallback payload contract"))
+
+    if contract.get("id") != "loom-init":
+        failures.append(Failure(category, "`skills/loom-init/contract.json` id must remain `loom-init`"))
+    if contract.get("root_entry") is not True:
+        failures.append(Failure(category, "`skills/loom-init/contract.json` must keep `root_entry: true`"))
+
+    routing = contract.get("routing")
+    if not isinstance(routing, dict):
+        failures.append(Failure(category, "`skills/loom-init/contract.json` must declare `routing`"))
+    else:
+        if routing.get("reference") != "../route-matrix.md":
+            failures.append(Failure(category, "`skills/loom-init/contract.json` must reference `../route-matrix.md`"))
+        if routing.get("fallback_entry") != "loom-init":
+            failures.append(Failure(category, "`skills/loom-init/contract.json` fallback entry must remain `loom-init`"))
+        if routing.get("priority_order") != [
+            "explicit skill name",
+            "task signal routing",
+            "fallback to loom-init with missing inputs",
+        ]:
+            failures.append(Failure(category, "`skills/loom-init/contract.json` routing priority order drifted from the stable contract"))
+
+    installation_commands = (
+        "npx @mc-and-his-agents/loom-installer add plugin",
+        "npx @mc-and-his-agents/loom-installer add skill <skill-id>",
+    )
+    for command in installation_commands:
+        if command not in skills_readme:
+            failures.append(Failure(category, f"`skills/README.md` must document `{command}`"))
+    if "请按当前 Agent 环境支持的方式，只接入 `loom-init`" not in readme:
+        failures.append(Failure(category, "`README.md` must preserve the `loom-init` single-skill boundary prompt"))
+
+    return failures
+
+
 def check_skill_manifests(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     expected_entries = {
@@ -1484,22 +1555,18 @@ def check_skill_routing(root: Path) -> list[Failure]:
         if error:
             failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` failed: {error}"))
             continue
-        if payload.get("command") != "route":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must report `command: route`"))
-        if payload.get("result") != "pass":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must pass"))
-        if payload.get("selected_skill") != skill_id:
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` selected `{payload.get('selected_skill')}`"))
-        if payload.get("mode") != "explicit":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must report `mode: explicit`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context=f"explicit route for `{skill_id}`",
+            payload=payload,
+            expected_skill=skill_id,
+            expected_mode="explicit",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+        )
         if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
             failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must include `summary`"))
-        if not isinstance(payload.get("matched_signals"), list):
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must include `matched_signals`"))
-        if not isinstance(payload.get("missing_inputs"), list):
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must include `missing_inputs`"))
-        if payload.get("fallback_to") != "loom-init":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must keep `fallback_to: loom-init`"))
         if skill_id in GOVERNANCE_SURFACE_ROUTE_SKILLS and payload.get("result") == "pass":
             require_governance_surface(
                 failures,
@@ -1525,20 +1592,20 @@ def check_skill_routing(root: Path) -> list[Failure]:
         if error:
             failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` failed: {error}"))
             continue
-        if payload.get("command") != "route":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must report `command: route`"))
-        if payload.get("result") != "pass":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must pass"))
-        if payload.get("selected_skill") != skill_id:
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` selected `{payload.get('selected_skill')}`"))
-        if payload.get("mode") != "implicit":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must report `mode: implicit`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context=f"implicit route for `{skill_id}`",
+            payload=payload,
+            expected_skill=skill_id,
+            expected_mode="implicit",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+        )
         if not isinstance(payload.get("matched_signals"), list) or not payload.get("matched_signals"):
             failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must include matched signals"))
         if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
             failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must include `summary`"))
-        if payload.get("fallback_to") != "loom-init":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must keep `fallback_to: loom-init`"))
         if skill_id in GOVERNANCE_SURFACE_ROUTE_SKILLS and payload.get("result") == "pass":
             require_governance_surface(
                 failures,
@@ -1554,10 +1621,17 @@ def check_skill_routing(root: Path) -> list[Failure]:
     if error:
         failures.append(Failure("skill-routing", f"fallback route failed: {error}"))
     else:
-        if fallback_payload.get("result") != "fallback":
-            failures.append(Failure("skill-routing", "ambiguous task must return `fallback`"))
-        if fallback_payload.get("selected_skill") != "loom-init":
-            failures.append(Failure("skill-routing", "fallback route must select `loom-init`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context="fallback route",
+            payload=fallback_payload,
+            expected_skill="loom-init",
+            expected_mode="fallback",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+            allowed_results={"fallback"},
+        )
         if not isinstance(fallback_payload.get("missing_inputs"), list) or not fallback_payload.get("missing_inputs"):
             failures.append(Failure("skill-routing", "fallback route must include `missing_inputs`"))
 
@@ -1576,10 +1650,17 @@ def check_skill_routing(root: Path) -> list[Failure]:
     if error:
         failures.append(Failure("skill-routing", f"ambiguous route failed: {error}"))
     else:
-        if ambiguous_payload.get("result") != "fallback":
-            failures.append(Failure("skill-routing", "multi-match task must return `fallback`"))
-        if ambiguous_payload.get("selected_skill") != "loom-init":
-            failures.append(Failure("skill-routing", "multi-match route must select `loom-init`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context="multi-match route",
+            payload=ambiguous_payload,
+            expected_skill="loom-init",
+            expected_mode="fallback",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+            allowed_results={"fallback"},
+        )
         if not isinstance(ambiguous_payload.get("matched_signals"), list) or len(ambiguous_payload.get("matched_signals", [])) < 2:
             failures.append(Failure("skill-routing", "multi-match route must expose matched signals"))
 
@@ -1590,10 +1671,62 @@ def check_skill_routing(root: Path) -> list[Failure]:
     if error:
         failures.append(Failure("skill-routing", f"unknown explicit route failed: {error}"))
     else:
-        if unknown_payload.get("result") != "block":
-            failures.append(Failure("skill-routing", "unknown explicit skill must block"))
-        if unknown_payload.get("selected_skill") != "loom-init":
-            failures.append(Failure("skill-routing", "unknown explicit skill must fall back to `loom-init`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context="unknown explicit route",
+            payload=unknown_payload,
+            expected_skill="loom-init",
+            expected_mode="explicit",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+            allowed_results={"block"},
+        )
+        if "unknown skill" not in str(unknown_payload.get("summary", "")):
+            failures.append(Failure("skill-routing", "unknown explicit skill must expose an `unknown skill` summary"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-route-registry-") as tmp:
+        broken_skills = Path(tmp) / "skills"
+        shutil.copytree(root / "skills", broken_skills)
+        registry_path = broken_skills / "registry.json"
+        registry = load_json_file(registry_path)
+        if isinstance(registry, dict):
+            entries = registry.get("entries")
+            if isinstance(entries, list):
+                registry["entries"] = [
+                    entry
+                    for entry in entries
+                    if not (isinstance(entry, dict) and entry.get("id") == "loom-review")
+                ]
+                registry_path.write_text(json.dumps(registry, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        drift_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                str(broken_skills / "loom-init" / "scripts" / "loom-init.py"),
+                "route",
+                "--target",
+                str(target),
+                "--task",
+                "请对当前事项做正式 review 并给出审查结论",
+            ],
+        )
+        if error:
+            failures.append(Failure("skill-routing", f"registry drift route failed: {error}"))
+        else:
+            require_route_payload(
+                failures,
+                category="skill-routing",
+                context="registry drift route",
+                payload=drift_payload,
+                expected_skill="loom-init",
+                expected_mode="implicit",
+                expected_runtime_scene="installed-runtime",
+                expected_runtime_carrier="installed-skills-root",
+                allowed_results={"block"},
+            )
+            if "route table resolved to unknown registry skill" not in str(drift_payload.get("summary", "")):
+                failures.append(Failure("skill-routing", "registry drift route must expose an unknown registry skill summary"))
 
     return failures
 
@@ -4677,6 +4810,7 @@ def collect_failures(root: Path) -> list[Failure]:
             AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT,
         )
     )
+    failures.extend(check_root_route_contracts(root))
     failures.extend(check_skill_manifests(root))
     failures.extend(check_skill_routing(root))
     failures.extend(check_demo_assets(root))
@@ -4692,7 +4826,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 16
+    categories_checked = 17
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -359,6 +359,10 @@ def load_json_file(path: Path) -> object:
         return json.load(handle)
 
 
+def load_text_file(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
 def run_command(
     root: Path,
     args: list[str],
@@ -1200,6 +1204,73 @@ def require_route_payload(
         )
 
 
+def check_root_route_contracts(root: Path) -> list[Failure]:
+    category = "skill-routing-contract"
+    failures: list[Failure] = []
+    readme_path = root / "README.md"
+    skills_readme_path = root / "skills/README.md"
+    route_matrix_path = root / "skills/route-matrix.md"
+    contract_path = root / "skills/loom-init/contract.json"
+
+    try:
+        readme = load_text_file(readme_path)
+        skills_readme = load_text_file(skills_readme_path)
+        route_matrix = load_text_file(route_matrix_path)
+        contract = load_json_file(contract_path)
+    except FileNotFoundError:
+        return failures
+    except json.JSONDecodeError as exc:
+        return [Failure(category, f"`skills/loom-init/contract.json` is invalid JSON: {exc.msg}")]
+
+    if not isinstance(contract, dict):
+        return [Failure(category, "`skills/loom-init/contract.json` must be a JSON object")]
+
+    if "### 完整接入 Loom Plugin" not in readme:
+        failures.append(Failure(category, "`README.md` must keep the Loom plugin installation entry section"))
+    if "### `loom-init`" not in readme:
+        failures.append(Failure(category, "`README.md` must keep the single-skill `loom-init` installation section"))
+    if "它是 Loom 唯一的 root entry" not in skills_readme:
+        failures.append(Failure(category, "`skills/README.md` must keep `loom-init` as the unique root entry"))
+    if "显式 skill 名称调用优先" not in route_matrix:
+        failures.append(Failure(category, "`skills/route-matrix.md` must keep explicit routing as the first priority"))
+    if "若无法稳定判断，回退到 `loom-init`" not in route_matrix:
+        failures.append(Failure(category, "`skills/route-matrix.md` must keep fallback-to-loom-init semantics"))
+    if "`plugin` 与 `single-skill` 两类安装结果边界" not in route_matrix and "fallback_to: \"loom-init\"" not in route_matrix:
+        failures.append(Failure(category, "`skills/route-matrix.md` must keep the stable fallback payload contract"))
+
+    if contract.get("id") != "loom-init":
+        failures.append(Failure(category, "`skills/loom-init/contract.json` id must remain `loom-init`"))
+    if contract.get("root_entry") is not True:
+        failures.append(Failure(category, "`skills/loom-init/contract.json` must keep `root_entry: true`"))
+
+    routing = contract.get("routing")
+    if not isinstance(routing, dict):
+        failures.append(Failure(category, "`skills/loom-init/contract.json` must declare `routing`"))
+    else:
+        if routing.get("reference") != "../route-matrix.md":
+            failures.append(Failure(category, "`skills/loom-init/contract.json` must reference `../route-matrix.md`"))
+        if routing.get("fallback_entry") != "loom-init":
+            failures.append(Failure(category, "`skills/loom-init/contract.json` fallback entry must remain `loom-init`"))
+        if routing.get("priority_order") != [
+            "explicit skill name",
+            "task signal routing",
+            "fallback to loom-init with missing inputs",
+        ]:
+            failures.append(Failure(category, "`skills/loom-init/contract.json` routing priority order drifted from the stable contract"))
+
+    installation_commands = (
+        "npx @mc-and-his-agents/loom-installer add plugin",
+        "npx @mc-and-his-agents/loom-installer add skill <skill-id>",
+    )
+    for command in installation_commands:
+        if command not in skills_readme:
+            failures.append(Failure(category, f"`skills/README.md` must document `{command}`"))
+    if "请按当前 Agent 环境支持的方式，只接入 `loom-init`" not in readme:
+        failures.append(Failure(category, "`README.md` must preserve the `loom-init` single-skill boundary prompt"))
+
+    return failures
+
+
 def check_skill_manifests(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     expected_entries = {
@@ -1484,22 +1555,18 @@ def check_skill_routing(root: Path) -> list[Failure]:
         if error:
             failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` failed: {error}"))
             continue
-        if payload.get("command") != "route":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must report `command: route`"))
-        if payload.get("result") != "pass":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must pass"))
-        if payload.get("selected_skill") != skill_id:
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` selected `{payload.get('selected_skill')}`"))
-        if payload.get("mode") != "explicit":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must report `mode: explicit`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context=f"explicit route for `{skill_id}`",
+            payload=payload,
+            expected_skill=skill_id,
+            expected_mode="explicit",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+        )
         if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
             failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must include `summary`"))
-        if not isinstance(payload.get("matched_signals"), list):
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must include `matched_signals`"))
-        if not isinstance(payload.get("missing_inputs"), list):
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must include `missing_inputs`"))
-        if payload.get("fallback_to") != "loom-init":
-            failures.append(Failure("skill-routing", f"explicit route for `{skill_id}` must keep `fallback_to: loom-init`"))
         if skill_id in GOVERNANCE_SURFACE_ROUTE_SKILLS and payload.get("result") == "pass":
             require_governance_surface(
                 failures,
@@ -1525,20 +1592,20 @@ def check_skill_routing(root: Path) -> list[Failure]:
         if error:
             failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` failed: {error}"))
             continue
-        if payload.get("command") != "route":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must report `command: route`"))
-        if payload.get("result") != "pass":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must pass"))
-        if payload.get("selected_skill") != skill_id:
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` selected `{payload.get('selected_skill')}`"))
-        if payload.get("mode") != "implicit":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must report `mode: implicit`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context=f"implicit route for `{skill_id}`",
+            payload=payload,
+            expected_skill=skill_id,
+            expected_mode="implicit",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+        )
         if not isinstance(payload.get("matched_signals"), list) or not payload.get("matched_signals"):
             failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must include matched signals"))
         if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
             failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must include `summary`"))
-        if payload.get("fallback_to") != "loom-init":
-            failures.append(Failure("skill-routing", f"implicit route for `{skill_id}` must keep `fallback_to: loom-init`"))
         if skill_id in GOVERNANCE_SURFACE_ROUTE_SKILLS and payload.get("result") == "pass":
             require_governance_surface(
                 failures,
@@ -1554,10 +1621,17 @@ def check_skill_routing(root: Path) -> list[Failure]:
     if error:
         failures.append(Failure("skill-routing", f"fallback route failed: {error}"))
     else:
-        if fallback_payload.get("result") != "fallback":
-            failures.append(Failure("skill-routing", "ambiguous task must return `fallback`"))
-        if fallback_payload.get("selected_skill") != "loom-init":
-            failures.append(Failure("skill-routing", "fallback route must select `loom-init`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context="fallback route",
+            payload=fallback_payload,
+            expected_skill="loom-init",
+            expected_mode="fallback",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+            allowed_results={"fallback"},
+        )
         if not isinstance(fallback_payload.get("missing_inputs"), list) or not fallback_payload.get("missing_inputs"):
             failures.append(Failure("skill-routing", "fallback route must include `missing_inputs`"))
 
@@ -1576,10 +1650,17 @@ def check_skill_routing(root: Path) -> list[Failure]:
     if error:
         failures.append(Failure("skill-routing", f"ambiguous route failed: {error}"))
     else:
-        if ambiguous_payload.get("result") != "fallback":
-            failures.append(Failure("skill-routing", "multi-match task must return `fallback`"))
-        if ambiguous_payload.get("selected_skill") != "loom-init":
-            failures.append(Failure("skill-routing", "multi-match route must select `loom-init`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context="multi-match route",
+            payload=ambiguous_payload,
+            expected_skill="loom-init",
+            expected_mode="fallback",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+            allowed_results={"fallback"},
+        )
         if not isinstance(ambiguous_payload.get("matched_signals"), list) or len(ambiguous_payload.get("matched_signals", [])) < 2:
             failures.append(Failure("skill-routing", "multi-match route must expose matched signals"))
 
@@ -1590,10 +1671,62 @@ def check_skill_routing(root: Path) -> list[Failure]:
     if error:
         failures.append(Failure("skill-routing", f"unknown explicit route failed: {error}"))
     else:
-        if unknown_payload.get("result") != "block":
-            failures.append(Failure("skill-routing", "unknown explicit skill must block"))
-        if unknown_payload.get("selected_skill") != "loom-init":
-            failures.append(Failure("skill-routing", "unknown explicit skill must fall back to `loom-init`"))
+        require_route_payload(
+            failures,
+            category="skill-routing",
+            context="unknown explicit route",
+            payload=unknown_payload,
+            expected_skill="loom-init",
+            expected_mode="explicit",
+            expected_runtime_scene="repo-local-demo",
+            expected_runtime_carrier="repo-local-wrapper",
+            allowed_results={"block"},
+        )
+        if "unknown skill" not in str(unknown_payload.get("summary", "")):
+            failures.append(Failure("skill-routing", "unknown explicit skill must expose an `unknown skill` summary"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-route-registry-") as tmp:
+        broken_skills = Path(tmp) / "skills"
+        shutil.copytree(root / "skills", broken_skills)
+        registry_path = broken_skills / "registry.json"
+        registry = load_json_file(registry_path)
+        if isinstance(registry, dict):
+            entries = registry.get("entries")
+            if isinstance(entries, list):
+                registry["entries"] = [
+                    entry
+                    for entry in entries
+                    if not (isinstance(entry, dict) and entry.get("id") == "loom-review")
+                ]
+                registry_path.write_text(json.dumps(registry, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        drift_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                str(broken_skills / "loom-init" / "scripts" / "loom-init.py"),
+                "route",
+                "--target",
+                str(target),
+                "--task",
+                "请对当前事项做正式 review 并给出审查结论",
+            ],
+        )
+        if error:
+            failures.append(Failure("skill-routing", f"registry drift route failed: {error}"))
+        else:
+            require_route_payload(
+                failures,
+                category="skill-routing",
+                context="registry drift route",
+                payload=drift_payload,
+                expected_skill="loom-init",
+                expected_mode="implicit",
+                expected_runtime_scene="installed-runtime",
+                expected_runtime_carrier="installed-skills-root",
+                allowed_results={"block"},
+            )
+            if "route table resolved to unknown registry skill" not in str(drift_payload.get("summary", "")):
+                failures.append(Failure("skill-routing", "registry drift route must expose an unknown registry skill summary"))
 
     return failures
 
@@ -4677,6 +4810,7 @@ def collect_failures(root: Path) -> list[Failure]:
             AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT,
         )
     )
+    failures.extend(check_root_route_contracts(root))
     failures.extend(check_skill_manifests(root))
     failures.extend(check_skill_routing(root))
     failures.extend(check_demo_assets(root))
@@ -4692,7 +4826,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 16
+    categories_checked = 17
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")


### PR DESCRIPTION
## Summary
- 补强 root route、fallback 与 registry drift 的行为级回归检查
- 扩展 installer tests，覆盖 plugin / single-skill 边界、冲突 fail-closed 与 `--force` 接管语义
- 收紧 README / route matrix / contract / implementation 的一致性门禁

## Testing
- npm ci --prefix packages/loom-installer
- npm --prefix packages/loom-installer run check:docs
- npm --prefix packages/loom-installer run check:payload
- npm --prefix packages/loom-installer test
- make loom-check

Closes #273
