### PR TITLE
feat: 定义强治理成熟度字段矩阵

### DIFF
--- a/docs/evidence/validations/validation-adoption-maturity-required-fields.md
+++ b/docs/evidence/validations/validation-adoption-maturity-required-fields.md
@@ -1,0 +1,39 @@
+# Adoption Maturity Required Fields Validation
+
+本记录归档 `#327` 的验证结果。
+
+## 1. 验证目标
+
+证明 light / standard / strong 成熟度不再只是一组隐含 requires，而是具备机器可读的强治理补装矩阵。
+
+## 2. Runtime Contract
+
+`governance_control_plane.maturity` 固定包含：
+
+- `required_fields`
+- `missing_by_level`
+- `missing_details_by_level`
+
+每个 required field 至少声明：
+
+- `id`
+- `layer`
+- `required`
+- `defaulting`
+- `recommended_action`
+
+`layer` 只允许：
+
+- `core`
+- `github-profile`
+- `repo-owned-residue`
+
+## 3. Consumer Contract
+
+`governance-profile upgrade-plan` 必须继续输出稳定 `missing_inputs`，并新增 `missing_details` 与 `recommended_action`。
+
+`governance-profile upgrade --to <level> --dry-run` 的 `satisfy_missing_input` actions 必须携带 `layer` 与 `recommended_action`，让后续 `loom-adopt` / `loom-resume` 可以直接消费。
+
+## 4. Boundary
+
+本轮只冻结矩阵和 runtime 校验，不改变 `loom-adopt` / `loom-resume` 的展示行为；该消费路径由 `#328` 承接。

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -574,6 +574,112 @@
             "summary": "Host-backed binding, reconciliation, controlled merge, and closeout gates are available."
           }
         },
+        "required_fields": {
+          "light": [
+            {
+              "id": "work_item",
+              "layer": "core",
+              "required": true,
+              "defaulting": "generated",
+              "recommended_action": "run loom-init or restore the Work Item carrier"
+            },
+            {
+              "id": "recovery",
+              "layer": "core",
+              "required": true,
+              "defaulting": "generated",
+              "recommended_action": "restore the recovery carrier"
+            },
+            {
+              "id": "status_surface",
+              "layer": "core",
+              "required": true,
+              "defaulting": "generated",
+              "recommended_action": "restore the status surface carrier"
+            },
+            {
+              "id": "review",
+              "layer": "core",
+              "required": true,
+              "defaulting": "generated",
+              "recommended_action": "restore the review carrier"
+            }
+          ],
+          "standard": [
+            {
+              "id": "fr_work_item_layer",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "profile",
+              "recommended_action": "declare the FR -> Work Item split through the GitHub profile upgrade path"
+            },
+            {
+              "id": "spec_path",
+              "layer": "core",
+              "required": true,
+              "defaulting": "generated",
+              "recommended_action": "install formal spec scaffold"
+            },
+            {
+              "id": "plan_path",
+              "layer": "core",
+              "required": true,
+              "defaulting": "generated",
+              "recommended_action": "install execution plan scaffold"
+            },
+            {
+              "id": "spec_gate",
+              "layer": "core",
+              "required": true,
+              "defaulting": "generated",
+              "recommended_action": "record or restore the spec review gate"
+            },
+            {
+              "id": "status_control_plane",
+              "layer": "core",
+              "required": true,
+              "defaulting": "builtin",
+              "recommended_action": "run loom_status or loom_check to rebuild the status control plane"
+            },
+            {
+              "id": "basic_host_binding",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "profile",
+              "recommended_action": "run governance-profile binding and repair missing host bindings"
+            },
+            {
+              "id": "closeout_reconciliation_read",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "profile",
+              "recommended_action": "install repo interop so closeout can consume reconciliation"
+            }
+          ],
+          "strong": [
+            {
+              "id": "repo_interface",
+              "layer": "repo-owned-residue",
+              "required": true,
+              "defaulting": "scaffold",
+              "recommended_action": "install or repair the repo companion interface"
+            },
+            {
+              "id": "repo_interop",
+              "layer": "repo-owned-residue",
+              "required": true,
+              "defaulting": "scaffold",
+              "recommended_action": "install or repair the repo interop contract"
+            },
+            {
+              "id": "github_controlled_merge",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "host",
+              "recommended_action": "enable controlled merge binding and required host gates"
+            }
+          ]
+        },
         "missing_by_level": {
           "light": [],
           "standard": [
@@ -585,6 +691,48 @@
             "repo_interface",
             "repo_interop",
             "github_controlled_merge"
+          ]
+        },
+        "missing_details_by_level": {
+          "light": [],
+          "standard": [
+            {
+              "id": "fr_work_item_layer",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "profile",
+              "recommended_action": "declare the FR -> Work Item split through the GitHub profile upgrade path"
+            },
+            {
+              "id": "closeout_reconciliation_read",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "profile",
+              "recommended_action": "install repo interop so closeout can consume reconciliation"
+            }
+          ],
+          "strong": [
+            {
+              "id": "repo_interface",
+              "layer": "repo-owned-residue",
+              "required": true,
+              "defaulting": "scaffold",
+              "recommended_action": "install or repair the repo companion interface"
+            },
+            {
+              "id": "repo_interop",
+              "layer": "repo-owned-residue",
+              "required": true,
+              "defaulting": "scaffold",
+              "recommended_action": "install or repair the repo interop contract"
+            },
+            {
+              "id": "github_controlled_merge",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "host",
+              "recommended_action": "enable controlled merge binding and required host gates"
+            }
           ]
         }
       }

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -146,6 +146,112 @@ MATURITY_LEVELS = {
         "summary": "Host-backed binding, reconciliation, controlled merge, and closeout gates are available.",
     },
 }
