### PR TITLE
feat: 让 adopt 和 resume 消费成熟度升级路径

### DIFF
--- a/docs/evidence/validations/validation-skills-consume-maturity-upgrade-path.md
+++ b/docs/evidence/validations/validation-skills-consume-maturity-upgrade-path.md
@@ -1,0 +1,38 @@
+# Skills Consume Maturity Upgrade Path Validation
+
+本记录归档 `#328` 的验证结果。
+
+## 1. 验证目标
+
+证明 `loom-adopt` / `loom-resume` 不再只依赖文字说明，而是能消费 governance maturity upgrade path。
+
+## 2. Runtime Surfaces
+
+`loom-init` bootstrap / adopt 输出新增：
+
+- `maturity_upgrade_path.current`
+- `maturity_upgrade_path.next`
+- `maturity_upgrade_path.missing_inputs`
+- `maturity_upgrade_path.missing_details`
+- `maturity_upgrade_path.upgrade_entry`
+- `maturity_upgrade_path.validation_entries`
+
+`loom-resume` 的底层入口：
+
+```bash
+python3 tools/loom_flow.py flow resume --target <repo> --item <item>
+```
+
+也输出同一 `maturity_upgrade_path`，并把下一档缺口并入 resume 的 `missing_inputs`。
+
+## 3. Consumption Contract
+
+`maturity_upgrade_path` 不只是文本建议。它必须链接到具体 gate / validation entry：
+
+- `governance-profile status`
+- `governance-profile upgrade-plan`
+- `governance-profile upgrade --dry-run`
+
+## 4. Boundary
+
+本轮不自动应用升级；真实写入仍由 `governance-profile upgrade --apply` 的 Loom-owned scaffold 边界控制。

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -739,5 +739,36 @@
     },
     "summary": "repository is treated as new; Loom can plan the first governance carriers and bootstrap entrypoints without adding a second truth source.",
     "missing_inputs": []
