### PR TITLE
feat: 产品化治理成熟度升级自动化

### DIFF
--- a/docs/evidence/validations/validation-adoption-maturity-upgrade-automation.md
+++ b/docs/evidence/validations/validation-adoption-maturity-upgrade-automation.md
@@ -1,0 +1,35 @@
+# Adoption Maturity Upgrade Automation Validation
+
+本记录归档 `#326` 的验证结果。
+
+## 1. 验证目标
+
+证明 GitHub governance profile 的 `light -> standard -> strong` 升级路径不再只是文档说明，而是具备 dry-run-first 的可执行升级入口。
+
+## 2. Runtime Entry
+
+```bash
+python3 tools/loom_flow.py governance-profile upgrade \
+  --target <repo> \
+  --to standard \
+  --dry-run
+```
+
+输出固定使用 `schema_version: loom-governance-upgrade/v1`。
+
+## 3. Write Boundary
+
+默认行为是 dry-run，只输出 action plan。
+
+非 dry-run 必须显式使用 `--apply`，并且只允许写 Loom-owned scaffold：
+
+- `.loom/companion/manifest.json`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/companion/AGENTS.md`
+
+遇到 repo-owned 文件或已存在 Loom-owned scaffold 且未显式 `--force` 时必须 `block`。
+
+## 4. Boundary
+
+本轮只产品化升级动作入口与安全写入边界。成熟度强制字段矩阵由 `#327` 冻结；`loom-adopt` / `loom-resume` 消费升级路径由 `#328` 承接。

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -93,6 +93,7 @@ CORE_DOCS = (
     "docs/evidence/extraction-ledger.md",
     "docs/evidence/landing-map.md",
     "docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md",
+    "docs/evidence/validations/validation-adoption-maturity-upgrade-automation.md",
     "docs/evidence/validations/validation-github-profile-binding-orchestration.md",
     "docs/evidence/validations/validation-github-profile-drift-reconciliation.md",
     "docs/evidence/validations/validation-github-profile-graphql-budget-guard.md",
@@ -1329,6 +1330,42 @@ def require_github_binding_payload(
             failures.append(Failure(category, f"{context}.binding findings must fallback to `github-profile-binding`"))
 
 
+def require_governance_upgrade_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "governance-profile":
+        failures.append(Failure(category, f"{context} must report `command: governance-profile`"))
+    if payload.get("operation") != "upgrade":
+        failures.append(Failure(category, f"{context} must report `operation: upgrade`"))
+    if payload.get("schema_version") != "loom-governance-upgrade/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-governance-upgrade/v1`"))
+    if payload.get("result") not in {"pass", "block"}:
+        failures.append(Failure(category, f"{context} result must be pass/block"))
+    if payload.get("target_maturity") not in {"standard", "strong"}:
+        failures.append(Failure(category, f"{context} target_maturity must be standard/strong"))
+    if not isinstance(payload.get("dry_run"), bool):
+        failures.append(Failure(category, f"{context} dry_run must be boolean"))
+    actions = payload.get("actions")
+    if not isinstance(actions, list) or not actions:
+        failures.append(Failure(category, f"{context} must include non-empty actions"))
+        return
+    for action in actions:
+        if not isinstance(action, dict):
+            failures.append(Failure(category, f"{context} actions must be objects"))
+            continue
+        if action.get("owner") not in {"loom-owned", "repo-owned", "profile"}:
+            failures.append(Failure(category, f"{context} action owner must stay within the stable set"))
+        if action.get("status") not in {"planned", "present"}:
+            failures.append(Failure(category, f"{context} action status must be planned/present"))
+
+
 def require_review_record_contract(
     failures: list[Failure],
     *,
@@ -2316,6 +2353,21 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             {"pass", "block"},
         ),
         (
+            "governance-profile-upgrade",
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "governance-profile",
+                "upgrade",
+                "--target",
+                "examples/new-project",
+                "--to",
+                "standard",
+                "--dry-run",
+            ],
+            {"pass"},
+        ),
+        (
             "governance-profile-binding",
             ["python3", "tools/loom_flow.py", "governance-profile", "binding", "--target", "."],
             {"block"},
@@ -2572,6 +2624,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures,
                 category="daily-execution-cli",
                 context="`governance-profile binding`",
+                payload=payload,
+            )
+        if label == "governance-profile-upgrade":
+            require_governance_upgrade_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`governance-profile upgrade`",
                 payload=payload,
             )
         if label == "flow-pre-review":

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -312,8 +312,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "governance-profile",
         help="Read Loom governance maturity and upgrade requirements",
     )