+MATURITY_REQUIRED_FIELDS = {
+    "light": [
+        {
+            "id": "work_item",
+            "layer": "core",
+            "required": True,
+            "defaulting": "generated",
+            "recommended_action": "run loom-init or restore the Work Item carrier",
+        },
+        {
+            "id": "recovery",
+            "layer": "core",
+            "required": True,
+            "defaulting": "generated",
+            "recommended_action": "restore the recovery carrier",
+        },
+        {
+            "id": "status_surface",
+            "layer": "core",
+            "required": True,
+            "defaulting": "generated",
+            "recommended_action": "restore the status surface carrier",
+        },
+        {
+            "id": "review",
+            "layer": "core",
+            "required": True,
+            "defaulting": "generated",
+            "recommended_action": "restore the review carrier",
+        },
+    ],
+    "standard": [
+        {
+            "id": "fr_work_item_layer",
+            "layer": "github-profile",
+            "required": True,
+            "defaulting": "profile",
+            "recommended_action": "declare the FR -> Work Item split through the GitHub profile upgrade path",
+        },
+        {
+            "id": "spec_path",
+            "layer": "core",
+            "required": True,
+            "defaulting": "generated",
+            "recommended_action": "install formal spec scaffold",
+        },
+        {
+            "id": "plan_path",
+            "layer": "core",
+            "required": True,
+            "defaulting": "generated",
+            "recommended_action": "install execution plan scaffold",
+        },
+        {
+            "id": "spec_gate",
+            "layer": "core",
+            "required": True,
+            "defaulting": "generated",
+            "recommended_action": "record or restore the spec review gate",
+        },
+        {
+            "id": "status_control_plane",
+            "layer": "core",
+            "required": True,
+            "defaulting": "builtin",
+            "recommended_action": "run loom_status or loom_check to rebuild the status control plane",
+        },
+        {
+            "id": "basic_host_binding",
+            "layer": "github-profile",
+            "required": True,
+            "defaulting": "profile",
+            "recommended_action": "run governance-profile binding and repair missing host bindings",
+        },
+        {
+            "id": "closeout_reconciliation_read",
+            "layer": "github-profile",
+            "required": True,
+            "defaulting": "profile",
+            "recommended_action": "install repo interop so closeout can consume reconciliation",
+        },
+    ],
+    "strong": [
+        {
+            "id": "repo_interface",
+            "layer": "repo-owned-residue",
+            "required": True,
+            "defaulting": "scaffold",
+            "recommended_action": "install or repair the repo companion interface",
+        },
+        {
+            "id": "repo_interop",
+            "layer": "repo-owned-residue",
+            "required": True,
+            "defaulting": "scaffold",
+            "recommended_action": "install or repair the repo interop contract",
+        },
+        {
+            "id": "github_controlled_merge",
+            "layer": "github-profile",
+            "required": True,
+            "defaulting": "host",
+            "recommended_action": "enable controlled merge binding and required host gates",
+        },
+    ],
+}
 
 
 def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -1033,9 +1139,16 @@ def maturity_status(
     }
     achieved: list[str] = []
     missing_by_level: dict[str, list[str]] = {}
