### PR TITLE
feat: 高频 GitHub 读取改用 REST 降低 GraphQL 消耗

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -337,10 +337,15 @@
     },
     "github_control_plane": {
       "repository": "MC-and-his-Agents/Loom",
-      "default_branch": "unknown",
-      "branch_protection": "unknown",
-      "required_checks": "unknown",
-      "pr_reviews": "unknown"
+      "default_branch": "main",
+      "branch_protection": "enabled",
+      "required_checks": [
+        "py-compile",
+        "demo-bootstrap",
+        "repo-local-cli",
+        "loom-check"
+      ],
+      "pr_reviews": "not_required"
     },
     "repo_interface": {
       "availability": "absent",
@@ -425,7 +430,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "feat/syvert-governance-parity",
+            "locator": "feat/graphql-budget-rest-high-frequency",
             "authority": "git"
           },
           "worktree": {
@@ -449,12 +454,10 @@
             "authority": "loom + host"
           }
         },
-        "default_branch": "unknown",
-        "missing_inputs": [
-          "github default branch"
-        ],
-        "result": "block",
-        "summary": "host binding surface is readable, but required binding facts are missing or host-managed."
+        "default_branch": "main",
+        "missing_inputs": [],
+        "result": "pass",
+        "summary": "host binding surface can relate the active Work Item to branch, worktree, PR, merge commit, and closeout."
       },
       "taxonomy": {
         "spec_stale": "Approved spec no longer covers the implementation surface.",
@@ -575,7 +578,6 @@
           "light": [],
           "standard": [
             "fr_work_item_layer",
-            "basic_host_binding",
             "closeout_reconciliation_read"
           ],
           "strong": [
@@ -588,8 +590,6 @@
       }
     },
     "summary": "repository is treated as new; Loom can plan the first governance carriers and bootstrap entrypoints without adding a second truth source.",
