### PR TITLE
docs: 规范双语 README 入口与文档门禁

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,33 @@
 # Loom
 
-Loom 是一个以 skills 为先的方法论仓库，用来组织 agent coding workflow。
+Language: English | [中文版本](./README.zh-CN.md)
 
-它给编码智能体提供一条受治理约束的执行路径：从 adopt、resume、review、merge-ready，到 handoff 和 closeout。它的目标不是更快地产生业务代码，而是避免智能体工作停在“代码已经改了”，并把结果收敛到 merge-ready 与 closeout 完成态。
+Loom is a skills-first methodology repository for agent coding workflows.
 
-## 工作方式
+It gives coding agents a governance-shaped execution path across adopt, resume, review, merge-ready, handoff, and closeout. The goal is not to produce business code faster at any cost, but to keep work from stopping at "files changed" and to converge on a real merge-ready and closeout-complete state.
 
-Loom 以整包 skills library 的方式接入。智能体从 `loom-init` 起步，再根据当前任务和仓库状态路由到合适的 scenario skill。
+## How It Works
 
-基础执行流如下：
+Loom is installed as a complete skills library. Agents start from `loom-init`, then route into the right scenario skill based on the task and repository state.
 
-1. `loom-init` 判断当前应当 adopt、resume、review、handoff、retire，还是检查 merge readiness。
-2. scenario skills 执行具体工作流，并消费共享的 Loom runtime contract。
-3. 方法论文档下沉在 skills 层之后，用户不需要先理解治理内部结构再开始使用 Loom。
-4. runtime evidence、review record、merge checkpoint 和 closeout check 共同维持仓库状态一致。
+The core execution model is:
 
-## 安装
+1. `loom-init` decides whether the current work should adopt, resume, review, hand off, retire, or validate merge readiness.
+2. Scenario skills run the concrete workflow and consume the shared Loom runtime contract.
+3. Methodology and architecture documents stay behind the skills layer, so users do not need to study Loom internals before starting.
+4. Runtime evidence, review records, merge checkpoints, and closeout checks keep repository state aligned.
 
-### Codex 原生 Skills 发现
+## Install
 
-可以直接这样告诉 Codex：
+### Codex Native Skill Discovery
+
+You can tell Codex:
 
 ```text
 Fetch and follow instructions from https://raw.githubusercontent.com/MC-and-his-Agents/Loom/refs/heads/main/.codex/INSTALL.md
 ```
 
-也可以手动安装：
+Or install Loom manually:
 
 ```bash
 git clone https://github.com/MC-and-his-Agents/Loom.git ~/.codex/loom
@@ -33,18 +35,18 @@ mkdir -p ~/.agents/skills
 ln -s ~/.codex/loom/skills ~/.agents/skills/loom
 ```
 
-安装后请重启 Codex，让原生 skills discovery 重新加载 Loom skills。
+Restart Codex after installation so native skill discovery reloads the Loom skills.
 
 ### npm Installer
 
-如果你希望通过 installer 把 plugin 接到目标仓库，可以使用：
+If you want to attach the Loom plugin surface to a target repository through the installer:
 
 ```bash
 npx @mc-and-his-agents/loom-installer add plugin --host codex
 npx @mc-and-his-agents/loom-installer add plugin --host claude
 ```
 
-也可以先固定 installer 版本：
+You can also pin the installer first:
 
 ```bash
 npm install -D @mc-and-his-agents/loom-installer
@@ -52,68 +54,68 @@ npx loom-installer add plugin --host codex
 npx loom-installer add plugin --host claude
 ```
 
-要求：
+Requirements:
 
 - Node `>=20`
-- Python `>=3.10`，推荐 `3.11+`
+- Python `>=3.10`, recommended `3.11+`
 
-installer 负责安装、发现和校验；Loom 的实际执行仍然运行在 skills library 随附的 Python runtime 上。
+The installer is responsible for install, discovery, and verification. Loom execution still runs on the Python runtime bundled with the skills library.
 
-## 基本工作流
+## Basic Workflow
 
