### PR TITLE
feat: 强化 closeout 与 reconciliation 阻断门禁

### DIFF
--- a/docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md
+++ b/docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md
@@ -1,0 +1,62 @@
+# Validation: Closeout / Reconciliation Blocking Gate
+
+## 1. 样本标识
+
+- 验证目标：`#319`
+- 验证日期：`2026-04-25`
+- 验证范围：Loom core closeout / reconciliation gate
+
+## 2. 验证目标
+
+本记录证明 `closeout` 不再只读取零散 host 状态，而是必须消费同范围 `reconciliation audit` 结果，并按统一 taxonomy fail-closed。
+
+## 3. 稳定 finding taxonomy
+
+`reconciliation.findings[*]` 固定包含：
+
+- `category`
+- `kind`
+- `severity`
+- `fallback_to`
+- `subject`
+- `evidence`
+- `recommended_action`
+
+当前冻结的 `kind`：
+
+- `merged_but_open`
+- `absorbed_but_open`
+- `parent_drift`
+- `project_drift`
+- `host_signal_drift`
+
+## 4. Runtime Contract
+
+`closeout check|sync` 必须遵守：
+
+- `reconciliation.result = pass`
+  - 允许继续 closeout 判断
+- `reconciliation.result = warn`
+  - 显式挂到 closeout 输出，但不默认阻断
+- `reconciliation.result = fix-needed`
+  - `closeout.result = block`
+  - `closeout.fallback_to = reconciliation-sync`
+- `reconciliation.result = block`
+  - `closeout.result = block`
+  - `closeout.fallback_to = manual-reconciliation`
+
+## 5. 本轮验证
+
+本轮把以下正向/负向样本写入 `loom_check` synthetic contract：
+
+- `merged_but_open`
+- `absorbed_but_open`
+- `parent_drift`
+- `host_signal_drift`
+- `warn` 不默认阻断
+- `fix-needed` 不允许 fail-open
+- `block` 不允许回退到普通 `merge`
+
+## 6. Release Judgment
+
+`#319` 完成后，Loom core closeout/reconciliation 已具备稳定 blocking gate 语义。GitHub profile 后续仍可增强对象自动编排，但不得绕过这里冻结的 fail-closed 纪律。

--- a/docs/methodology/harness/closeout-gate.md
+++ b/docs/methodology/harness/closeout-gate.md
@@ -57,8 +57,10 @@ closeout gate 用来回答两件事：
 因此，`closeout check` 至少要能区分：
 
 - 该 issue 已由其对应实现进入 `closed_out`
+- 该 issue 的对应实现已 merged，但 issue 仍 open，需要 `reconciliation sync`
 - 该 issue 的实现已被其他 merged work `absorbed`，但控制面尚未完成 closeout sync
 - 该 issue 仍保留独立剩余缺口，不能被视为 `absorbed`
+- GitHub host signal 不可读或互相冲突，必须进入 `manual-reconciliation`
 
 ## 4. `sync` 最小动作
 

--- a/docs/methodology/harness/reconciliation-audit.md
+++ b/docs/methodology/harness/reconciliation-audit.md
@@ -13,16 +13,18 @@
 
 ## 3. 固定 findings
 
-当前冻结四类 finding：
+当前冻结五类 finding：
 
+- `merged_but_open`
+  - 当前 issue 对应的实现 PR 已 merged 且 merge commit 已进入主干，但 issue 仍 open
 - `absorbed_but_open`
-  - merge 已吸收实现，但事项仍 open
+  - 当前事项已被其他 merged work 证明吸收，但控制面仍 open
 - `parent_drift`
   - parent 与 child 的收口结论不一致
 - `project_drift`
   - issue / PR / project 状态未对齐
