### PR TITLE
feat: 增加 Loom core runtime parity 验证

### DIFF
--- a/docs/evidence/validations/validation-loom-core-runtime-parity.md
+++ b/docs/evidence/validations/validation-loom-core-runtime-parity.md
@@ -1,0 +1,53 @@
+# Validation: Loom Core Runtime Parity
+
+## 1. 样本标识
+
+- 验证目标：`#318`
+- 验证日期：`2026-04-25`
+- 样本仓库：`examples/new-project`
+
+## 2. 验证目标
+
+本记录把 Syvert strong governance parity 从文档层推进到最小 runtime parity。
+
+它不证明 GitHub profile 已完成完整宿主编排，也不把 Syvert repo-local 文件名提升为 Loom core。它只证明 Loom core 能用机器可读 runtime surface 表达以下能力：
+
+- `Work Item` 作为唯一执行入口
+- `status control plane`
+- `gate chain`
+- `controlled merge` 合同
+- `closeout / reconciliation` 前置关系
+- `shadow parity` 默认 validation-only 边界
+
+## 3. Runtime Entry
+
+新增 runtime parity 验证入口：
+
+```bash
+python3 tools/loom_flow.py runtime-parity validate --target examples/new-project --item INIT-0001
+```
+
+该入口输出 `loom-runtime-parity/v1` JSON，并由 `loom_check` 消费。
+
+## 4. Runtime Parity 边界
+
+本验证明确区分两层：
+
+- 文档层 parity
+  - 由 `docs/methodology/**`、`docs/adoption/**` 与既有 Syvert parity validation 证明语义落点完整。
+- runtime parity
+  - 由 `runtime-parity validate` 证明核心治理路径可被工具读取、归类并 fail-closed。
+
+本阶段仍不覆盖：
+
+- ProjectV2 / native sub-issues 的完整自动编排
+- GitHub profile 的重宿主动作
+- Syvert 反向消费 Loom 的 release judgment
+
+这些进入后续 `#321` 与 `#329`。
+
+## 5. Release Judgment
+
+`#318` 完成后，Loom core 不再只声称具备 strong governance parity，而是拥有可运行、可检查、可安装回归的 runtime parity 入口。
+
+`#317` 仍不能关闭，直到 `#319` 与 `#320` 继续补齐 closeout/reconciliation 阻断和可选 shadow parity blocking gate。

--- a/docs/evidence/validations/validation-syvert-strong-governance-parity.md
+++ b/docs/evidence/validations/validation-syvert-strong-governance-parity.md
@@ -72,10 +72,12 @@
 2. GitHub profile upgrade 已能表达从一般仓库升级到 Syvert 级治理强度的路径
 3. parity validation 已明确哪些能力是 Loom core，哪些仍是 repo-local 宿主实现
 
-但本轮仍保留两个明确 residue：
+本轮原始验证仍保留两个明确 residue：
 
-- 这是文档层 parity，不是 runtime parity
+- `#318` 之前，这是文档层 parity，不是 runtime parity
 - `Syvert` 真正切换到消费 Loom 文档与脚本，还需要后续 implementation / smoke / release judgment 支撑
