### PR TITLE
chore(release): 发布 loom-installer 0.1.5

### DIFF
--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- 将 `@mc-and-his-agents/loom-installer` 从 `0.1.4` 提升到 `0.1.5`
- 触发一次真实 npm 发布、installer tag 与 GitHub Release 流程

## Validation

- `npm --prefix packages/loom-installer run check:docs`
- `npm --prefix packages/loom-installer run check:payload`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `make loom-check`