+  },
+  "maturity_upgrade_path": {
+    "result": "block",
+    "current": "light",
+    "next": "standard",
+    "missing_inputs": [
+      "fr_work_item_layer",
+      "closeout_reconciliation_read"
+    ],
+    "missing_details": [
+      {
+        "id": "fr_work_item_layer",
+        "layer": "github-profile",
+        "required": true,
+        "defaulting": "profile",
+        "recommended_action": "declare the FR -> Work Item split through the GitHub profile upgrade path"
+      },
+      {
+        "id": "closeout_reconciliation_read",
+        "layer": "github-profile",
+        "required": true,
+        "defaulting": "profile",
+        "recommended_action": "install repo interop so closeout can consume reconciliation"
+      }
+    ],
+    "fallback_to": "adoption",
+    "upgrade_entry": "python3 .loom/bin/loom_flow.py governance-profile upgrade --target . --to standard --dry-run",
+    "validation_entries": [
+      "python3 .loom/bin/loom_flow.py governance-profile status --target .",
+      "python3 .loom/bin/loom_flow.py governance-profile upgrade-plan --target ."
+    ]
   }
 }

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -95,6 +95,7 @@ CORE_DOCS = (
     "docs/evidence/validations/validation-closeout-reconciliation-blocking-gate.md",
     "docs/evidence/validations/validation-adoption-maturity-upgrade-automation.md",
     "docs/evidence/validations/validation-adoption-maturity-required-fields.md",
+    "docs/evidence/validations/validation-skills-consume-maturity-upgrade-path.md",
     "docs/evidence/validations/validation-github-profile-binding-orchestration.md",
     "docs/evidence/validations/validation-github-profile-drift-reconciliation.md",
     "docs/evidence/validations/validation-github-profile-graphql-budget-guard.md",
@@ -1386,6 +1387,35 @@ def require_governance_upgrade_payload(
             failures.append(Failure(category, f"{context} action status must be planned/present"))
         if action.get("action") == "satisfy_missing_input" and not isinstance(action.get("recommended_action"), str):
             failures.append(Failure(category, f"{context} missing-input actions must include recommended_action"))
+
+
+def require_maturity_upgrade_path(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include maturity_upgrade_path"))
+        return
+    if payload.get("result") not in {"pass", "block"}:
+        failures.append(Failure(category, f"{context} result must be pass/block"))
+    if payload.get("current") not in {"unadopted", "light", "standard", "strong", "unknown"}:
+        failures.append(Failure(category, f"{context} current maturity must stay within the stable set"))
+    if payload.get("next") not in {None, "light", "standard", "strong"}:
+        failures.append(Failure(category, f"{context} next maturity must stay within the stable set"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+    if not isinstance(payload.get("missing_details"), list):
+        failures.append(Failure(category, f"{context} missing_details must be a list"))
+    if payload.get("fallback_to") not in {None, "adoption", "admission"}:
+        failures.append(Failure(category, f"{context} fallback_to must be stable"))
+    if payload.get("next") is not None and not isinstance(payload.get("upgrade_entry"), str):
+        failures.append(Failure(category, f"{context} upgrade_entry must be present when next maturity exists"))
+    validation_entries = payload.get("validation_entries")
+    if not isinstance(validation_entries, list) or not validation_entries:
+        failures.append(Failure(category, f"{context} validation_entries must be non-empty"))
 
 
 def require_review_record_contract(
@@ -2733,6 +2763,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 category="daily-execution-cli",
                 context="`flow resume`",
                 payload=payload,
+            )
+            require_maturity_upgrade_path(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload.get("maturity_upgrade_path"),
             )
             steps = payload.get("steps")
             if not isinstance(steps, list):

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -3728,6 +3728,50 @@ def governance_profile_upgrade_payload(
     }
 
 
+def maturity_upgrade_path(governance_surface: dict[str, Any], target_root: Path) -> dict[str, Any]:
+    control_plane = governance_surface.get("governance_control_plane")
+    maturity = control_plane.get("maturity") if isinstance(control_plane, dict) else None
+    if not isinstance(maturity, dict):
+        return {
+            "result": "block",
+            "current": "unknown",
+            "next": None,
+            "missing_inputs": ["governance_control_plane.maturity"],
+            "missing_details": [],
+            "fallback_to": "admission",
+            "upgrade_entry": None,
+            "validation_entries": [],
+        }
+    current = maturity.get("current")
+    next_level = maturity.get("next")
+    missing_by_level = maturity.get("missing_by_level")
+    missing_details_by_level = maturity.get("missing_details_by_level")
+    missing_inputs = []
+    missing_details = []
+    if isinstance(next_level, str):
+        if isinstance(missing_by_level, dict) and isinstance(missing_by_level.get(next_level), list):
+            missing_inputs = list(missing_by_level[next_level])
+        if isinstance(missing_details_by_level, dict) and isinstance(missing_details_by_level.get(next_level), list):
+            missing_details = list(missing_details_by_level[next_level])
+    return {
+        "result": "pass" if next_level is None else "block",
+        "current": current,
+        "next": next_level,
+        "missing_inputs": missing_inputs,
+        "missing_details": missing_details,
+        "fallback_to": None if next_level is None else "adoption",
+        "upgrade_entry": (
+            f"python3 tools/loom_flow.py governance-profile upgrade --target {target_root} --to {next_level} --dry-run"
+            if isinstance(next_level, str)
+            else None
+        ),
+        "validation_entries": [
+            f"python3 tools/loom_flow.py governance-profile status --target {target_root}",
+            f"python3 tools/loom_flow.py governance-profile upgrade-plan --target {target_root}",
+        ],
+    }
+
+
 def issue_binding_entry(role: str, number: int | None, payload: dict[str, Any] | None, errors: list[str]) -> dict[str, Any]:
     status = "present" if payload is not None else "missing"
     if errors:
@@ -6349,6 +6393,7 @@ def handle_flow(args: argparse.Namespace) -> int:
 
     review_payload: dict[str, Any] | None = None
     governance_surface = build_governance_surface(target_root)
+    upgrade_path = maturity_upgrade_path(governance_surface, target_root)
     repo_interface = governance_surface.get("repo_interface")
     repo_specific_requirements: dict[str, Any] | None = None
 
@@ -6540,6 +6585,9 @@ def handle_flow(args: argparse.Namespace) -> int:
         for message in governance_surface.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+        for message in upgrade_path.get("missing_inputs", []):
+            if message not in missing_inputs:
+                missing_inputs.append(message)
 
     return emit(
         {
@@ -6558,6 +6606,7 @@ def handle_flow(args: argparse.Namespace) -> int:
             "steps": steps,
             "runtime_state": runtime_state,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
+            **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **(
                 {
                     "workspace": {

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -970,6 +970,11 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
         ),
     }[scenario]
 
+    governance_surface = build_governance_surface(
+        target_root,
+        bootstrap_mode=True,
+        scenario_override=scenario,
+    )
     result = {
         "schema_version": "loom-init-output/v1",
         "generator": {
@@ -1059,13 +1064,53 @@ def build_result(target_root: Path, scenario: str, intake: dict[str, object], in
             ),
         },
         "runtime_state": runtime_state_payload(target_root),
-        "governance_surface": build_governance_surface(
-            target_root,
-            bootstrap_mode=True,
-            scenario_override=scenario,
-        ),
+        "governance_surface": governance_surface,
+        "maturity_upgrade_path": init_maturity_upgrade_path(governance_surface),
     }
     return result
+
+
+def init_maturity_upgrade_path(governance_surface: dict[str, object]) -> dict[str, object]:
+    control_plane = governance_surface.get("governance_control_plane")
+    maturity = control_plane.get("maturity") if isinstance(control_plane, dict) else None
+    if not isinstance(maturity, dict):
+        return {
+            "result": "block",
+            "current": "unknown",
+            "next": None,
+            "missing_inputs": ["governance_control_plane.maturity"],
+            "missing_details": [],
+            "fallback_to": "admission",
+            "upgrade_entry": None,
+            "validation_entries": [],
+        }
+    next_level = maturity.get("next")
+    missing_by_level = maturity.get("missing_by_level")
+    missing_details_by_level = maturity.get("missing_details_by_level")
+    missing_inputs: list[object] = []
+    missing_details: list[object] = []
+    if isinstance(next_level, str):
+        if isinstance(missing_by_level, dict) and isinstance(missing_by_level.get(next_level), list):
+            missing_inputs = list(missing_by_level[next_level])
+        if isinstance(missing_details_by_level, dict) and isinstance(missing_details_by_level.get(next_level), list):
+            missing_details = list(missing_details_by_level[next_level])
+    return {
+        "result": "pass" if next_level is None else "block",
+        "current": maturity.get("current"),
+        "next": next_level,
+        "missing_inputs": missing_inputs,
+        "missing_details": missing_details,
+        "fallback_to": None if next_level is None else "adoption",
+        "upgrade_entry": (
+            f"python3 .loom/bin/loom_flow.py governance-profile upgrade --target . --to {next_level} --dry-run"
+            if isinstance(next_level, str)
+            else None
+        ),
+        "validation_entries": [
+            "python3 .loom/bin/loom_flow.py governance-profile status --target .",
+            "python3 .loom/bin/loom_flow.py governance-profile upgrade-plan --target .",
+        ],
+    }
 
 
 def render_loom_readme(result: dict[str, object]) -> str:
@@ -1481,6 +1526,7 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
             "initial_artifacts",
             "initial_work_items",
             "runtime_state",
+            "maturity_upgrade_path",
             "validation_and_closing",
         ):
             if key not in result:


### PR DESCRIPTION
## Summary
- Closes #328.
- Adds `maturity_upgrade_path` to loom-init/adopt bootstrap output and flow resume output.
- Links upgrade advice to concrete `governance-profile status`, `governance-profile upgrade-plan`, and `governance-profile upgrade --dry-run` validation entries.
- Updates the example bootstrap payload and installer package version to 0.1.19.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py flow resume --target examples/new-project --item INIT-0001`
- `python3 tools/loom_init.py bootstrap --target /tmp/loom-adopt-smoke --write --force --verify`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`

## Boundary
- Does not auto-apply upgrades; write actions still go through `governance-profile upgrade --apply` and the Loom-owned scaffold boundary.