+
+`#318` 已开始由 [validation-loom-core-runtime-parity.md](./validation-loom-core-runtime-parity.md) 承接 runtime parity 验证入口。该入口证明 Loom core 的 Work Item、status control plane、gate chain、controlled merge contract、closeout/reconciliation 和 shadow parity validation-only 边界可被机器读取；但 Syvert 反向消费与宿主编排仍属于后续阶段。
 
 ## 6. 结论
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -92,6 +92,7 @@ CORE_DOCS = (
     "docs/methodology/templates/pull-request.md",
     "docs/evidence/extraction-ledger.md",
     "docs/evidence/landing-map.md",
+    "docs/evidence/validations/validation-loom-core-runtime-parity.md",
     "docs/evidence/validations/validation-syvert-strong-governance-parity.md",
     "docs/adoption/rationale.md",
     "docs/adoption/routing-and-checkpoints.md",
@@ -1162,6 +1163,68 @@ def require_closeout_reconciliation_contract(
             failures.append(Failure(category, f"{context} must point blocked reconciliation drift to `manual-reconciliation`"))
 
 
+def require_runtime_parity_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "runtime-parity":
+        failures.append(Failure(category, f"{context} must report `command: runtime-parity`"))
+    if payload.get("operation") != "validate":
+        failures.append(Failure(category, f"{context} must report `operation: validate`"))
+    if payload.get("schema_version") != "loom-runtime-parity/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-runtime-parity/v1`"))
+    if payload.get("result") not in {"pass", "block"}:
+        failures.append(Failure(category, f"{context} result must be `pass` or `block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include a non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "admission", "merge", "reconciliation-sync", "manual-runtime-reconciliation", "rebootstrap-runtime", "refresh-install", "loom-init"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable runtime parity contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass"},
+    )
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} must include `checks` as a list"))
+        return
+    required_checks = {
+        "work_item",
+        "status_control_plane",
+        "gate_chain",
+        "controlled_merge_contract",
+        "closeout_reconciliation",
+        "shadow_parity_boundary",
+    }
+    check_names = {check.get("name") for check in checks if isinstance(check, dict)}
+    if not required_checks.issubset(check_names):
+        failures.append(Failure(category, f"{context} must cover the stable runtime parity check set"))
+    for check in checks:
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} checks must be JSON objects"))
+            continue
+        if check.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} check `{check.get('name')}` result must be `pass` or `block`"))
+        if not isinstance(check.get("summary"), str) or not check.get("summary"):
+            failures.append(Failure(category, f"{context} check `{check.get('name')}` must include non-empty `summary`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
 def require_review_record_contract(
     failures: list[Failure],
     *,
@@ -2125,6 +2188,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             {"pass", "block"},
         ),
         (
+            "runtime-parity",
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "runtime-parity",
+                "validate",
+                "--target",
+                "examples/new-project",
+                "--item",
+                "INIT-0001",
+            ],
+            {"pass"},
+        ),
+        (
             "governance-profile-status",
             ["python3", "tools/loom_flow.py", "governance-profile", "status", "--target", "examples/new-project"],
             {"pass"},
@@ -2359,6 +2436,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
+                payload=payload,
+            )
+        if label == "runtime-parity":
+            require_runtime_parity_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`runtime-parity validate`",
                 payload=payload,
             )
         if label in {"governance-profile-status", "governance-profile-upgrade-plan"}:

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -277,6 +277,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Init-result path relative to the target root",
     )
 