-    governance_profile.add_argument("operation", choices=("status", "upgrade-plan", "binding"))
+    governance_profile.add_argument("operation", choices=("status", "upgrade-plan", "upgrade", "binding"))
     governance_profile.add_argument("--target", required=True, help="Target repository root")
+    governance_profile.add_argument("--to", choices=("standard", "strong"), help="Target maturity for governance-profile upgrade")
+    governance_profile.add_argument("--dry-run", action="store_true", default=True, help="Preview upgrade actions without writing files; this is the default")
+    governance_profile.add_argument("--apply", dest="dry_run", action="store_false", help="Apply Loom-owned scaffold writes")
+    governance_profile.add_argument("--force", action="store_true", help="Allow replacement of existing Loom-owned scaffold files during upgrade apply")
     governance_profile.add_argument("--owner", help="GitHub owner; auto-detected from origin when omitted")
     governance_profile.add_argument("--repo", dest="repo_name", help="GitHub repository name; auto-detected from origin when omitted")
     governance_profile.add_argument("--phase", type=int, help="GitHub Phase issue number")
@@ -322,7 +326,6 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--pr", type=int, help="GitHub implementation PR number")
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
-    governance_profile.add_argument("--dry-run", action="store_true", help="Preview binding sync actions without changing GitHub state")
 
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
@@ -3573,6 +3576,141 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
     }
 
 
