### PR TITLE
feat: 支持可选 shadow parity blocking gate

### DIFF
--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -123,12 +123,41 @@
 稳定约束：
 
 - parity compare 结果只允许 `match | mismatch | unreadable`
-- `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
 - `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
 
-### 5.1 从 validation-only 升级前必须满足的证据标准
+### 5.1 blocking 消费模式
 
-在进入下一阶段之前，`shadow parity` 仍固定保持为 validation-only compare surface。
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
 
 要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
 
@@ -151,13 +180,13 @@
 5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
    - 例如 host action、closeout gate、review / checkpoint 合同
 
-只要以上任一条件未满足，`shadow parity` 就不得从 validation-only 升级。
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
 
-### 5.2 当前明确不做
+### 5.3 当前明确不做
 
 在本树当前阶段，明确不做以下升级：
 
-- 不把 `mismatch` 直接视为 blocking merge gate
+- 不把 `mismatch` 默认视为 blocking merge gate
 - 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
 - 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
 - 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth

--- a/docs/evidence/validations/validation-shadow-parity-blocking-gate.md
+++ b/docs/evidence/validations/validation-shadow-parity-blocking-gate.md
@@ -1,0 +1,67 @@
+# Validation: Optional Shadow Parity Blocking Gate
+
+## 1. 样本标识
+
+- 验证目标：`#320`
+- 验证日期：`2026-04-25`
+- 验证范围：Loom core candidate shadow parity consumption
+
+## 2. 验证目标
+
+本记录证明 `shadow parity` 可以被 strong governance profile 显式消费成 blocking gate，同时保持默认 validation-only 行为。
+
+## 3. Runtime Contract
+
+默认入口保持 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+默认结果只允许：
+
+- `pass`
+- `warn`
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+或：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --mode blocking
+```
+
+blocking 模式结果只允许：
+
+- `pass`
+- `block`
+
+## 4. Taxonomy
+
+`reports[*].result` 继续保持兼容词表：
+
+- `match`
+- `mismatch`
+- `unreadable`
+
+新增并行字段：
+
+- `classification`
+  - `drift` 用于 `mismatch`
+  - `gate_failure` 用于 `unreadable`
+- `blocking`
+- `recommended_action`
+
+## 5. 边界
+
+`interop.json` 仍然只描述读取入口，不声明 blocking owner、override decision 或 final verdict。
+
+blocking enablement、fallback、owner、authority-of-truth 必须落在 strong governance profile 或其他权威合同中。
+
+## 6. Release Judgment
+
+`#320` 完成后，Loom core 支持 optional shadow parity blocking gate，但默认仓库不会因为存在 shadow parity mismatch 自动阻断 merge 或 closeout。

--- a/docs/methodology/harness/closeout-gate.md
+++ b/docs/methodology/harness/closeout-gate.md
@@ -53,6 +53,8 @@ closeout gate 用来回答两件事：
 - `fix-needed`：必须返回 `block`；先经 `reconciliation sync` 完成机械对齐，再重新执行 closeout check
 - `block`：必须返回 `block`；先消除硬冲突或缺失事实，且在 audit 重新达标前禁止任何 closeout sync 写入
 