-1. 当你不确定下一步该做什么时，从 `loom-init` 开始。
-2. 用 `loom-adopt` 初始化新仓库，或把 Loom retrofit 到既有仓库。
-3. 用 `loom-resume` 恢复上下文并继续当前 work item。
-4. 用 `loom-pre-review` 在正式 review 前暴露明显的 readiness 缺口。
-5. 命中 formal spec 路径时，先用 `loom-spec-review` 产出 `spec-approved` gate。
-6. 用 `loom-review` 产出结构化 review 结果。
-7. 用 `loom-merge-ready` 在合并前验证 release boundary。
-8. 用 `loom-handoff` 或 `loom-retire` 把现场收成可恢复或已关闭状态。
+1. Start from `loom-init` when you are unsure what should happen next.
+2. Use `loom-adopt` to initialize a new repository or retrofit Loom into an existing one.
+3. Use `loom-resume` to restore context and continue the current `Work Item`.
+4. Use `loom-pre-review` to expose obvious readiness gaps before formal review.
+5. When the task hits the formal spec path, use `loom-spec-review` first to produce the `spec-approved` gate.
+6. Use `loom-review` to produce a structured review result.
+7. Use `loom-merge-ready` to validate the release boundary before merge.
+8. Use `loom-handoff` or `loom-retire` to leave the worksite in a recoverable or closed state.
 
-智能体不能把“已经有改动文件”当作完成。对 Loom 来说，只有目标、文档、review 状态、验证证据、主干真相和宿主控制面全部对齐，才算真正完成。
+Agents should not treat "there are changed files" as completion. In Loom, work is only done when goals, documents, review state, validation evidence, trunk truth, and host control plane all agree.
 
-## SKILLS 库
+## Skills Library
 
-Loom 当前暴露一个 root entry 和八个 scenario skills：
+Loom exposes one root entry and eight scenario skills:
 
-| Skill | 作用 |
+| Skill | Role |
 | --- | --- |
-| `loom-init` | root entry；负责初始化或路由到正确场景。 |
-| `loom-adopt` | 为仓库建立最小 Loom 接入面。 |
-| `loom-resume` | 恢复上下文并继续 work item。 |
-| `loom-pre-review` | 在正式 review 前检查 readiness。 |
-| `loom-spec-review` | 审查 formal spec 路径并产出 `spec-approved` gate。 |
-| `loom-review` | 执行正式 review 并记录结果。 |
-| `loom-handoff` | 写出可恢复的交接点。 |
-| `loom-merge-ready` | 验证 merge readiness。 |
-| `loom-retire` | 在不丢弃用户改动的前提下清理并退场。 |
+| `loom-init` | Root entry; initializes or routes to the correct scene. |
+| `loom-adopt` | Creates the minimum Loom adoption surface for a repository. |
+| `loom-resume` | Restores context and continues the current `Work Item`. |
+| `loom-pre-review` | Checks readiness before formal review. |
+| `loom-spec-review` | Reviews the formal spec path and produces the `spec-approved` gate. |
+| `loom-review` | Runs formal review and records the result. |
+| `loom-handoff` | Writes a recoverable handoff point. |
+| `loom-merge-ready` | Validates merge readiness. |
+| `loom-retire` | Cleans up and exits without discarding user changes. |
 
-canonical skills library 位于 [skills/](./skills/)。生成出来的 plugin 和 single-skill payload 不再提交到仓库；release tooling 会从根级 canonical `.codex-plugin/` 与 `skills/` 真相源动态构建它们。
+The canonical skills library lives under [skills/](./skills/). Generated plugin payloads and single-skill payloads are not committed. Release tooling builds them dynamically from the canonical root `.codex-plugin/` and `skills/` sources.
 
-## 高级 / 兼容
+## Advanced / Compatibility
 
-单 skill 安装仍然保留，作为兼容和高级路径，但它不再是 Loom 的主路径：
+Single-skill installation remains available as an advanced compatibility path, but it is no longer the default Loom journey:
 
 ```bash
 npx @mc-and-his-agents/loom-installer add skill loom-retire --host codex
 npx @mc-and-his-agents/loom-installer add skill loom-retire --host claude
 ```
 
-单独安装的 skill 只会向宿主暴露该 skill 本身。如果你需要 `loom-init` 路由能力和完整 scenario surface，请安装完整 Loom plugin 或整包 skills library。
+An individually installed skill only exposes that skill to the host. If you need `loom-init` routing and the full scenario surface, install the full Loom plugin or the complete skills library.
 
-## 维护者文档
+## Maintainer Docs
 
-- 愿景与边界：[VISION.md](./VISION.md)
-- 仓库宪法：[AGENTS.md](./AGENTS.md)
-- Skills 面：[skills/README.md](./skills/README.md)
-- 方法论文档：[docs/methodology/](./docs/methodology/)
-- 架构说明：[docs/architecture/](./docs/architecture/)
-- 接入合同：[docs/adoption/](./docs/adoption/)
-- 证据台账：[docs/evidence/](./docs/evidence/)
-- 分发合同：[skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)
+- Vision and boundary: [VISION.md](./VISION.md)
+- Repository constitution: [AGENTS.md](./AGENTS.md)
+- Skills surface: [skills/README.md](./skills/README.md)
+- Methodology docs: [docs/methodology/](./docs/methodology/)
+- Architecture docs: [docs/architecture/](./docs/architecture/)
+- Adoption contracts: [docs/adoption/](./docs/adoption/)
+- Evidence ledger: [docs/evidence/](./docs/evidence/)
+- Distribution contract: [skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)
 