-- `merge_signal_drift`
-  - PR、merge commit、主干或 closeout basis 互相冲突
+- `host_signal_drift`
+  - GitHub issue、PR、project、branch 或 repository 信号不可读或互相冲突
 
 每条 finding 至少表达：
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -92,6 +92,7 @@ CORE_DOCS = (
     "docs/methodology/templates/pull-request.md",
     "docs/evidence/extraction-ledger.md",
     "docs/evidence/landing-map.md",
+    "docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md",
     "docs/evidence/validations/validation-loom-core-runtime-parity.md",
     "docs/evidence/validations/validation-syvert-strong-governance-parity.md",
     "docs/adoption/rationale.md",
@@ -1118,10 +1119,14 @@ def require_reconciliation_payload(
         if not isinstance(finding, dict):
             failures.append(Failure(category, f"{context} reconciliation findings must be JSON objects"))
             continue
-        if finding.get("kind") not in {"absorbed_but_open", "parent_drift", "project_drift"}:
+        if finding.get("category") not in {"drift", "gate_failure"}:
+            failures.append(Failure(category, f"{context} reconciliation finding category must stay within the stable taxonomy"))
+        if finding.get("kind") not in {"merged_but_open", "absorbed_but_open", "parent_drift", "project_drift", "host_signal_drift"}:
             failures.append(Failure(category, f"{context} reconciliation finding kind must stay within the stable contract"))
         if finding.get("severity") not in {"warn", "fix-needed", "block"}:
             failures.append(Failure(category, f"{context} reconciliation finding severity must stay within the stable contract"))
+        if finding.get("fallback_to") not in {"reconciliation-sync", "manual-reconciliation", None}:
+            failures.append(Failure(category, f"{context} reconciliation finding fallback_to must stay within the stable contract"))
         if not isinstance(finding.get("subject"), str) or not finding.get("subject"):
             failures.append(Failure(category, f"{context} reconciliation findings must include non-empty `subject`"))
         if not isinstance(finding.get("evidence"), dict):
@@ -4692,18 +4697,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 "summary": "warn",
                 "missing_inputs": [],
                 "fallback_to": "manual-reconciliation",
-                "findings": [
-                    {
-                        "kind": "project_drift",
-                        "severity": "warn",
-                        "subject": "project 5",
-                        "evidence": {},
-                        "recommended_action": "review warning",
-                    }
-                ],
+                    "findings": [
+                        {
+                            "category": "drift",
+                            "kind": "project_drift",
+                            "severity": "warn",
+                            "subject": "project 5",
+                            "evidence": {},
+                            "recommended_action": "review warning",
+                            "fallback_to": "reconciliation-sync",
+                        }
+                    ],
+                },
             },
-        },
-    )
+        )
     if warn_payload_failures:
         failures.append(
             Failure(
@@ -4711,6 +4718,50 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 "`closeout-warn-does-not-block` synthetic payload must allow non-blocking reconciliation warnings",
             )
         )
+
+    valid_reconciliation_samples = [
+        ("merged_but_open", "fix-needed", "reconciliation-sync"),
+        ("absorbed_but_open", "fix-needed", "reconciliation-sync"),
+        ("parent_drift", "block", "manual-reconciliation"),
+        ("host_signal_drift", "block", "manual-reconciliation"),
+    ]
+    for kind, reconciliation_result_value, fallback_to in valid_reconciliation_samples:
+        sample_failures = []
+        require_closeout_reconciliation_contract(
+            sample_failures,
+            category="daily-execution-cli",
+            context=f"`closeout-{kind}`",
+            payload={
+                "result": "block",
+                "fallback_to": fallback_to,
+                "reconciliation": {
+                    "command": "reconciliation",
+                    "operation": "audit",
+                    "result": reconciliation_result_value,
+                    "summary": kind,
+                    "missing_inputs": [] if kind != "host_signal_drift" else ["github control plane"],
+                    "fallback_to": "manual-reconciliation",
+                    "findings": [
+                        {
+                            "category": "drift",
+                            "kind": kind,
+                            "severity": reconciliation_result_value,
+                            "subject": "closeout sample",
+                            "evidence": {},
+                            "recommended_action": "reconcile closeout sample",
+                            "fallback_to": fallback_to,
+                        }
+                    ],
+                },
+            },
+        )
+        if sample_failures:
+            failures.append(
+                Failure(
+                    "daily-execution-cli",
+                    f"`closeout-{kind}` synthetic payload must satisfy closeout reconciliation validation",
+                )
+            )
 
     return failures
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -3748,13 +3748,19 @@ def make_reconciliation_finding(
     subject: str,
     evidence: dict[str, Any],
     recommended_action: str,
+    category: str = "drift",
+    fallback_to: str | None = None,
 ) -> dict[str, Any]:
