### PR TITLE
feat: 防止 bootstrapped runtime 被环境变量误判

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -430,7 +430,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "main",
+            "locator": "issue-349-runtime-env-poisoning",
             "authority": "git"
           },
           "worktree": {

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3675,14 +3675,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             root,
             ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
             cwd=bootstrap_target,
+            env={"LOOM_SOURCE_REPO_ROOT": "/tmp/not-loom"},
         )
         if error:
-            failures.append(Failure("daily-execution-cli", f"`bootstrapped loom-init runtime-state` failed: {error}"))
+            failures.append(Failure("daily-execution-cli", f"`bootstrapped loom-init runtime-state with unrelated source env` failed: {error}"))
         else:
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
-                context="`bootstrapped loom-init runtime-state`",
+                context="`bootstrapped loom-init runtime-state with unrelated source env`",
                 payload=payload.get("runtime_state"),
                 expected_scene="installed-runtime",
                 expected_carrier="bootstrapped-target-runtime",

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -1745,12 +1746,16 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
             )
 
         for label, command, allowed in commands:
+            command_env = os.environ.copy()
+            for key in ("LOOM_SOURCE_REPO_ROOT", "LOOM_INSTALLED_SKILLS_ROOT", "LOOM_RUNTIME_SCENE"):
+                command_env.pop(key, None)
             result = subprocess.run(
                 command,
                 cwd=target_root,
                 check=False,
                 capture_output=True,
                 text=True,
+                env=command_env,
             )
             output = result.stdout.strip()
             if not output:

--- a/skills/shared/scripts/runtime_state.py
+++ b/skills/shared/scripts/runtime_state.py
@@ -76,10 +76,10 @@ def _check(status: str, summary: str, *, evidence: object | None = None) -> dict
 
 
 def detect_carrier(caller_file: str) -> str | None:
-    if source_repo_root() is not None:
-        return "repo-local-wrapper"
     if bootstrap_runtime_root(caller_file) is not None:
         return "bootstrapped-target-runtime"
+    if source_repo_root() is not None:
+        return "repo-local-wrapper"
     if installed_skills_root(caller_file) is not None:
         return "installed-skills-root"
     return None


### PR DESCRIPTION
## Summary
- Fix bootstrapped `.loom/bin` runtime detection so it wins over unrelated `LOOM_SOURCE_REPO_ROOT`.
- Clear Loom runtime env markers when bootstrap verify runs target-local runtime commands.
- Add a loom_check sample that verifies bootstrapped runtime with an unrelated source env.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `LOOM_SOURCE_REPO_ROOT=/tmp/not-loom python3 examples/new-project/.loom/bin/loom_init.py runtime-state --target examples/new-project`

Closes #349