+    missing_details_by_level: dict[str, list[dict[str, Any]]] = {}
     for level in ("light", "standard", "strong"):
         missing = [field for field in MATURITY_LEVELS[level]["requires"] if not facts.get(field)]
         missing_by_level[level] = missing
+        field_rows = MATURITY_REQUIRED_FIELDS.get(level, [])
+        missing_details_by_level[level] = [
+            row
+            for row in field_rows
+            if row["id"] in missing
+        ]
         if not missing:
             achieved.append(level)
             facts[level] = True
@@ -1051,7 +1164,9 @@ def maturity_status(
         "achieved": achieved,
         "next": next_level,
         "levels": MATURITY_LEVELS,
+        "required_fields": MATURITY_REQUIRED_FIELDS,
         "missing_by_level": missing_by_level,
+        "missing_details_by_level": missing_details_by_level,
     }
 
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -94,6 +94,7 @@ CORE_DOCS = (
     "docs/evidence/landing-map.md",
     "docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md",
     "docs/evidence/validations/validation-adoption-maturity-upgrade-automation.md",
+    "docs/evidence/validations/validation-adoption-maturity-required-fields.md",
     "docs/evidence/validations/validation-github-profile-binding-orchestration.md",
     "docs/evidence/validations/validation-github-profile-drift-reconciliation.md",
     "docs/evidence/validations/validation-github-profile-graphql-budget-guard.md",
@@ -832,6 +833,25 @@ def require_governance_control_plane(
         strong_requires = levels.get("strong", {}).get("requires") if isinstance(levels, dict) and isinstance(levels.get("strong"), dict) else None
         if not isinstance(strong_requires, list) or "github_controlled_merge" not in strong_requires:
             failures.append(Failure(category, f"{context}.maturity strong level must require GitHub controlled merge"))
+        required_fields = maturity.get("required_fields")
+        if not isinstance(required_fields, dict) or set(required_fields) != {"light", "standard", "strong"}:
+            failures.append(Failure(category, f"{context}.maturity required_fields must define light, standard, and strong"))
+        else:
+            for level, rows in required_fields.items():
+                if not isinstance(rows, list) or not rows:
+                    failures.append(Failure(category, f"{context}.maturity required_fields.{level} must be a non-empty list"))
+                    continue
+                for row in rows:
+                    if not isinstance(row, dict):
+                        failures.append(Failure(category, f"{context}.maturity required_fields.{level} entries must be objects"))
+                        continue
+                    if row.get("layer") not in {"core", "github-profile", "repo-owned-residue"}:
+                        failures.append(Failure(category, f"{context}.maturity required_fields.{level} layer must be stable"))
+                    if not isinstance(row.get("recommended_action"), str) or not row.get("recommended_action"):
+                        failures.append(Failure(category, f"{context}.maturity required_fields.{level} entries must include recommended_action"))
+        missing_details = maturity.get("missing_details_by_level")
+        if not isinstance(missing_details, dict) or set(missing_details) != {"light", "standard", "strong"}:
+            failures.append(Failure(category, f"{context}.maturity missing_details_by_level must define light, standard, and strong"))
 
 
 def require_locator_entry(
@@ -1364,6 +1384,8 @@ def require_governance_upgrade_payload(
             failures.append(Failure(category, f"{context} action owner must stay within the stable set"))
         if action.get("status") not in {"planned", "present"}:
             failures.append(Failure(category, f"{context} action status must be planned/present"))
+        if action.get("action") == "satisfy_missing_input" and not isinstance(action.get("recommended_action"), str):
+            failures.append(Failure(category, f"{context} missing-input actions must include recommended_action"))
 
 
 def require_review_record_contract(

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -3553,11 +3553,17 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
     current = maturity.get("current")
     next_level = maturity.get("next")
     missing_by_level = maturity.get("missing_by_level")
+    missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs: list[Any] = []
+    missing_details: list[Any] = []
     if operation == "upgrade-plan" and isinstance(next_level, str) and isinstance(missing_by_level, dict):
         raw_missing = missing_by_level.get(next_level, [])
         if isinstance(raw_missing, list):
             missing_inputs = raw_missing
+        if isinstance(missing_details_by_level, dict):
+            raw_details = missing_details_by_level.get(next_level, [])
+            if isinstance(raw_details, list):
+                missing_details = raw_details
     result = "pass" if not missing_inputs else "block"
     summary = (
         f"governance profile is already at `{current}` maturity."
@@ -3570,6 +3576,8 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
         "result": result,
         "summary": summary,
         "missing_inputs": missing_inputs,
+        "missing_details": missing_details,
+        "recommended_action": "run governance-profile upgrade --dry-run" if result == "block" else None,
         "fallback_to": None if result == "pass" else "adoption",
         "maturity": maturity,
         "governance_control_plane": control_plane,
@@ -3617,7 +3625,9 @@ UPGRADE_SCAFFOLD: dict[str, dict[str, str]] = {
 
 def governance_upgrade_actions(target_root: Path, target_level: str, maturity: dict[str, Any]) -> list[dict[str, Any]]:
     missing_by_level = maturity.get("missing_by_level")
+    missing_details_by_level = maturity.get("missing_details_by_level")
     missing = missing_by_level.get(target_level, []) if isinstance(missing_by_level, dict) else []
+    missing_details = missing_details_by_level.get(target_level, []) if isinstance(missing_details_by_level, dict) else []
     actions: list[dict[str, Any]] = []
     for relative, content in UPGRADE_SCAFFOLD.items():
         path = target_root / relative
@@ -3633,12 +3643,19 @@ def governance_upgrade_actions(target_root: Path, target_level: str, maturity: d
             }
         )
     for item in missing if isinstance(missing, list) else []:
+        detail = next((row for row in missing_details if isinstance(row, dict) and row.get("id") == item), {})
         actions.append(
             {
                 "action": "satisfy_missing_input",
                 "id": item,
-                "owner": "loom-owned" if str(item) in {"repo_interface", "repo_interop"} else "profile",
+                "owner": (
+                    "loom-owned"
+                    if str(item) in {"repo_interface", "repo_interop"}
+                    else "profile"
+                ),
                 "status": "planned",
+                "layer": detail.get("layer"),
+                "recommended_action": detail.get("recommended_action"),
                 "reason": f"`{target_level}` maturity currently reports this missing input.",
             }
         )


### PR DESCRIPTION
## Summary
- Closes #327.
- Adds machine-readable light / standard / strong required fields to governance maturity.
- Exposes missing details with layer ownership and recommended actions.
- Updates upgrade-plan and upgrade dry-run outputs so later skills can consume the matrix.

## Validation
- `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py governance-profile upgrade-plan --target examples/new-project`
- `python3 tools/loom_flow.py governance-profile upgrade --target examples/new-project --to standard --dry-run`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`

## Boundary
- `loom-adopt` / `loom-resume` display and consumption remain in #328.