+    if fallback_to is None:
+        fallback_to = "manual-reconciliation" if severity == "block" else "reconciliation-sync"
     return {
+        "category": category,
         "kind": kind,
         "severity": severity,
         "subject": subject,
         "evidence": evidence,
         "recommended_action": recommended_action,
+        "fallback_to": fallback_to,
     }
 
 
@@ -3824,13 +3830,13 @@ def reconciliation_audit_payload(
                     merge_commit_sha = oid
                     merge_commit_in_main = contains_merged_commit(target_root, merge_commit_sha)
 
-    absorbed_issue = False
+    merged_issue_open = False
     if issue_payload is not None and pr_payload is not None:
         if issue_payload.get("state") == "OPEN" and pr_payload.get("state") == "MERGED" and merge_commit_sha and merge_commit_in_main:
-            absorbed_issue = True
+            merged_issue_open = True
             findings.append(
                 make_reconciliation_finding(
-                    kind="absorbed_but_open",
+                    kind="merged_but_open",
                     severity="fix-needed",
                     subject=f"issue #{issue_number}",
                     evidence={
@@ -3840,7 +3846,7 @@ def reconciliation_audit_payload(
                         "merge_commit": merge_commit_sha,
                         "merge_commit_in_main": merge_commit_in_main,
                     },
-                    recommended_action="close the absorbed issue or run reconciliation sync after reviewing the evidence.",
+                    recommended_action="close the merged issue or run reconciliation sync after reviewing the evidence.",
                 )
             )
 
@@ -3866,7 +3872,7 @@ def reconciliation_audit_payload(
                 if child_state == "CLOSED":
                     resolved_children.append(child)
                     continue
-                if child_number == issue_number and absorbed_issue:
+                if child_number == issue_number and merged_issue_open:
                     resolved_children.append(child)
                     continue
                 unresolved_children.append(child)
@@ -3929,7 +3935,7 @@ def reconciliation_audit_payload(
             }
 
             if issue_number is not None:
-                expected_done = issue_payload is not None and (issue_payload.get("state") == "CLOSED" or absorbed_issue)
+                expected_done = issue_payload is not None and (issue_payload.get("state") == "CLOSED" or merged_issue_open)
                 if issue_item is None:
                     project_drift_details.append(
                         {
@@ -3994,12 +4000,23 @@ def reconciliation_audit_payload(
         )
 
     if missing_inputs:
+        findings.append(
+            make_reconciliation_finding(
+                kind="host_signal_drift",
+                severity="block",
+                subject="github control plane",
+                evidence={"missing_inputs": missing_inputs},
+                recommended_action="restore readable GitHub issue, PR, project, or repository signals before closeout.",
+                category="drift",
+                fallback_to="manual-reconciliation",
+            )
+        )
         result = "block"
         summary = "reconciliation audit could not complete because required GitHub inputs were missing."
     else:
         result = reconciliation_result(findings)
         summary = (
-            "reconciliation audit found no absorbed-but-open, parent-drift, or project-drift findings."
+            "reconciliation audit found no merged-but-open, absorbed-but-open, parent-drift, host-signal-drift, or project-drift findings."
             if result == "pass"
             else "reconciliation audit found GitHub drift that must be reviewed before closeout."
         )
@@ -4037,7 +4054,7 @@ def reconciliation_sync_plan(audit_payload: dict[str, Any]) -> tuple[list[dict[s
         evidence = finding.get("evidence")
         if severity != "fix-needed":
             continue
-        if kind == "absorbed_but_open":
+        if kind in {"merged_but_open", "absorbed_but_open"}:
             plan.append(
                 {
                     "kind": kind,


### PR DESCRIPTION
## Summary

- strengthen reconciliation findings with stable category and fallback fields
- split `merged_but_open` from `absorbed_but_open` and add `host_signal_drift`
- add closeout/reconciliation blocking-gate evidence and synthetic contract checks
- bump loom-installer to 0.1.12 for the updated runtime payload

## Validation

- `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py reconciliation audit --target . --owner MC-and-his-Agents --repo Loom` returned `block host_signal_drift` for the missing host-object negative sample
- `python3 tools/loom_flow.py runtime-parity validate --target examples/new-project --item INIT-0001`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer run check:docs`
- `npm --prefix packages/loom-installer test`

Fixes #319
