### PR TITLE
feat: 增加 vendored runtime provenance hash 合同

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -112,42 +112,50 @@
     {
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_init.py"
+      "source": "skills/shared/scripts/loom_init.py",
+      "sha256": "f7748a8971611a3c23e5e0bcbb3d49cf0854db12469961c074756f9887bd25a8"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/fact_chain_support.py"
+      "source": "skills/shared/scripts/fact_chain_support.py",
+      "sha256": "9ba73a76710189a2306f3ced374ea99c7ef43d4df10f25fef929e874b006fa22"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/governance_surface.py"
+      "source": "skills/shared/scripts/governance_surface.py",
+      "sha256": "ae74631688a91f774f29c54177f7b8477f23d445395e315fb91b24f5412dfcd2"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_flow.py"
+      "source": "skills/shared/scripts/loom_flow.py",
+      "sha256": "69c44efb623eb26aadda9141ecb73eea036444c1023b833da7f9cbb709f68428"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_status.py"
+      "source": "skills/shared/scripts/loom_status.py",
+      "sha256": "b8c74d31898ba4fdd5326abe82d175ec10e0a30cc2ea61810f1ec096052519f6"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/runtime_paths.py"
+      "source": "skills/shared/scripts/runtime_paths.py",
+      "sha256": "2e2701f2ca131482cabf1efd00d1c58790bec807f5ef1203d7332256892653f5"
     },
     {
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/runtime_state.py"
+      "source": "skills/shared/scripts/runtime_state.py",
+      "sha256": "5c5e096dbea072ab8e4f305ac06ee5d983e0bade519f6bea7fd119a92de52f09"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_check.py"
+      "source": "skills/shared/scripts/loom_check.py",
+      "sha256": "6cf4df1afa7dd6772a18f45fdc10c14917ad457dc3fd2f5a48980081d4883daa"
     },
     {
       "path": "AGENTS.md",
@@ -430,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-349-runtime-env-poisoning",
+            "locator": "issue-350-runtime-provenance-hash",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -34,42 +34,50 @@
     {
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_init.py"
+      "source": "skills/shared/scripts/loom_init.py",
+      "sha256": "f7748a8971611a3c23e5e0bcbb3d49cf0854db12469961c074756f9887bd25a8"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/fact_chain_support.py"
+      "source": "skills/shared/scripts/fact_chain_support.py",
+      "sha256": "9ba73a76710189a2306f3ced374ea99c7ef43d4df10f25fef929e874b006fa22"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/governance_surface.py"
+      "source": "skills/shared/scripts/governance_surface.py",
+      "sha256": "ae74631688a91f774f29c54177f7b8477f23d445395e315fb91b24f5412dfcd2"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_flow.py"
+      "source": "skills/shared/scripts/loom_flow.py",
+      "sha256": "69c44efb623eb26aadda9141ecb73eea036444c1023b833da7f9cbb709f68428"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_status.py"
+      "source": "skills/shared/scripts/loom_status.py",
+      "sha256": "b8c74d31898ba4fdd5326abe82d175ec10e0a30cc2ea61810f1ec096052519f6"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/runtime_paths.py"
+      "source": "skills/shared/scripts/runtime_paths.py",
+      "sha256": "2e2701f2ca131482cabf1efd00d1c58790bec807f5ef1203d7332256892653f5"
     },
     {
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
-      "source": "skills/shared/scripts/runtime_state.py"
+      "source": "skills/shared/scripts/runtime_state.py",
+      "sha256": "5c5e096dbea072ab8e4f305ac06ee5d983e0bade519f6bea7fd119a92de52f09"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
-      "source": "skills/shared/scripts/loom_check.py"
+      "source": "skills/shared/scripts/loom_check.py",
+      "sha256": "6cf4df1afa7dd6772a18f45fdc10c14917ad457dc3fd2f5a48980081d4883daa"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3711,6 +3711,27 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         elif payload.get("result") != "block":
             failures.append(Failure("daily-execution-cli", "`bootstrapped runtime-state` must block when the bootstrap manifest drifts"))
 
+        hash_drift_bootstrap = tmp_root / "hash-drift-bootstrapped-target"
+        shutil.copytree(example_target, hash_drift_bootstrap)
+        manifest_path = hash_drift_bootstrap / ".loom" / "bootstrap" / "manifest.json"
+        manifest = load_json_file(manifest_path)
+        if isinstance(manifest, dict):
+            artifacts = manifest.get("artifacts")
+            if isinstance(artifacts, list):
+                for artifact in artifacts:
+                    if isinstance(artifact, dict) and artifact.get("path") == ".loom/bin/runtime_state.py":
+                        artifact["sha256"] = "0" * 64
+            manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
+            cwd=hash_drift_bootstrap,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`bootstrapped runtime-state` provenance hash drift failed unexpectedly: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`bootstrapped runtime-state` must block when runtime provenance hashes drift"))
+
     if shutil.which("git") is not None:
         with tempfile.TemporaryDirectory(prefix="loom-check-installed-pre-merge-") as tmp:
             tmp_root = Path(tmp)

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -26,6 +27,17 @@ GOVERNANCE_RUNTIME_SOURCE = "skills/shared/scripts/governance_surface.py"
 TOOL_VERSION = "1.3.0"
 CONTRACT_VERSION = "1.3.0"
 WORK_ITEM_ID = "INIT-0001"
+
+RUNTIME_ARTIFACT_SOURCES = {
+    ".loom/bin/loom_init.py": RUNTIME_SOURCE,
+    ".loom/bin/fact_chain_support.py": FACT_CHAIN_RUNTIME_SOURCE,
+    ".loom/bin/governance_surface.py": GOVERNANCE_RUNTIME_SOURCE,
+    ".loom/bin/loom_flow.py": FLOW_RUNTIME_SOURCE,
+    ".loom/bin/loom_status.py": STATUS_RUNTIME_SOURCE,
+    ".loom/bin/runtime_paths.py": "skills/shared/scripts/runtime_paths.py",
+    ".loom/bin/runtime_state.py": "skills/shared/scripts/runtime_state.py",
+    ".loom/bin/loom_check.py": CHECK_RUNTIME_SOURCE,
+}
 
 ROOT_BOUNDARY_FILES = (
     "AGENTS.md",
@@ -816,46 +828,14 @@ def initial_artifacts(target_root: Path, install_pr_template: bool, adoption_pat
             "kind": "capability-map",
             "source": "generated",
         },
-        {
-            "path": ".loom/bin/loom_init.py",
-            "kind": "loom-tool",
-            "source": RUNTIME_SOURCE,
-        },
-        {
-            "path": ".loom/bin/fact_chain_support.py",
-            "kind": "loom-tool-support",
-            "source": FACT_CHAIN_RUNTIME_SOURCE,
-        },
-        {
-            "path": ".loom/bin/governance_surface.py",
-            "kind": "loom-tool-support",
-            "source": GOVERNANCE_RUNTIME_SOURCE,
-        },
-        {
-            "path": ".loom/bin/loom_flow.py",
-            "kind": "loom-tool",
-            "source": FLOW_RUNTIME_SOURCE,
-        },
-        {
-            "path": ".loom/bin/loom_status.py",
-            "kind": "loom-tool",
-            "source": STATUS_RUNTIME_SOURCE,
-        },
-        {
-            "path": ".loom/bin/runtime_paths.py",
-            "kind": "loom-tool-support",
-            "source": "skills/shared/scripts/runtime_paths.py",
-        },
-        {
-            "path": ".loom/bin/runtime_state.py",
-            "kind": "loom-tool-support",
-            "source": "skills/shared/scripts/runtime_state.py",
-        },
-        {
-            "path": ".loom/bin/loom_check.py",
-            "kind": "loom-tool",
-            "source": CHECK_RUNTIME_SOURCE,
-        },
+        runtime_artifact(".loom/bin/loom_init.py", "loom-tool", RUNTIME_SOURCE),
+        runtime_artifact(".loom/bin/fact_chain_support.py", "loom-tool-support", FACT_CHAIN_RUNTIME_SOURCE),
+        runtime_artifact(".loom/bin/governance_surface.py", "loom-tool-support", GOVERNANCE_RUNTIME_SOURCE),
+        runtime_artifact(".loom/bin/loom_flow.py", "loom-tool", FLOW_RUNTIME_SOURCE),
+        runtime_artifact(".loom/bin/loom_status.py", "loom-tool", STATUS_RUNTIME_SOURCE),
+        runtime_artifact(".loom/bin/runtime_paths.py", "loom-tool-support", "skills/shared/scripts/runtime_paths.py"),
+        runtime_artifact(".loom/bin/runtime_state.py", "loom-tool-support", "skills/shared/scripts/runtime_state.py"),
+        runtime_artifact(".loom/bin/loom_check.py", "loom-tool", CHECK_RUNTIME_SOURCE),
     ]
     if uses_attach_only_path(adoption_path):
         artifacts.extend(
@@ -1360,6 +1340,34 @@ def copy_file(source: Path, target: Path, force: bool) -> bool:
     target.parent.mkdir(parents=True, exist_ok=True)
     content = source.read_text(encoding="utf-8")
     return write_text(target, content, force=force)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def runtime_artifact(path: str, kind: str, source: str) -> dict[str, str]:
+    runtime_sources = {
+        ".loom/bin/loom_init.py": Path(__file__),
+        ".loom/bin/fact_chain_support.py": Path(__file__).with_name("fact_chain_support.py"),
+        ".loom/bin/governance_surface.py": Path(__file__).with_name("governance_surface.py"),
+        ".loom/bin/loom_flow.py": Path(__file__).with_name("loom_flow.py"),
+        ".loom/bin/loom_status.py": Path(__file__).with_name("loom_status.py"),
+        ".loom/bin/runtime_paths.py": Path(__file__).with_name("runtime_paths.py"),
+        ".loom/bin/runtime_state.py": Path(__file__).with_name("runtime_state.py"),
+        ".loom/bin/loom_check.py": Path(__file__).with_name("loom_check.py"),
+    }
+    source_path = runtime_sources[path]
+    return {
+        "path": path,
+        "kind": kind,
+        "source": source,
+        "sha256": sha256_file(source_path),
+    }
 
 
 def manifest_payload(result: dict[str, object]) -> dict[str, object]:

--- a/skills/shared/scripts/runtime_state.py
+++ b/skills/shared/scripts/runtime_state.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 from pathlib import Path
 from typing import Any
@@ -83,6 +84,14 @@ def detect_carrier(caller_file: str) -> str | None:
     if installed_skills_root(caller_file) is not None:
         return "installed-skills-root"
     return None
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _default_scene_for_carrier(carrier: str) -> str:
@@ -284,6 +293,14 @@ def _validate_bootstrapped_runtime(caller_file: str) -> tuple[dict[str, Any], li
         runtime_file = runtime_root / Path(relative).name
         if not runtime_file.exists():
             errors.append(f"bootstrapped runtime file is missing: `{relative}`")
+            continue
+        expected_hash = artifact.get("sha256")
+        if not isinstance(expected_hash, str) or not expected_hash.strip():
+            errors.append(f"bootstrap runtime artifact `{relative}` must declare sha256 provenance")
+            continue
+        actual_hash = sha256_file(runtime_file)
+        if actual_hash != expected_hash:
+            errors.append(f"bootstrap runtime artifact `{relative}` sha256 drifted")
 
     status = "pass" if not errors else "block"
     summary = (


### PR DESCRIPTION
## Summary
- 为 bootstrapped `.loom/bin/*` runtime artifacts 在 manifest/init-result 中写入 sha256 provenance。
- `runtime-state` 校验 manifest 声明、runtime 文件存在性与 sha256 一致性，缺失或漂移时 fail closed。
- 刷新 `examples/new-project` bootstrapped sample，并在 `loom_check` 增加 hash drift 回归样本。

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `LOOM_SOURCE_REPO_ROOT=/tmp/not-loom python3 examples/new-project/.loom/bin/loom_init.py runtime-state --target examples/new-project`
- temp manifest hash drift smoke returned `block` for `.loom/bin/runtime_state.py` sha256 drift

Closes #350