+UPGRADE_SCAFFOLD: dict[str, dict[str, str]] = {
+    ".loom/companion/manifest.json": json.dumps(
+        {
+            "schema_version": "loom-repo-companion-manifest/v1",
+            "companion_entry": ".loom/companion/AGENTS.md",
+            "repo_interface": ".loom/companion/repo-interface.json",
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n",
+    ".loom/companion/repo-interface.json": json.dumps(
+        {
+            "schema_version": "loom-repo-interface/v2",
+            "companion_entry": ".loom/companion/AGENTS.md",
+            "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+            "specialized_gates": [],
+            "metadata_contract": {"fields": []},
+            "context_schema": {"fields": []},
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n",
+    ".loom/companion/interop.json": json.dumps(
+        {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {},
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n",
+    ".loom/companion/AGENTS.md": "# Loom Repo Companion\n\n本文件承接 repo-local governance residue；Loom core 与 GitHub profile 规则仍以上游合同为准。\n",
+}
+
+
+def governance_upgrade_actions(target_root: Path, target_level: str, maturity: dict[str, Any]) -> list[dict[str, Any]]:
+    missing_by_level = maturity.get("missing_by_level")
+    missing = missing_by_level.get(target_level, []) if isinstance(missing_by_level, dict) else []
+    actions: list[dict[str, Any]] = []
+    for relative, content in UPGRADE_SCAFFOLD.items():
+        path = target_root / relative
+        owner = "loom-owned" if relative.startswith(".loom/") else "repo-owned"
+        actions.append(
+            {
+                "action": "write_scaffold" if not path.exists() else "keep_existing",
+                "path": relative,
+                "owner": owner,
+                "status": "present" if path.exists() else "planned",
+                "reason": "required by governance profile upgrade path",
+                "bytes": len(content.encode("utf-8")),
+            }
+        )
+    for item in missing if isinstance(missing, list) else []:
+        actions.append(
+            {
+                "action": "satisfy_missing_input",
+                "id": item,
+                "owner": "loom-owned" if str(item) in {"repo_interface", "repo_interop"} else "profile",
+                "status": "planned",
+                "reason": f"`{target_level}` maturity currently reports this missing input.",
+            }
+        )
+    return actions
+
+
+def governance_profile_upgrade_payload(
+    *,
+    target_root: Path,
+    target_level: str | None,
+    dry_run: bool,
+    force: bool,
+) -> dict[str, Any]:
+    if target_level is None:
+        return {
+            "command": "governance-profile",
+            "operation": "upgrade",
+            "result": "block",
+            "summary": "governance profile upgrade requires `--to standard` or `--to strong`.",
+            "missing_inputs": ["to"],
+            "fallback_to": "adoption",
+        }
+    base = governance_profile_payload(target_root, "upgrade-plan")
+    maturity = base.get("maturity") if isinstance(base.get("maturity"), dict) else {}
+    actions = governance_upgrade_actions(target_root, target_level, maturity if isinstance(maturity, dict) else {})
+    blockers: list[str] = []
+    written_files: list[str] = []
+    if not dry_run:
+        for action in actions:
+            if action.get("action") != "write_scaffold":
+                continue
+            relative = action.get("path")
+            if not isinstance(relative, str):
+                continue
+            if action.get("owner") != "loom-owned":
+                blockers.append(f"{relative} is repo-owned")
+                continue
+            path = target_root / relative
+            if path.exists() and not force:
+                blockers.append(f"{relative} already exists; use --force to replace Loom-owned scaffold")
+                continue
+            content = UPGRADE_SCAFFOLD.get(relative)
+            if content is None:
+                blockers.append(f"{relative} has no scaffold content")
+                continue
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+            written_files.append(relative)
+    result = "block" if blockers else "pass"
+    return {
+        "command": "governance-profile",
+        "operation": "upgrade",
+        "schema_version": "loom-governance-upgrade/v1",
+        "result": result,
+        "summary": (
+            f"governance profile upgrade toward `{target_level}` produced a dry-run action plan."
+            if dry_run and result == "pass"
+            else f"governance profile upgrade toward `{target_level}` applied Loom-owned scaffold writes."
+            if result == "pass"
+            else f"governance profile upgrade toward `{target_level}` is blocked by unsafe writes."
+        ),
+        "missing_inputs": blockers,
+        "fallback_to": None if result == "pass" else "adoption",
+        "target_maturity": target_level,
+        "dry_run": dry_run,
+        "force": force,
+        "actions": actions,
+        "written_files": written_files,
+        "maturity": maturity,
+    }
+
+
 def issue_binding_entry(role: str, number: int | None, payload: dict[str, Any] | None, errors: list[str]) -> dict[str, Any]:
     status = "present" if payload is not None else "missing"
     if errors:
@@ -3800,6 +3938,15 @@ def github_binding_payload(
 
 def handle_governance_profile(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
+    if args.operation == "upgrade":
+        return emit(
+            governance_profile_upgrade_payload(
+                target_root=target_root,
+                target_level=args.to,
+                dry_run=args.dry_run,
+                force=args.force,
+            )
+        )
     if args.operation == "binding":
         return emit(
             github_binding_payload(


### PR DESCRIPTION
## Summary
- Closes #326.
- Adds `governance-profile upgrade --to standard|strong` with dry-run-first upgrade plans.
- Defines safe apply boundaries for Loom-owned scaffold writes.

## Validation
- `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py governance-profile upgrade --target examples/new-project --to standard --dry-run`
- `python3 tools/loom_flow.py governance-profile upgrade-plan --target examples/new-project`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`

## Boundary
- Required maturity field matrix remains in #327.
- `loom-adopt` / `loom-resume` consumption remains in #328.