-    "missing_inputs": [
-      "github control plane: GraphQL: API rate limit already exceeded for user ID 9820018."
-    ]
+    "missing_inputs": []
   }
 }

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -219,6 +219,10 @@ def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[st
     return payload, []
 
 
+def gh_rest_json(root: Path, path: str) -> tuple[dict[str, Any] | None, list[str]]:
+    return gh_json(root, ["api", path])
+
+
 def detect_loom_state(root: Path) -> str:
     active_requirements = (
         root / ".loom/bootstrap/init-result.json",
@@ -866,16 +870,17 @@ def detect_github_control_plane(root: Path) -> tuple[dict[str, Any], list[str]]:
         missing_inputs.append("cannot resolve GitHub repository from git origin")
         return surface, missing_inputs
 
-    repo_payload, repo_errors = gh_json(root, ["repo", "view", f"{owner}/{repo}", "--json", "nameWithOwner,defaultBranchRef"])
+    repo_payload, repo_errors = gh_rest_json(root, f"repos/{owner}/{repo}")
     if repo_errors or repo_payload is None:
         missing_inputs.extend(f"github control plane: {message}" for message in repo_errors)
         return surface, missing_inputs
 
-    branch_ref = repo_payload.get("defaultBranchRef")
-    if isinstance(branch_ref, dict):
-        branch_name = branch_ref.get("name")
-        if isinstance(branch_name, str) and branch_name:
-            surface["default_branch"] = branch_name
+    full_name = repo_payload.get("full_name")
+    if isinstance(full_name, str) and full_name:
+        surface["repository"] = full_name
+    branch_name = repo_payload.get("default_branch")
+    if isinstance(branch_name, str) and branch_name:
+        surface["default_branch"] = branch_name
     if surface["default_branch"] == "unknown":
         missing_inputs.append("github control plane: default branch is unavailable")
         return surface, missing_inputs

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -782,6 +782,63 @@ def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[st
     return payload, []
 
 
+def gh_rest_json(root: Path, path: str) -> tuple[dict[str, Any] | None, list[str]]:
+    return gh_json(root, ["api", path])
+
+
+def github_issue_state(value: Any) -> str:
+    return str(value or "unknown").upper()
+
+
+def github_pr_state(payload: dict[str, Any]) -> str:
+    if payload.get("merged_at"):
+        return "MERGED"
+    return str(payload.get("state") or "unknown").upper()
+
+
+def normalize_rest_issue(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": payload.get("node_id"),
+        "databaseId": payload.get("id"),
+        "number": payload.get("number"),
+        "state": github_issue_state(payload.get("state")),
+        "title": payload.get("title"),
+        "url": payload.get("html_url"),
+    }
+
+
+def normalize_rest_pr(payload: dict[str, Any]) -> dict[str, Any]:
+    head = payload.get("head") if isinstance(payload.get("head"), dict) else {}
+    base = payload.get("base") if isinstance(payload.get("base"), dict) else {}
+    merge_commit_sha = payload.get("merge_commit_sha")
+    return {
+        "number": payload.get("number"),
+        "state": github_pr_state(payload),
+        "title": payload.get("title"),
+        "url": payload.get("html_url"),
+        "isDraft": bool(payload.get("draft")),
+        "mergedAt": payload.get("merged_at"),
+        "mergeCommit": {"oid": merge_commit_sha} if isinstance(merge_commit_sha, str) and merge_commit_sha else None,
+        "mergeStateStatus": str(payload.get("mergeable_state")).upper() if payload.get("mergeable_state") else None,
+        "headRefName": head.get("ref"),
+        "baseRefName": base.get("ref"),
+    }
+
+
+def github_issue_payload(root: Path, owner: str, repo_name: str, issue_number: int) -> tuple[dict[str, Any] | None, list[str]]:
+    payload, errors = gh_rest_json(root, f"repos/{owner}/{repo_name}/issues/{issue_number}")
+    if errors or payload is None:
+        return None, errors
+    return normalize_rest_issue(payload), []
+
+
+def github_pr_payload(root: Path, owner: str, repo_name: str, pr_number: int) -> tuple[dict[str, Any] | None, list[str]]:
+    payload, errors = gh_rest_json(root, f"repos/{owner}/{repo_name}/pulls/{pr_number}")
+    if errors or payload is None:
+        return None, errors
+    return normalize_rest_pr(payload), []
+
+
 def gh_json_list(root: Path, args: list[str], key: str) -> tuple[list[dict[str, Any]], list[str]]:
     payload, errors = gh_json(root, args)
     if errors or payload is None:
@@ -3515,6 +3572,7 @@ def find_project_item(items: list[dict[str, Any]], number: int, kind: str) -> di
 
 
 def project_item_for_issue(root: Path, issue_id: str, project_number: int) -> tuple[dict[str, Any] | None, list[str]]:
+    # GraphQL-only for now: GitHub ProjectV2 item field values are not covered by the REST budget-hardening pass.
     query = """
 query($id: ID!) {
   node(id: $id) {
@@ -3606,6 +3664,7 @@ def set_project_item_done(root: Path, project_id: str, item_id: str, status_fiel
 
 
 def issue_tree_payload(root: Path, owner: str, repo_name: str, issue_number: int) -> tuple[dict[str, Any] | None, list[str]]:
+    # GraphQL-only for now: native parent/sub-issue tree shape is outside the high-frequency REST replacement scope.
     query = """
 query($owner:String!, $name:String!, $number:Int!) {
   repository(owner:$owner, name:$name) {
@@ -3710,33 +3769,31 @@ def reconciliation_audit_payload(
     issue_id: str | None = None
     parent_payload: dict[str, Any] | None = None
     if issue_number is not None:
-        issue_payload, issue_errors = issue_tree_payload(target_root, owner, repo_name, issue_number)
+        issue_payload, issue_errors = github_issue_payload(target_root, owner, repo_name, issue_number)
         if issue_errors:
             missing_inputs.extend(f"issue: {message}" for message in issue_errors)
         elif issue_payload is not None:
             raw_issue_id = issue_payload.get("id")
             if isinstance(raw_issue_id, str) and raw_issue_id:
                 issue_id = raw_issue_id
-            parent = issue_payload.get("parent")
-            if isinstance(parent, dict):
-                parent_payload = parent
+            issue_tree, issue_tree_errors = issue_tree_payload(target_root, owner, repo_name, issue_number)
+            if issue_tree_errors:
+                issue_payload["sub_issue_tree"] = {
+                    "status": "unavailable",
+                    "reason": "GraphQL-only parent/sub-issue tree could not be read.",
+                    "errors": issue_tree_errors,
+                }
+            elif issue_tree is not None:
+                issue_payload = {**issue_payload, **issue_tree}
+                parent = issue_payload.get("parent")
+                if isinstance(parent, dict):
+                    parent_payload = parent
 
     pr_payload: dict[str, Any] | None = None
     merge_commit_sha: str | None = None
     merge_commit_in_main = False
     if pr_number is not None:
-        pr_payload, pr_errors = gh_json(
-            target_root,
-            [
-                "pr",
-                "view",
-                str(pr_number),
-                "--repo",
-                f"{owner}/{repo_name}",
-                "--json",
-                "number,state,isDraft,mergedAt,mergeCommit,url,title",
-            ],
-        )
+        pr_payload, pr_errors = github_pr_payload(target_root, owner, repo_name, pr_number)
         if pr_errors:
             missing_inputs.extend(f"pr: {message}" for message in pr_errors)
         elif pr_payload is not None:
@@ -4153,10 +4210,7 @@ def closeout_payload(
     issue_payload: dict[str, Any] | None = None
     issue_id: str | None = None
     if issue_number is not None:
-        issue_payload, issue_errors = gh_json(
-            target_root,
-            ["issue", "view", str(issue_number), "--repo", f"{owner}/{repo_name}", "--json", "id,number,state,title,url"],
-        )
+        issue_payload, issue_errors = github_issue_payload(target_root, owner, repo_name, issue_number)
         if issue_errors:
             missing_inputs.extend(f"issue: {message}" for message in issue_errors)
         elif issue_payload is not None:
@@ -4167,18 +4221,7 @@ def closeout_payload(
     pr_payload: dict[str, Any] | None = None
     merge_commit_sha: str | None = None
     if pr_number is not None:
-        pr_payload, pr_errors = gh_json(
-            target_root,
-            [
-                "pr",
-                "view",
-                str(pr_number),
-                "--repo",
-                f"{owner}/{repo_name}",
-                "--json",
-                "number,state,isDraft,mergedAt,mergeCommit,url",
-            ],
-        )
+        pr_payload, pr_errors = github_pr_payload(target_root, owner, repo_name, pr_number)
         if pr_errors:
             missing_inputs.extend(f"pr: {message}" for message in pr_errors)
         elif pr_payload is not None:

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -12,7 +12,8 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
-    gh_json,
+    github_issue_payload,
+    github_pr_payload,
     implementation_review_status_payload,
     load_context,
     runtime_state_payload,
@@ -59,29 +60,14 @@ def github_status_payload(
             errors.append("GitHub repository could not be detected from origin")
         return payload, errors
 
-    repo_slug = f"{owner}/{repo_name}"
     if issue_number is not None:
-        issue_payload, issue_errors = gh_json(
-            root,
-            ["issue", "view", str(issue_number), "--repo", repo_slug, "--json", "number,state,title,url"],
-        )
+        issue_payload, issue_errors = github_issue_payload(root, owner, repo_name, issue_number)
         if issue_errors:
             errors.extend([f"issue #{issue_number}: {message}" for message in issue_errors])
         else:
             payload["issue"] = issue_payload
     if pr_number is not None:
-        pr_payload, pr_errors = gh_json(
-            root,
-            [
-                "pr",
-                "view",
-                str(pr_number),
-                "--repo",
-                repo_slug,
-                "--json",
-                "number,state,title,url,isDraft,mergeStateStatus,headRefName,baseRefName",
-            ],
-        )
+        pr_payload, pr_errors = github_pr_payload(root, owner, repo_name, pr_number)
         if pr_errors:
             errors.extend([f"pr #{pr_number}: {message}" for message in pr_errors])
         else:

--- a/tools/governance_surface.py
+++ b/tools/governance_surface.py
@@ -95,6 +95,10 @@ def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[st
     return payload, []
 
 
+def gh_rest_json(root: Path, path: str) -> tuple[dict[str, Any] | None, list[str]]:
+    return gh_json(root, ["api", path])
+
+
 def detect_loom_state(root: Path) -> str:
     active_requirements = (
         root / ".loom/bootstrap/init-result.json",
@@ -251,16 +255,17 @@ def detect_github_control_plane(root: Path) -> tuple[dict[str, Any], list[str]]:
         missing_inputs.append("cannot resolve GitHub repository from git origin")
         return surface, missing_inputs
 
-    repo_payload, repo_errors = gh_json(root, ["repo", "view", f"{owner}/{repo}", "--json", "nameWithOwner,defaultBranchRef"])
+    repo_payload, repo_errors = gh_rest_json(root, f"repos/{owner}/{repo}")
     if repo_errors or repo_payload is None:
         missing_inputs.extend(f"github control plane: {message}" for message in repo_errors)
         return surface, missing_inputs
 
-    branch_ref = repo_payload.get("defaultBranchRef")
-    if isinstance(branch_ref, dict):
-        branch_name = branch_ref.get("name")
-        if isinstance(branch_name, str) and branch_name:
-            surface["default_branch"] = branch_name
+    full_name = repo_payload.get("full_name")
+    if isinstance(full_name, str) and full_name:
+        surface["repository"] = full_name
+    branch_name = repo_payload.get("default_branch")
+    if isinstance(branch_name, str) and branch_name:
+        surface["default_branch"] = branch_name
     if surface["default_branch"] == "unknown":
         missing_inputs.append("github control plane: default branch is unavailable")
         return surface, missing_inputs


### PR DESCRIPTION
## Goal

Lower Loom's routine GitHub GraphQL budget pressure by moving high-frequency repo / issue / PR reads to REST.

Closes #313

## Delivery funnel

- Phase: #311
- FR: #312
- Work Item: #313
- Spec review / implementation review / merge-ready basis recorded on #313.

## Changes

- `governance_surface` now reads repository metadata through REST `GET /repos/{owner}/{repo}` instead of `gh repo view`.
- `loom_status` now reads issue / PR metadata through REST helpers instead of `gh issue view` / `gh pr view`.
- `loom_flow` closeout/reconciliation now reads ordinary issue / PR metadata through REST helpers.
- ProjectV2 and native sub-issues GraphQL paths remain in place and are marked GraphQL-only for now.
- Demo bootstrap truth updated after `make loom-check`.

## Compatibility

- `html_url -> url`
- issue `state -> OPEN|CLOSED`
- PR `draft -> isDraft`
- PR `head.ref/base.ref -> headRefName/baseRefName`
- PR `merge_commit_sha -> mergeCommit.oid`

## Validation

- `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `npm --prefix packages/loom-installer run check:payload`
- `npm --prefix packages/loom-installer run check:docs`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- static regression: no high-frequency `gh repo view|gh issue view|gh pr view` hits under `skills/shared/scripts` or `tools`