+`shadow parity` 默认不进入 closeout 阻断面。只有 strong governance profile 或显式 opt-in 启用 blocking 消费时，closeout/review/merge-ready 才能把 shadow parity 的 `mismatch` / `unreadable` 当作阻断输入；启用点必须同时声明 owner、fallback、override path 与 authority-of-truth。
+
 这里的 `absorbed` 只表示 host merge 后可证明的实现吸收结论，不等于 `closed_out`。
 因此，`closeout check` 至少要能区分：
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -94,6 +94,7 @@ CORE_DOCS = (
     "docs/evidence/landing-map.md",
     "docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md",
     "docs/evidence/validations/validation-loom-core-runtime-parity.md",
+    "docs/evidence/validations/validation-shadow-parity-blocking-gate.md",
     "docs/evidence/validations/validation-syvert-strong-governance-parity.md",
     "docs/adoption/rationale.md",
     "docs/adoption/routing-and-checkpoints.md",
@@ -969,10 +970,17 @@ def require_shadow_parity_payload(
         return
     if payload.get("command") != "shadow-parity":
         failures.append(Failure(category, f"{context} must report `command: shadow-parity`"))
-    if payload.get("result") not in {"pass", "warn"}:
-        failures.append(Failure(category, f"{context} result must be `pass` or `warn`"))
-    if payload.get("fallback_to") is not None:
-        failures.append(Failure(category, f"{context} fallback_to must remain `null`"))
+    mode = payload.get("mode", "validation-only")
+    if mode not in {"validation-only", "blocking"}:
+        failures.append(Failure(category, f"{context} mode must be `validation-only` or `blocking`"))
+    if payload.get("blocking") != (mode == "blocking"):
+        failures.append(Failure(category, f"{context} blocking flag must match mode"))
+    allowed_results = {"pass", "block"} if mode == "blocking" else {"pass", "warn"}
+    if payload.get("result") not in allowed_results:
+        failures.append(Failure(category, f"{context} result must stay within the stable mode-specific contract"))
+    expected_fallbacks = {"manual-reconciliation"} if payload.get("result") == "block" else {None}
+    if payload.get("fallback_to") not in expected_fallbacks:
+        failures.append(Failure(category, f"{context} fallback_to must match the shadow parity enforcement mode"))
     if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
@@ -1008,6 +1016,14 @@ def require_shadow_parity_payload(
             failures.append(Failure(category, f"{context} reports[{index}] must declare a known surface"))
         if report.get("result") not in {"match", "mismatch", "unreadable"}:
             failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+        if report.get("classification") not in {None, "drift", "gate_failure"}:
+            failures.append(Failure(category, f"{context} reports[{index}] classification must stay within the stable contract"))
+        if not isinstance(report.get("blocking"), bool):
+            failures.append(Failure(category, f"{context} reports[{index}] must include boolean `blocking`"))
+        if not isinstance(report.get("recommended_action"), str) or not report.get("recommended_action"):
+            failures.append(Failure(category, f"{context} reports[{index}] must include non-empty `recommended_action`"))
+        if mode == "blocking" and report.get("result") != "match" and report.get("blocking") is not True:
+            failures.append(Failure(category, f"{context} reports[{index}] must block non-matching reports in blocking mode"))
         if not isinstance(report.get("summary"), str) or not report.get("summary"):
             failures.append(Failure(category, f"{context} reports[{index}] must include non-empty `summary`"))
         if not isinstance(report.get("missing_inputs"), list):
@@ -5301,6 +5317,23 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             if parity_payload.get("result") != "pass":
                 failures.append(Failure("repo-interop", "`shadow-parity` must pass when all declared surfaces match"))
 
+        blocking_match_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(present_target), "--blocking"],
+        )
+        if error:
+            failures.append(Failure("repo-interop", f"`shadow-parity --blocking` match sample failed: {error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="repo-interop",
+                context="`shadow-parity --blocking` match sample",
+                payload=blocking_match_payload,
+                expected_reports=4,
+            )
+            if blocking_match_payload.get("result") != "pass":
+                failures.append(Failure("repo-interop", "`shadow-parity --blocking` must pass when all declared surfaces match"))
+
         mismatch_target = base / "mismatch"
         shutil.copytree(present_target, mismatch_target)
         write_json(mismatch_target / ".loom/shadow/review-repo.json", {"decision": "block"})
@@ -5321,6 +5354,62 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
             reports = mismatch_payload.get("reports")
             if not isinstance(reports, list) or not reports or reports[0].get("result") != "mismatch":
                 failures.append(Failure("repo-interop", "`shadow-parity` mismatch sample must report `mismatch`"))
+
+        blocking_mismatch_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "shadow-parity",
+                "--target",
+                str(mismatch_target),
+                "--surface",
+                "review",
+                "--mode",
+                "blocking",
+            ],
+        )
+        if error:
+            failures.append(Failure("repo-interop", f"`shadow-parity --mode blocking` mismatch sample failed: {error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="repo-interop",
+                context="`shadow-parity --mode blocking` mismatch sample",
+                payload=blocking_mismatch_payload,
+                expected_reports=1,
+            )
+            if blocking_mismatch_payload.get("result") != "block":
+                failures.append(Failure("repo-interop", "`shadow-parity --mode blocking` must block mismatches"))
+
+        unreadable_target = base / "unreadable"
+        shutil.copytree(present_target, unreadable_target)
+        (unreadable_target / ".loom/shadow/closeout-repo.json").unlink()
+        blocking_unreadable_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "shadow-parity",
+                "--target",
+                str(unreadable_target),
+                "--surface",
+                "closeout",
+                "--blocking",
+            ],
+        )
+        if error:
+            failures.append(Failure("repo-interop", f"`shadow-parity --blocking` unreadable sample failed: {error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="repo-interop",
+                context="`shadow-parity --blocking` unreadable sample",
+                payload=blocking_unreadable_payload,
+                expected_reports=1,
+            )
+            if blocking_unreadable_payload.get("result") != "block":
+                failures.append(Failure("repo-interop", "`shadow-parity --blocking` must block unreadable surfaces"))
 
     return failures
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -276,6 +276,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=".loom/bootstrap/init-result.json",
         help="Init-result path relative to the target root",
     )