+    runtime_parity = subparsers.add_parser(
+        "runtime-parity",
+        help="Validate Loom core strong-governance runtime parity without host-specific orchestration",
+    )
+    runtime_parity.add_argument("operation", choices=("validate",))
+    runtime_parity.add_argument("--target", required=True, help="Target repository root")
+    runtime_parity.add_argument("--item", help="Expected current item id")
+    runtime_parity.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+
     governance_profile = subparsers.add_parser(
         "governance-profile",
         help="Read Loom governance maturity and upgrade requirements",
@@ -4162,6 +4175,239 @@ def closeout_reconciliation_result(
     return None, None
 
 
+def runtime_parity_check(
+    name: str,
+    *,
+    result: str,
+    summary: str,
+    evidence: dict[str, Any] | None = None,
+    missing_inputs: list[str] | None = None,
+    fallback_to: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "result": result,
+        "summary": summary,
+        "evidence": evidence or {},
+        "missing_inputs": missing_inputs or [],
+        "fallback_to": fallback_to,
+    }
+
+
+def runtime_parity_payload(
+    *,
+    target_root: Path,
+    output_relative: str,
+    expected_item: str | None,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    checks: list[dict[str, Any]] = []
+    if runtime_state["result"] != "pass":
+        checks.append(
+            runtime_parity_check(
+                "runtime_state",
+                result="block",
+                summary="runtime carrier is not consistent enough to prove runtime parity.",
+                missing_inputs=list(runtime_state.get("missing_inputs", [])),
+                fallback_to=runtime_state.get("fallback_to"),
+                evidence={"runtime_state": runtime_state},
+            )
+        )
+        return {
+            "command": "runtime-parity",
+            "operation": "validate",
+            "schema_version": "loom-runtime-parity/v1",
+            "result": "block",
+            "summary": "Loom core runtime parity validation is blocked by runtime-state drift.",
+            "missing_inputs": list(runtime_state.get("missing_inputs", [])),
+            "fallback_to": runtime_state.get("fallback_to"),
+            "runtime_state": runtime_state,
+            "checks": checks,
+        }
+
+    context, context_errors = load_context(target_root, output_relative, expected_item)
+    governance_surface = build_governance_surface(target_root)
+    control_plane = governance_surface.get("governance_control_plane")
+    carrier_summary = governance_surface.get("carrier_summary")
+
+    if context_errors:
+        checks.append(
+            runtime_parity_check(
+                "work_item",
+                result="block",
+                summary="runtime parity could not read the Work Item fact chain.",
+                missing_inputs=[f"fact-chain: {message}" for message in context_errors],
+                fallback_to="admission",
+            )
+        )
+    else:
+        checks.append(
+            runtime_parity_check(
+                "work_item",
+                result="pass",
+                summary="Work Item is readable as the single execution entry.",
+                evidence={
+                    "item_id": context["item_id"],
+                    "work_item": context["report"]["fact_chain"]["entry_points"]["work_item"],
+                    "recovery_entry": context["report"]["fact_chain"]["entry_points"]["recovery_entry"],
+                    "status_surface": context["report"]["fact_chain"]["entry_points"]["status_surface"],
+                },
+            )
+        )
+
+    if isinstance(control_plane, dict) and control_plane.get("schema_version") == "loom-governance-control/v1":
+        checks.append(
+            runtime_parity_check(
+                "status_control_plane",
+                result="pass",
+                summary="governance control plane is available as a machine-readable runtime surface.",
+                evidence={
+                    "schema_version": control_plane.get("schema_version"),
+                    "taxonomy": sorted((control_plane.get("taxonomy") or {}).keys())
+                    if isinstance(control_plane.get("taxonomy"), dict)
+                    else [],
+                    "maturity": (control_plane.get("maturity") or {}).get("current")
+                    if isinstance(control_plane.get("maturity"), dict)
+                    else None,
+                },
+            )
+        )
+    else:
+        checks.append(
+            runtime_parity_check(
+                "status_control_plane",
+                result="block",
+                summary="governance control plane is missing or unreadable.",
+                missing_inputs=["governance_control_plane"],
+                fallback_to="admission",
+            )
+        )
+
+    expected_gate_order = [
+        "work_item_admission",
+        "spec_gate",
+        "build_gate",
+        "review_gate",
+        "merge_gate",
+        "github_controlled_merge",
+        "closeout",
+    ]
+    gate_chain = control_plane.get("gate_chain") if isinstance(control_plane, dict) else None
+    actual_gate_order = [entry.get("id") for entry in gate_chain if isinstance(entry, dict)] if isinstance(gate_chain, (list, tuple)) else []
+    checks.append(
+        runtime_parity_check(
+            "gate_chain",
+            result="pass" if actual_gate_order == expected_gate_order else "block",
+            summary=(
+                "strong governance gate chain is available in runtime order."
+                if actual_gate_order == expected_gate_order
+                else "strong governance gate chain does not match the runtime parity contract."
+            ),
+            evidence={"gate_order": actual_gate_order, "expected_gate_order": expected_gate_order},
+            missing_inputs=[] if actual_gate_order == expected_gate_order else ["governance_control_plane.gate_chain"],
+            fallback_to=None if actual_gate_order == expected_gate_order else "admission",
+        )
+    )
+
+    host_binding = control_plane.get("host_binding") if isinstance(control_plane, dict) else None
+    required_objects = host_binding.get("required_objects") if isinstance(host_binding, dict) else None
+    controlled_merge_ready = (
+        isinstance(host_binding, dict)
+        and isinstance(required_objects, dict)
+        and {"implementation_pr", "merge_commit", "closeout"}.issubset(required_objects.keys())
+    )
+    checks.append(
+        runtime_parity_check(
+            "controlled_merge_contract",
+            result="pass" if controlled_merge_ready else "block",
+            summary=(
+                "controlled merge contract exposes PR, merge commit, and closeout host-owned bindings."
+                if controlled_merge_ready
+                else "controlled merge contract is missing required host-owned bindings."
+            ),
+            evidence={
+                "host_binding_result": host_binding.get("result") if isinstance(host_binding, dict) else None,
+                "required_objects": sorted(required_objects.keys()) if isinstance(required_objects, dict) else [],
+            },
+            missing_inputs=[] if controlled_merge_ready else ["governance_control_plane.host_binding"],
+            fallback_to=None if controlled_merge_ready else "merge",
+        )
+    )
+
+    closeout_gate = next((entry for entry in gate_chain or [] if isinstance(entry, dict) and entry.get("id") == "closeout"), {})
+    closeout_requires = closeout_gate.get("requires") if isinstance(closeout_gate, dict) else None
+    closeout_ready = isinstance(closeout_requires, (list, tuple)) and "reconciliation_audit" in closeout_requires
+    checks.append(
+        runtime_parity_check(
+            "closeout_reconciliation",
+            result="pass" if closeout_ready else "block",
+            summary=(
+                "closeout gate consumes reconciliation audit as a runtime prerequisite."
+                if closeout_ready
+                else "closeout gate does not expose reconciliation audit as a runtime prerequisite."
+            ),
+            evidence={
+                "closeout_requires": closeout_requires if isinstance(closeout_requires, (list, tuple)) else [],
+                "repo_interop_availability": (governance_surface.get("repo_interop") or {}).get("availability")
+                if isinstance(governance_surface.get("repo_interop"), dict)
+                else None,
+            },
+            missing_inputs=[] if closeout_ready else ["governance_control_plane.gate_chain.closeout"],
+            fallback_to=None if closeout_ready else "reconciliation-sync",
+        )
+    )
+
+    checks.append(
+        runtime_parity_check(
+            "shadow_parity_boundary",
+            result="pass",
+            summary="shadow parity remains validation-only in Loom core runtime parity.",
+            evidence={
+                "default_result_contract": ["pass", "warn"],
+                "blocking_default": False,
+                "surfaces": list(SHADOW_PARITY_SURFACES),
+            },
+        )
+    )
+
+    if not isinstance(carrier_summary, dict):
+        checks.append(
+            runtime_parity_check(
+                "carrier_summary",
+                result="block",
+                summary="carrier summary is missing from governance surface.",
+                missing_inputs=["governance_surface.carrier_summary"],
+                fallback_to="admission",
+            )
+        )
+
+    missing_inputs: list[str] = []
+    fallback_to: str | None = None
+    for check in checks:
+        if check["result"] == "block":
+            fallback_to = fallback_to or check.get("fallback_to")
+            for message in check.get("missing_inputs", []):
+                if message not in missing_inputs:
+                    missing_inputs.append(message)
+
+    result = "pass" if not missing_inputs else "block"
+    return {
+        "command": "runtime-parity",
+        "operation": "validate",
+        "schema_version": "loom-runtime-parity/v1",
+        "result": result,
+        "summary": (
+            "Loom core runtime parity is machine-readable across Work Item, status, gates, controlled merge, closeout, and shadow boundary."
+            if result == "pass"
+            else "Loom core runtime parity validation found missing or unreadable runtime surfaces."
+        ),
+        "missing_inputs": missing_inputs,
+        "fallback_to": fallback_to,
+        "runtime_state": runtime_state,
+        "checks": checks,
+    }
+
+
 def closeout_payload(
     *,
     target_root: Path,
@@ -5898,6 +6144,17 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     )
 
 
+def handle_runtime_parity(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    return emit(
+        runtime_parity_payload(
+            target_root=target_root,
+            output_relative=args.output,
+            expected_item=args.item,
+        )
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     if args.command == "fact-chain":
@@ -5922,6 +6179,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "runtime-parity":
+        return handle_runtime_parity(args)
     if args.command == "governance-profile":
         return handle_governance_profile(args)
     if args.command == "flow":


### PR DESCRIPTION
## Summary

- add `runtime-parity validate` as the machine-readable Loom core runtime parity entry
- make `loom_check` consume the `loom-runtime-parity/v1` payload
- add evidence that separates prior document-layer parity from runtime parity

## Validation

- `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py runtime-parity validate --target examples/new-project --item INIT-0001`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`

Fixes #318
