### PR TITLE
feat: 为 GitHub profile GraphQL-only 路径增加预算保护

### DIFF
--- a/docs/evidence/validations/validation-github-profile-graphql-budget-guard.md
+++ b/docs/evidence/validations/validation-github-profile-graphql-budget-guard.md
@@ -1,0 +1,41 @@
+# GitHub Profile GraphQL Budget Guard Validation
+
+本记录归档 `#324` 的验证结果。
+
+## 1. 验证目标
+
+证明 GitHub profile 不再把 GraphQL-only host reads 隐藏成普通读取，也不会把高频 repo / issue / PR 读取退回 `gh repo view`、`gh issue view` 或 `gh pr view`。
+
+## 2. GraphQL-only Boundaries
+
+以下路径仍是 GraphQL-only for now：
+
+- ProjectV2 item / status surface
+- ProjectV2 issue item field lookup
+- native parent / sub-issue tree
+
+这些 payload 必须暴露：
+
+- `graphql_only: true`
+- `budget_scope`
+- `fallback_to`
+- `recommended_action`
+
+## 3. REST Boundary
+
+以下高频读取继续使用 REST helper：
+
+- `GET /repos/{owner}/{repo}`
+- `GET /repos/{owner}/{repo}/branches/{branch}`
+- `GET /repos/{owner}/{repo}/issues/{number}`
+- `GET /repos/{owner}/{repo}/pulls/{number}`
+
+`loom_check` 增加静态回归，禁止在 `skills/shared/scripts` 与 `tools` 的高频实现路径中重新引入：
+
+```bash
+rg "gh repo view|gh issue view|gh pr view" skills/shared/scripts tools
+```
+
+## 4. Boundary
+
+本轮不尝试把 ProjectV2 或 native sub-issues REST 化，也不改变 #323 已冻结的 reconciliation taxonomy。预算 guard 只负责显式暴露 GraphQL-only 范围与失败降级。

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -95,6 +95,7 @@ CORE_DOCS = (
     "docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md",
     "docs/evidence/validations/validation-github-profile-binding-orchestration.md",
     "docs/evidence/validations/validation-github-profile-drift-reconciliation.md",
+    "docs/evidence/validations/validation-github-profile-graphql-budget-guard.md",
     "docs/evidence/validations/validation-loom-core-runtime-parity.md",
     "docs/evidence/validations/validation-shadow-parity-blocking-gate.md",
     "docs/evidence/validations/validation-syvert-strong-governance-parity.md",
@@ -272,6 +273,8 @@ def iter_markdown_files(root: Path) -> list[Path]:
             continue
         relative = path.relative_to(root).as_posix()
         if any(relative == part or relative.startswith(f"{part}/") for part in skipped_parts):
+            continue
+        if any(part.startswith(".payload-build-") for part in path.relative_to(root).parts):
             continue
         if relative.startswith("packages/loom-installer/payload/"):
             continue
@@ -5559,6 +5562,31 @@ def check_generated_artifacts_untracked(root: Path) -> list[Failure]:
     ]
 
 
+def check_github_cli_budget(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    forbidden = tuple(f"gh {kind} view" for kind in ("repo", "issue", "pr"))
+    search_roots = [root / "skills/shared/scripts", root / "tools"]
+    for search_root in search_roots:
+        if not search_root.exists():
+            continue
+        for path in search_root.rglob("*.py"):
+            if path.name == "loom_check.py":
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            for needle in forbidden:
+                if needle in text:
+                    failures.append(
+                        Failure(
+                            "github-api-budget",
+                            f"`{needle}` must not be used in high-frequency implementation path `{path.relative_to(root)}`",
+                        )
+                    )
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -5596,6 +5624,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_repo_interop_contracts(root))
     failures.extend(check_node_installer(root))
     failures.extend(check_generated_artifacts_untracked(root))