+    shadow.add_argument(
+        "--mode",
+        choices=("validation-only", "blocking"),
+        default="validation-only",
+        help="Shadow parity enforcement mode; defaults to validation-only.",
+    )
+    shadow.add_argument(
+        "--blocking",
+        action="store_true",
+        help="Shortcut for --mode blocking. This is explicit opt-in and never the default.",
+    )
 
     runtime_parity = subparsers.add_parser(
         "runtime-parity",
@@ -543,8 +554,11 @@ def shadow_parity_report(
     empty_report = {
         "surface": surface,
         "result": "unreadable",
+        "classification": "gate_failure",
+        "blocking": False,
         "summary": "shadow parity could not be evaluated for this surface.",
         "missing_inputs": [],
+        "recommended_action": "restore the declared Loom and repo-native shadow parity locators before treating this surface as authoritative.",
         "host_adapters": [],
         "repo_native_carriers": [],
         "loom_surface": {
@@ -633,8 +647,11 @@ def shadow_parity_report(
         return {
             "surface": surface,
             "result": "match",
+            "classification": None,
+            "blocking": False,
             "summary": "Loom and repo-native surfaces report the same normalized result.",
             "missing_inputs": [],
+            "recommended_action": "no shadow parity action required.",
             "host_adapters": relevant_host_adapters,
             "repo_native_carriers": relevant_repo_native_carriers,
             "loom_surface": loom_surface,
@@ -643,8 +660,11 @@ def shadow_parity_report(
     return {
         "surface": surface,
         "result": "mismatch",
+        "classification": "drift",
+        "blocking": False,
         "summary": "Loom and repo-native surfaces disagree on the normalized result.",
         "missing_inputs": [],
+        "recommended_action": "resolve the parity mismatch or explicitly choose the authoritative surface outside repo interop before enabling blocking consumption.",
         "host_adapters": relevant_host_adapters,
         "repo_native_carriers": relevant_repo_native_carriers,
         "loom_surface": loom_surface,
@@ -6122,6 +6142,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     governance_surface = build_governance_surface(target_root)
     repo_interop = governance_surface.get("repo_interop")
     requested_surfaces = SHADOW_PARITY_SURFACES if args.surface == "all" else (args.surface,)
+    mode = "blocking" if args.blocking else args.mode
     reports = [
         shadow_parity_report(
             repo_interop,
@@ -6131,9 +6152,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         for surface in requested_surfaces
     ]
 
-    result = "pass" if reports and all(report["result"] == "match" for report in reports) else "warn"
+    all_match = bool(reports) and all(report["result"] == "match" for report in reports)
+    blocking_reports = [report for report in reports if report.get("result") != "match"]
+    if mode == "blocking":
+        result = "pass" if all_match else "block"
+        for report in blocking_reports:
+            report["blocking"] = True
+    else:
+        result = "pass" if all_match else "warn"
     if result == "pass":
         summary = "shadow parity matches across all requested surfaces."
+    elif mode == "blocking":
+        summary = "shadow parity blocking mode found mismatch or unreadable surfaces."
     else:
         summaries = {report["result"] for report in reports}
         if "mismatch" in summaries:
@@ -6150,10 +6180,12 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(
         {
             "command": "shadow-parity",
+            "mode": mode,
+            "blocking": mode == "blocking",
             "result": result,
             "summary": summary,
             "missing_inputs": missing_inputs,
-            "fallback_to": None,
+            "fallback_to": "manual-reconciliation" if result == "block" else None,
             "runtime_state": runtime_state,
             "governance_surface": governance_surface,
             "reports": reports,


### PR DESCRIPTION
## Summary

- keep `shadow-parity` validation-only by default
- add explicit `--blocking` / `--mode blocking` consumption mode
- add report-level classification, blocking flag, and recommended action
- document that blocking ownership stays outside `interop.json`
- bump loom-installer to 0.1.13 for the updated runtime payload

## Validation

- `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py shadow-parity --target examples/new-project --surface review` -> `validation-only warn null`
- `python3 tools/loom_flow.py shadow-parity --target examples/new-project --surface review --blocking` -> `blocking block manual-reconciliation`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer run check:docs`
- `npm --prefix packages/loom-installer test`

Fixes #320