-## 设计哲学
+## Philosophy
 
-Loom 以 merge-readiness 为中心。review、validation、host state 和 closeout 是彼此独立但必须收敛一致的表面，任何一个面没有收口，都不应视为工作完成。
+Loom is merge-readiness-centered. Review, validation, host state, and closeout are separate surfaces, but they must converge. If any one of them is still open, the work should not be treated as finished.
 
-Loom 不是业务模板、代码生成器，也不是 GitHub、CI、review engine 或 `git worktree` 的替代品。它是方法论与可执行 skills 层，用来让智能体以一致方式消费这些宿主能力。
+Loom is not a business template, a code generator, or a replacement for GitHub, CI, review engines, or `git worktree`. It is a methodology layer plus executable skills so agents can consume those host capabilities consistently.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,121 @@
+# Loom
+
+语言：中文 | [English version](./README.md)
+
+Loom 是一个以 skills 为先的方法论仓库，用来组织 agent coding workflow。
+
+它给编码智能体提供一条受治理约束的执行路径：从 adopt、resume、review、merge-ready，到 handoff 和 closeout。它的目标不是更快地产生业务代码，而是避免智能体工作停在“代码已经改了”，并把结果收敛到 merge-ready 与 closeout 完成态。
+
+## 工作方式
+
+Loom 以整包 skills library 的方式接入。智能体从 `loom-init` 起步，再根据当前任务和仓库状态路由到合适的 scenario skill。
+
+基础执行流如下：
+
+1. `loom-init` 判断当前应当 adopt、resume、review、handoff、retire，还是检查 merge readiness。
+2. Scenario skills 执行具体工作流，并消费共享的 Loom runtime contract。
+3. 方法论文档下沉在 skills 层之后，用户不需要先理解治理内部结构再开始使用 Loom。
+4. Runtime evidence、review record、merge checkpoint 和 closeout check 共同维持仓库状态一致。
+
+## 安装
+
+### Codex 原生 Skills 发现
+
+可以直接这样告诉 Codex：
+
+```text
+Fetch and follow instructions from https://raw.githubusercontent.com/MC-and-his-Agents/Loom/refs/heads/main/.codex/INSTALL.md
+```
+
+也可以手动安装：
+
+```bash
+git clone https://github.com/MC-and-his-Agents/Loom.git ~/.codex/loom
+mkdir -p ~/.agents/skills
+ln -s ~/.codex/loom/skills ~/.agents/skills/loom
+```
+
+安装后请重启 Codex，让原生 skills discovery 重新加载 Loom skills。
+
+### npm Installer
+
+如果你希望通过 installer 把 plugin 接到目标仓库，可以使用：
+
+```bash
+npx @mc-and-his-agents/loom-installer add plugin --host codex
+npx @mc-and-his-agents/loom-installer add plugin --host claude
+```
+
+也可以先固定 installer 版本：
+
+```bash
+npm install -D @mc-and-his-agents/loom-installer
+npx loom-installer add plugin --host codex
+npx loom-installer add plugin --host claude
+```
+
+要求：
+
+- Node `>=20`
+- Python `>=3.10`，推荐 `3.11+`
+
+Installer 负责安装、发现和校验；Loom 的实际执行仍然运行在 skills library 随附的 Python runtime 上。
+
+## 基本工作流
+
+1. 当你不确定下一步该做什么时，从 `loom-init` 开始。
+2. 用 `loom-adopt` 初始化新仓库，或把 Loom retrofit 到既有仓库。
+3. 用 `loom-resume` 恢复上下文并继续当前 `Work Item`。
+4. 用 `loom-pre-review` 在正式 review 前暴露明显的 readiness 缺口。
+5. 命中 formal spec 路径时，先用 `loom-spec-review` 产出 `spec-approved` gate。
+6. 用 `loom-review` 产出结构化 review 结果。
+7. 用 `loom-merge-ready` 在合并前验证 release boundary。
+8. 用 `loom-handoff` 或 `loom-retire` 把现场收成可恢复或已关闭状态。
+
+智能体不能把“已经有改动文件”当作完成。对 Loom 来说，只有目标、文档、review 状态、验证证据、主干真相和宿主控制面全部对齐，才算真正完成。
+
+## Skills 库
+
+Loom 当前暴露一个 root entry 和八个 scenario skills：
+
+| Skill | 作用 |
+| --- | --- |
+| `loom-init` | Root entry；负责初始化或路由到正确场景。 |
+| `loom-adopt` | 为仓库建立最小 Loom 接入面。 |
+| `loom-resume` | 恢复上下文并继续当前 `Work Item`。 |
+| `loom-pre-review` | 在正式 review 前检查 readiness。 |
+| `loom-spec-review` | 审查 formal spec 路径并产出 `spec-approved` gate。 |
+| `loom-review` | 执行正式 review 并记录结果。 |
+| `loom-handoff` | 写出可恢复的交接点。 |
+| `loom-merge-ready` | 验证 merge readiness。 |
+| `loom-retire` | 在不丢弃用户改动的前提下清理并退场。 |
+
+Canonical skills library 位于 [skills/](./skills/)。生成出来的 plugin 和 single-skill payload 不再提交到仓库；release tooling 会从根级 canonical `.codex-plugin/` 与 `skills/` 真相源动态构建它们。
+
+## 高级 / 兼容
+
+单 skill 安装仍然保留，作为兼容和高级路径，但它不再是 Loom 的主路径：
+
+```bash
+npx @mc-and-his-agents/loom-installer add skill loom-retire --host codex
+npx @mc-and-his-agents/loom-installer add skill loom-retire --host claude
+```
+
+单独安装的 skill 只会向宿主暴露该 skill 本身。如果你需要 `loom-init` 路由能力和完整 scenario surface，请安装完整 Loom plugin 或整包 skills library。
+
+## 维护者文档
+
+- 愿景与边界：[VISION.md](./VISION.md)
+- 仓库宪法：[AGENTS.md](./AGENTS.md)
+- Skills 面：[skills/README.md](./skills/README.md)
+- 方法论文档：[docs/methodology/](./docs/methodology/)
+- 架构说明：[docs/architecture/](./docs/architecture/)
+- 接入合同：[docs/adoption/](./docs/adoption/)
+- 证据台账：[docs/evidence/](./docs/evidence/)
+- 分发合同：[skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)
+
+## 设计哲学
+
+Loom 以 merge-readiness 为中心。Review、validation、host state 和 closeout 是彼此独立但必须收敛一致的表面，任何一个面没有收口，都不应视为工作完成。
+
+Loom 不是业务模板、代码生成器，也不是 GitHub、CI、review engine 或 `git worktree` 的替代品。它是方法论与可执行 skills 层，用来让智能体以一致方式消费这些宿主能力。

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -430,7 +430,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "feat/graphql-budget-rest-high-frequency",
+            "locator": "main",
             "authority": "git"
           },
           "worktree": {

--- a/packages/loom-installer/README.md
+++ b/packages/loom-installer/README.md
@@ -1,5 +1,7 @@
 # @mc-and-his-agents/loom-installer
 
+Language: English | [中文版本](./README.zh-CN.md)
+
 Loom npm / npx installer.
 
 The primary install mode is the complete Loom plugin surface. Single-skill install remains available for compatibility and advanced use.
@@ -11,7 +13,7 @@ npx @mc-and-his-agents/loom-installer add plugin --host codex
 npx @mc-and-his-agents/loom-installer add plugin --host claude
 ```
 
-Single skill compatibility path:
+Single-skill compatibility path:
 
 ```bash
 npx @mc-and-his-agents/loom-installer add skill <skill-id> --host codex
@@ -35,13 +37,13 @@ Options:
 ## Requirements
 
 - Node `>=20`
-- Python `>=3.10`，推荐 `3.11+`
+- Python `>=3.10`, recommended `3.11+`
 
 ## Payload Model
 
-The published package includes a generated payload. The payload is generated from the canonical root `.codex-plugin/` and `skills/` sources during build / pack / publish.
+The published package includes a generated payload. The payload is generated from the canonical root `.codex-plugin/` and `skills/` sources during build, pack, and publish.
 
-Generated payload directories are not committed to git. The build step recreates them deterministically and `check:payload` verifies rebuild stability.
+Generated payload directories are not committed to git. The build step recreates them deterministically, and `check:payload` verifies rebuild stability.
 
 ## Release Notes
 
@@ -52,4 +54,4 @@ Release model:
 - PRs run gates but do not publish npm.
 - `main` is the only release truth source.
 - Loom repository releases and installer npm package versions are maintained separately.
-- publish 成功后再创建 `loom-installer-v<version>` git tag 与同名前缀的 GitHub Release.
+- Create the `loom-installer-v<version>` git tag and matching GitHub Release only after npm publish succeeds.

--- a/packages/loom-installer/README.zh-CN.md
+++ b/packages/loom-installer/README.zh-CN.md
@@ -1,0 +1,57 @@
+# @mc-and-his-agents/loom-installer
+
+语言：中文 | [English version](./README.md)
+
+Loom 的 npm / npx installer。
+
+主安装模式是完整 Loom plugin surface。单 skill 安装仍然保留，用于兼容和高级场景。
+
+## Commands
+
+```bash
+npx @mc-and-his-agents/loom-installer add plugin --host codex
+npx @mc-and-his-agents/loom-installer add plugin --host claude
+```
+
+单 skill 兼容路径：
+
+```bash
+npx @mc-and-his-agents/loom-installer add skill <skill-id> --host codex
+npx @mc-and-his-agents/loom-installer add skill <skill-id> --host claude
+```
+
+也可以先固定 installer 版本：
+
+```bash
+npm install -D @mc-and-his-agents/loom-installer
+npx loom-installer add plugin --host codex
+```
+
+Options：
+
+- `--host codex|claude|auto`
+- `--target <repo-root>`
+- `--force`
+- `--json`
+
+## Requirements
+
+- Node `>=20`
+- Python `>=3.10`，推荐 `3.11+`
+
+## Payload Model
+
+发布包会包含生成出来的 payload。该 payload 会在 build、pack 和 publish 阶段，从 canonical root `.codex-plugin/` 与 `skills/` 源动态生成。
+
+生成出来的 payload 目录不会提交到 git。Build 步骤会以确定性方式重建它们，`check:payload` 会校验重建稳定性。
+
+## Release Notes
+
+发布只会从 `main` 进行。
+
+Release model：
+
+- PR 会运行 gates，但不会发布 npm。
+- `main` 是唯一 release truth source。
+- Loom 仓库 release 与 installer npm package version 分开维护。
+- 只有在 npm publish 成功后，才创建 `loom-installer-v<version>` git tag 和同名前缀的 GitHub Release。

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/packages/loom-installer/scripts/check-doc-sync.mjs
+++ b/packages/loom-installer/scripts/check-doc-sync.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,10 +10,21 @@ const requiredNeedles = [
   {
     path: 'README.md',
     needles: [
-      'Loom 是一个以 skills 为先的方法论仓库',
+      'skills-first methodology repository',
+      'Fetch and follow instructions from https://raw.githubusercontent.com/MC-and-his-Agents/Loom/refs/heads/main/.codex/INSTALL.md',
+      'npx @mc-and-his-agents/loom-installer add plugin --host codex',
+      'Advanced / Compatibility',
+      '[中文版本](./README.zh-CN.md)',
+    ],
+  },
+  {
+    path: 'README.zh-CN.md',
+    needles: [
+      '以 skills 为先的方法论仓库',
       'Fetch and follow instructions from https://raw.githubusercontent.com/MC-and-his-Agents/Loom/refs/heads/main/.codex/INSTALL.md',
       'npx @mc-and-his-agents/loom-installer add plugin --host codex',
       '高级 / 兼容',
+      '[English version](./README.md)',
     ],
   },
   {
@@ -28,9 +39,20 @@ const requiredNeedles = [
     path: 'skills/README.md',
     needles: [
       'canonical skills library',
-      '默认从 `loom-init` 开始',
+      'unique root entry',
       'Advanced / Compatibility',
       'npx @mc-and-his-agents/loom-installer add skill <skill-id>',
+      '[中文版本](./README.zh-CN.md)',
+    ],
+  },
+  {
+    path: 'skills/README.zh-CN.md',
+    needles: [
+      'canonical skills library',
+      '唯一的 root entry',
+      'Advanced / Compatibility',
+      'npx @mc-and-his-agents/loom-installer add skill <skill-id>',
+      '[English version](./README.md)',
     ],
   },
   {
@@ -47,10 +69,23 @@ const requiredNeedles = [
     needles: [
       'npm install -D @mc-and-his-agents/loom-installer',
       'Node `>=20`',
-      'Python `>=3.10`，推荐 `3.11+`',
+      'Python `>=3.10`, recommended `3.11+`',
       'add plugin',
       'add skill <skill-id>',
       'payload is generated from the canonical root `.codex-plugin/` and `skills/` sources',
+      '[中文版本](./README.zh-CN.md)',
+    ],
+  },
+  {
+    path: 'packages/loom-installer/README.zh-CN.md',
+    needles: [
+      'npm install -D @mc-and-his-agents/loom-installer',
+      'Node `>=20`',
+      'Python `>=3.10`，推荐 `3.11+`',
+      'add plugin',
+      'add skill <skill-id>',
+      'canonical root `.codex-plugin/` 与 `skills/` 源',
+      '[English version](./README.md)',
     ],
   },
 ];
@@ -60,6 +95,10 @@ function readRepoFile(relativePath) {
 }
 
 for (const entry of requiredNeedles) {
+  if (!existsSync(join(repoRoot, entry.path))) {
+    console.error(`doc sync check failed: missing ${entry.path}`);
+    process.exit(1);
+  }
   const content = readRepoFile(entry.path);
   for (const needle of entry.needles) {
     if (!content.includes(needle)) {

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,22 +1,24 @@
 # Skills
 
+Language: English | [中文版本](./README.zh-CN.md)
+
 `skills/` is the canonical skills library for Loom.
 
-When Loom is installed through Codex native skill discovery, a host plugin, or the npm installer, this directory is the user-facing execution surface. The methodology and architecture docs stay behind this layer; users should normally enter through skills, not through internal governance documents.
+When Loom is installed through Codex native skill discovery, a host plugin, or the npm installer, this directory is the user-facing execution surface. Methodology and architecture documents stay behind this layer; users should enter through skills instead of internal governance docs.
 
-默认从 `loom-init` 开始。它是 Loom 唯一的 root entry，负责两件事：
+By default, start from `loom-init`. It is the unique root entry for Loom and is responsible for two things:
 
-- 初始化 Loom，或把 Loom retrofit 进既有仓库
-- 在没有显式指定场景 skill 时，根据任务信号把执行者导向正确场景
+- initialize Loom or retrofit Loom into an existing repository
+- route the operator to the correct scenario skill when no explicit skill was named
 
-当前 `skills/` 层消费的是新的强治理控制面，固定约束如下：
+The `skills/` layer consumes the current strong-governance control plane with these fixed constraints:
 
-- `Work Item` 是唯一正式执行入口
-- 命中 formal spec 的事项，必须先通过 `spec gate`
-- 执行放行链固定收敛为 `spec gate -> build gate -> review gate -> merge gate`
-- `status control plane` 只读取并汇总事实链与宿主控制面，不新增 authored 真相
-- profile maturity 按 `light -> standard -> strong` 升级；事项成熟度仍按治理状态机推进
-- merge 由 GitHub 或等价宿主控制面受控执行；Loom 只消费并汇总 `GitHub controlled merge` 的前置条件
+- `Work Item` is the only formal execution entry
+- tasks that hit the formal spec path must pass the `spec gate` first
+- the release chain converges on `spec gate -> build gate -> review gate -> merge gate`
+- `status control plane` only reads and summarizes fact-chain and host control-plane truth, and does not author a second source of truth
+- profile maturity upgrades through `light -> standard -> strong`, while item maturity still advances through the governance state machine
+- merge is controlled by GitHub or an equivalent host control plane; Loom only consumes and summarizes the prerequisites for GitHub controlled merge
 
 ## Skills Library
 

--- a/skills/README.zh-CN.md
+++ b/skills/README.zh-CN.md
@@ -1,0 +1,92 @@
+# Skills
+
+语言：中文 | [English version](./README.md)
+
+`skills/` 是 Loom 的 canonical skills library。
+
+当 Loom 通过 Codex 原生 skill discovery、宿主 plugin 或 npm installer 安装时，这个目录就是面向用户的执行表面。方法论和架构文档位于这层之后，用户通常应该从 skills 进入，而不是先读内部治理文档。
+
+默认从 `loom-init` 开始。它是 Loom 唯一的 root entry，负责两件事：
+
+- 初始化 Loom，或把 Loom retrofit 进既有仓库
+- 在没有显式指定场景 skill 时，根据任务信号把执行者导向正确场景
+
+当前 `skills/` 层消费的是新的强治理控制面，固定约束如下：
+
+- `Work Item` 是唯一正式执行入口
+- 命中 formal spec 的事项，必须先通过 `spec gate`
+- 执行放行链固定收敛为 `spec gate -> build gate -> review gate -> merge gate`
+- `status control plane` 只读取并汇总事实链与宿主控制面，不新增 authored 真相
+- profile maturity 按 `light -> standard -> strong` 升级；事项成熟度仍按治理状态机推进
+- merge 由 GitHub 或等价宿主控制面受控执行；Loom 只消费并汇总 `GitHub controlled merge` 的前置条件
+
+## Skills Library
+
+Loom 暴露一个 root entry 和八个 scenario skills：
+
+| Skill | 作用 |
+| --- | --- |
+| `loom-init` | Root entry；负责初始化和路由。 |
+| `loom-adopt` | 初始化新仓库，或把 Loom retrofit 到既有仓库。 |
+| `loom-resume` | 恢复上下文并继续执行。 |
+| `loom-pre-review` | 在正式 review 前检查 readiness。 |
+| `loom-spec-review` | 审查 formal spec 路径，并产出后续 gate 消费的 `spec gate`。 |
+| `loom-review` | 执行正式 review 并记录输出。 |
+| `loom-handoff` | 写出 handoff 点和下一步状态。 |
+| `loom-retire` | 清理或退场当前工作现场。 |
+| `loom-merge-ready` | 在 GitHub controlled merge 前执行最终 `merge gate` 汇总。 |
+
+## Entry Model
+
+Loom 支持两种入口模式：
+
+- 显式入口：用户直接指定某个场景 skill。
+- 路由入口：用户从 `loom-init` 开始，由 `loom-init` 根据任务信号选择场景。
+
+如果任务信号不完整、存在冲突，或缺少稳定执行所需的最小输入，应回退到 `loom-init`，并要求补齐最小缺失信号。稳定路由规则见 [route-matrix.md](./route-matrix.md)。
+
+路由只决定场景 skill，不替代稳定控制面：
+
+- 执行入口仍然绑定在 `Work Item`
+- gate 仍然绑定在共享 `gate chain`
+- 状态读取仍然绑定在共享 `status control plane`
+- merge 仍然由宿主平台控制面执行
+
+## Install Model
+
+主安装路径是完整 Loom skills library：
+
+```bash
+git clone https://github.com/MC-and-his-Agents/Loom.git ~/.codex/loom
+mkdir -p ~/.agents/skills
+ln -s ~/.codex/loom/skills ~/.agents/skills/loom
+```
+
+npm installer 也可以安装完整 plugin surface：
+
+```bash
+npx @mc-and-his-agents/loom-installer add plugin --host codex
+npx @mc-and-his-agents/loom-installer add plugin --host claude
+```
+
+## Advanced / Compatibility
+
+单 skill 安装保留为高级兼容路径，但不再是默认用户路径：
+
+```bash
+npx @mc-and-his-agents/loom-installer add skill <skill-id> --host codex
+npx @mc-and-his-agents/loom-installer add skill <skill-id> --host claude
+```
+
+单独安装的 skill 只会向宿主暴露该 skill 本身。除非安装的就是 `loom-init`，否则它不会暴露完整的 `loom-init` 路由面，也不应被表述成完整的 Loom 体验。
+
+## Internal Contracts
+
+以下文件属于 runtime contract，应保持稳定：
+
+- [registry.json](./registry.json)
+- [install-layout.json](./install-layout.json)
+- [upgrade-contract.json](./upgrade-contract.json)
+- [distribution-and-adapter-contract.md](./distribution-and-adapter-contract.md)
+
+共享 runtime scripts、assets 和 references 位于 [shared/](./shared/)。它们会被 scenario skills 和 release tooling 一起消费，用来生成 plugin 或 single-skill payload。

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1372,13 +1372,17 @@ def check_root_route_contracts(root: Path) -> list[Failure]:
     category = "skill-routing-contract"
     failures: list[Failure] = []
     readme_path = root / "README.md"
+    readme_zh_path = root / "README.zh-CN.md"
     skills_readme_path = root / "skills/README.md"
+    skills_readme_zh_path = root / "skills/README.zh-CN.md"
     route_matrix_path = root / "skills/route-matrix.md"
     contract_path = root / "skills/loom-init/contract.json"
 
     try:
         readme = load_text_file(readme_path)
+        readme_zh = load_text_file(readme_zh_path)
         skills_readme = load_text_file(skills_readme_path)
+        skills_readme_zh = load_text_file(skills_readme_zh_path)
         route_matrix = load_text_file(route_matrix_path)
         contract = load_json_file(contract_path)
     except FileNotFoundError:
@@ -1389,12 +1393,20 @@ def check_root_route_contracts(root: Path) -> list[Failure]:
     if not isinstance(contract, dict):
         return [Failure(category, "`skills/loom-init/contract.json` must be a JSON object")]
 
-    if "Loom 是一个以 skills 为先的方法论仓库" not in readme:
+    if "skills-first methodology repository" not in readme:
         failures.append(Failure(category, "`README.md` must present Loom as a skills-first methodology repository"))
-    if "高级 / 兼容" not in readme:
+    if "Advanced / Compatibility" not in readme:
         failures.append(Failure(category, "`README.md` must keep single-skill installation as an advanced compatibility path"))
-    if "它是 Loom 唯一的 root entry" not in skills_readme:
+    if "[中文版本](./README.zh-CN.md)" not in readme or "[English version](./README.md)" not in readme_zh:
+        failures.append(Failure(category, "root README language switch links must stay in sync"))
+    if "以 skills 为先的方法论仓库" not in readme_zh:
+        failures.append(Failure(category, "`README.zh-CN.md` must preserve the Chinese repository positioning"))
+    if "unique root entry" not in skills_readme:
         failures.append(Failure(category, "`skills/README.md` must keep `loom-init` as the unique root entry"))
+    if "[中文版本](./README.zh-CN.md)" not in skills_readme or "[English version](./README.md)" not in skills_readme_zh:
+        failures.append(Failure(category, "skills README language switch links must stay in sync"))
+    if "唯一的 root entry" not in skills_readme_zh:
+        failures.append(Failure(category, "`skills/README.zh-CN.md` must preserve the Chinese root-entry explanation"))
     if "显式 skill 名称调用优先" not in route_matrix:
         failures.append(Failure(category, "`skills/route-matrix.md` must keep explicit routing as the first priority"))
     if "若无法稳定判断，回退到 `loom-init`" not in route_matrix:
@@ -1429,8 +1441,12 @@ def check_root_route_contracts(root: Path) -> list[Failure]:
     for command in installation_commands:
         if command not in skills_readme:
             failures.append(Failure(category, f"`skills/README.md` must document `{command}`"))
+        if command not in skills_readme_zh:
+            failures.append(Failure(category, f"`skills/README.zh-CN.md` must document `{command}`"))
     if "git clone https://github.com/MC-and-his-Agents/Loom.git ~/.codex/loom" not in readme:
         failures.append(Failure(category, "`README.md` must document native skills-library installation"))
+    if "git clone https://github.com/MC-and-his-Agents/Loom.git ~/.codex/loom" not in readme_zh:
+        failures.append(Failure(category, "`README.zh-CN.md` must document native skills-library installation"))
 
     return failures
 
@@ -3635,6 +3651,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         ".loom/reviews/INIT-0001.spec.json",
                     ],
                     env=installed_review_env,
+                    timeout_seconds=150,
                 )
                 spec_review_record_input: dict[str, object] | None = None
                 if error:
@@ -3769,6 +3786,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "INIT-0001",
                     ],
                     env=installed_review_env,
+                    timeout_seconds=150,
                 )
                 if error:
                     failures.append(Failure("daily-execution-cli", f"`installed review run` failed: {error}"))
@@ -4130,7 +4148,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif payload.get("result") != "block":
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` must block when HEAD drifts beyond Loom carriers"))
 
-    gh_auth_ready = shutil.which("gh") is not None and run_command(root, ["gh", "auth", "status"]).returncode == 0
+    gh_auth_probe = None
+    if shutil.which("gh") is not None:
+        try:
+            gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
+        except subprocess.TimeoutExpired:
+            gh_auth_probe = None
+    gh_auth_ready = gh_auth_probe is not None and gh_auth_probe.returncode == 0
     if gh_auth_ready:
         with tempfile.TemporaryDirectory(prefix="loom-check-installed-post-merge-") as tmp:
             tmp_root = Path(tmp)

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -88,6 +88,7 @@ REVIEW_FINDING_SEVERITIES = {"warn", "block"}
 REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
+DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -1904,10 +1905,16 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
+            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
         failure_detail = f"default review engine `{DEFAULT_REVIEW_ENGINE}` is unavailable in PATH"
+    except subprocess.TimeoutExpired:
+        failure_reason = "runtime_conflict"
+        failure_detail = (
+            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+        )
     else:
         if completed.returncode != 0:
             failure_reason = "runtime_conflict"


### PR DESCRIPTION
## 目标
- 让 Loom 的 README 入口统一为英文 canonical，并提供中文镜像
- 保持其余方法论文档与技能说明继续以中文为主，同时不破坏 runtime 协议字段
- 把文档门禁从旧文案硬编码切到新的双语入口和稳定语义锚点

## 主要变更
- 根 README、`skills/README.md`、`packages/loom-installer/README.md` 改为英文 canonical，并新增对应 `README.zh-CN.md`
- `check-doc-sync.mjs` 新增双语入口检查，并同步 installer 文案锚点
- `loom_check.py` 改为校验英文主入口、中文镜像存在、`loom-init` root entry 语义和 native discovery 安装路径
- `loom_flow.py` / `loom_check.py` 补充超时保护，避免 `loom_check` 在 review engine 或 `gh auth status` 探测上无上限阻塞
- 示例 bootstrap 真相文件刷新为当前 `main` 分支状态
- `loom-installer` 版本提升到 `0.1.10`

## 验证
- `python3 -m py_compile skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py tools/loom_check.py`
- `python3 tools/loom_init.py route --target examples/new-project --task '请接手当前事项并恢复上下文后继续推进'`
- `python3 examples/new-project/.loom/bin/loom_init.py verify --target examples/new-project`
- `npm --prefix packages/loom-installer run check:docs`
- `npm --prefix packages/loom-installer test`
- `python3 tools/loom_check.py .`
- `make loom-check`