+    failures.extend(check_github_cli_budget(root))
     failures.extend(check_markdown_links(root))
     return failures
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -926,6 +926,21 @@ def gh_graphql(root: Path, query: str, variables: dict[str, Any]) -> tuple[dict[
     return data, []
 
 
+def graphql_budget_guard(scope: str, errors: list[str] | None = None) -> dict[str, Any]:
+    return {
+        "graphql_only": True,
+        "budget_scope": scope,
+        "status": "unavailable" if errors else "guarded",
+        "errors": list(errors or []),
+        "fallback_to": "manual-reconciliation" if errors else None,
+        "recommended_action": (
+            "Retry this GraphQL-only host read with explicit operator intent, or continue with REST-backed issue/PR evidence when ProjectV2/native sub-issue data is not required."
+            if errors
+            else "Use this GraphQL-only host read sparingly; high-frequency repo, issue, and PR reads must stay on REST."
+        ),
+    }
+
+
 def git_dirty_entries(root: Path) -> list[dict[str, str]]:
     result = run_git(root, ["status", "--porcelain=v1"])
     if result is None or result.returncode != 0:
@@ -3946,6 +3961,7 @@ query($id: ID!) {
             "id": entry.get("id"),
             "content": {"number": None, "type": "Issue"},
             "status": status_name,
+            "budget_guard": graphql_budget_guard("project_v2_item_field_values"),
         }, []
     return None, []
 
@@ -4022,6 +4038,7 @@ query($owner:String!, $name:String!, $number:Int!) {
     issue = repository.get("issue")
     if not isinstance(issue, dict):
         return None, [f"issue #{issue_number} is missing from GraphQL payload"]
+    issue["budget_guard"] = graphql_budget_guard("native_parent_sub_issue_tree")
     return issue, []
 
 
@@ -4131,6 +4148,7 @@ def reconciliation_audit_payload(
                     "status": "unavailable",
                     "reason": "GraphQL-only parent/sub-issue tree could not be read.",
                     "errors": issue_tree_errors,
+                    "budget_guard": graphql_budget_guard("native_parent_sub_issue_tree", issue_tree_errors),
                 }
             elif issue_tree is not None:
                 issue_payload = {**issue_payload, **issue_tree}
@@ -4261,16 +4279,21 @@ def reconciliation_audit_payload(
                     "status": "unavailable",
                     "reason": "GitHub ProjectV2 CLI owner resolution is unavailable in this environment.",
                     "errors": project_errors,
+                    "budget_guard": graphql_budget_guard("project_v2_status_surface", project_errors),
                 }
             else:
                 missing_inputs.extend(f"project: {message}" for message in project_errors)
         else:
             items = project_context["items"]
             issue_item = find_project_item(items, issue_number, "issue") if issue_number is not None else None
+            issue_item_budget_guard: dict[str, Any] | None = None
             if issue_item is None and issue_id is not None and issue_number is not None:
                 issue_item, issue_item_errors = project_item_for_issue(target_root, issue_id, project_number)
                 if issue_item_errors:
-                    missing_inputs.extend(f"project: {message}" for message in issue_item_errors)
+                    issue_item_budget_guard = graphql_budget_guard(
+                        "project_v2_issue_item_lookup",
+                        issue_item_errors,
+                    )
             pr_item = find_project_item(items, pr_number, "pr") if pr_number is not None else None
             project_payload = {
                 "number": project_number,
@@ -4280,6 +4303,8 @@ def reconciliation_audit_payload(
                 "issue_item": issue_item,
                 "pr_item": pr_item,
             }
+            if issue_item_budget_guard is not None:
+                project_payload["issue_item_budget_guard"] = issue_item_budget_guard
 
             if issue_number is not None:
                 expected_done = issue_payload is not None and (issue_payload.get("state") == "CLOSED" or merged_issue_open)
@@ -4872,16 +4897,21 @@ def closeout_payload(
                     "status": "unavailable",
                     "reason": "GitHub ProjectV2 CLI owner resolution is unavailable in this environment.",
                     "errors": project_errors,
+                    "budget_guard": graphql_budget_guard("project_v2_status_surface", project_errors),
                 }
             else:
                 missing_inputs.extend(f"project: {message}" for message in project_errors)
         else:
             items = project_context["items"]
             issue_item = find_project_item(items, issue_number, "issue") if issue_number is not None else None
+            issue_item_budget_guard: dict[str, Any] | None = None
             if issue_item is None and issue_id is not None and issue_number is not None:
                 issue_item, issue_item_errors = project_item_for_issue(target_root, issue_id, project_number)
                 if issue_item_errors:
-                    missing_inputs.extend(f"project: {message}" for message in issue_item_errors)
+                    issue_item_budget_guard = graphql_budget_guard(
+                        "project_v2_issue_item_lookup",
+                        issue_item_errors,
+                    )
             pr_item = find_project_item(items, pr_number, "pr") if pr_number is not None else None
             if issue_number is not None and issue_item is None:
                 missing_inputs.append("issue is missing from project")
@@ -4893,6 +4923,8 @@ def closeout_payload(
                 "issue_item": issue_item,
                 "pr_item": pr_item,
             }
+            if issue_item_budget_guard is not None:
+                project_payload["issue_item_budget_guard"] = issue_item_budget_guard
             for label, item in (("issue", issue_item), ("pr", pr_item)):
                 if item is None:
                     continue


### PR DESCRIPTION
## Summary
- Closes #324.
- Adds explicit budget guards for GraphQL-only ProjectV2 and native parent/sub-issue reads.
- Keeps high-frequency repo/issue/PR reads on REST and adds a `loom_check` static regression against `gh repo view`, `gh issue view`, and `gh pr view`.
- Excludes installer `.payload-build-*` temporary directories from markdown link scanning.

## Validation
- `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py reconciliation audit --target . --issue 131 --pr 138 --project 5`
- `rg "gh repo view|gh issue view|gh pr view" skills/shared/scripts tools`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`

## Boundary
- Does not REST-ify ProjectV2 or native sub-issues. It only makes those GraphQL-only paths explicit and budget guarded.