### PR TITLE
feat: 分离 bootstrap item 与 active item 生命周期

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -113,7 +113,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "f7748a8971611a3c23e5e0bcbb3d49cf0854db12469961c074756f9887bd25a8"
+      "sha256": "fc819d8172a1525c4fb86cbee680110c655101b6d6db7471a4d6c50d5c0bc1fc"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -125,13 +125,13 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "ae74631688a91f774f29c54177f7b8477f23d445395e315fb91b24f5412dfcd2"
+      "sha256": "d12f21d009a5127a4b0aba70bc23e111a51a490017879ee59d51c22db65b5f0a"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "69c44efb623eb26aadda9141ecb73eea036444c1023b833da7f9cbb709f68428"
+      "sha256": "18c5dc39a4cd2982a40c729807b12c2b15efd41a2962719b5491b06dad83c028"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "6cf4df1afa7dd6772a18f45fdc10c14917ad457dc3fd2f5a48980081d4883daa"
+      "sha256": "3b2257fddc37fdb514953500a38e94ca241a5889a5c6343b975db5a1109bbff4"
     },
     {
       "path": "AGENTS.md",
@@ -346,14 +346,9 @@
     "github_control_plane": {
       "repository": "MC-and-his-Agents/Loom",
       "default_branch": "main",
-      "branch_protection": "enabled",
-      "required_checks": [
-        "py-compile",
-        "demo-bootstrap",
-        "repo-local-cli",
-        "loom-check"
-      ],
-      "pr_reviews": "not_required"
+      "branch_protection": "unknown",
+      "required_checks": "unknown",
+      "pr_reviews": "unknown"
     },
     "repo_interface": {
       "availability": "absent",
@@ -438,7 +433,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-350-runtime-provenance-hash",
+            "locator": "issue-351-bootstrap-active-item-lifecycle",
             "authority": "git"
           },
           "worktree": {
@@ -746,7 +741,9 @@
       }
     },
     "summary": "repository is treated as new; Loom can plan the first governance carriers and bootstrap entrypoints without adding a second truth source.",
-    "missing_inputs": []
+    "missing_inputs": [
+      "github control plane: Get \"https://api.github.com/repos/MC-and-his-Agents/Loom/branches/main\": EOF"
+    ]
   },
   "maturity_upgrade_path": {
     "result": "block",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -35,7 +35,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "f7748a8971611a3c23e5e0bcbb3d49cf0854db12469961c074756f9887bd25a8"
+      "sha256": "fc819d8172a1525c4fb86cbee680110c655101b6d6db7471a4d6c50d5c0bc1fc"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -47,13 +47,13 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "ae74631688a91f774f29c54177f7b8477f23d445395e315fb91b24f5412dfcd2"
+      "sha256": "d12f21d009a5127a4b0aba70bc23e111a51a490017879ee59d51c22db65b5f0a"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "69c44efb623eb26aadda9141ecb73eea036444c1023b833da7f9cbb709f68428"
+      "sha256": "18c5dc39a4cd2982a40c729807b12c2b15efd41a2962719b5491b06dad83c028"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "6cf4df1afa7dd6772a18f45fdc10c14917ad457dc3fd2f5a48980081d4883daa"
+      "sha256": "3b2257fddc37fdb514953500a38e94ca241a5889a5c6343b975db5a1109bbff4"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -893,18 +893,60 @@ def first_match(directory: Path, suffix: str, root: Path) -> str:
     return ""
 
 
+def existing_locator(root: Path, relative: str | None) -> str:
+    if not relative:
+        return ""
+    return relative if (root / relative).exists() else ""
+
+
+def active_or_first(root: Path, relative: str | None, directory: Path, suffix: str) -> str:
+    return existing_locator(root, relative) or (first_match(directory, suffix, root) if directory.exists() else "")
+
+
+def current_review_locator(root: Path, review_dir: Path, item_id: str) -> str:
+    review_path = review_dir / f"{item_id}.json"
+    if review_path.exists():
+        return relative_locator(review_path, root)
+    return first_match(review_dir, ".json", root) if review_dir.exists() else ""
+
+
+def active_entry_points(root: Path) -> dict[str, str]:
+    init_result = root / ".loom/bootstrap/init-result.json"
+    try:
+        payload = json.loads(init_result.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    fact_chain = payload.get("fact_chain")
+    if not isinstance(fact_chain, dict):
+        return {}
+    entry_points = fact_chain.get("entry_points")
+    if not isinstance(entry_points, dict):
+        return {}
+    active: dict[str, str] = {}
+    for key in ("current_item_id", "work_item", "recovery_entry", "status_surface"):
+        value = entry_points.get(key)
+        if isinstance(value, str) and value.strip():
+            active[key] = value.strip()
+    return active
+
+
 def detect_carrier_summary(root: Path, *, repository_mode: str, planning_mode: bool) -> dict[str, dict[str, str]]:
+    active = active_entry_points(root)
+    active_item_id = active.get("current_item_id") or "INIT-0001"
     item_dir = root / ".loom/work-items"
     recovery_dir = root / ".loom/progress"
     review_dir = root / ".loom/reviews"
-    status_path = root / ".loom/status/current.md"
-    spec_path = root / ".loom/specs/INIT-0001/spec.md"
-    plan_path = root / ".loom/specs/INIT-0001/plan.md"
+    status_locator = active.get("status_surface") or ".loom/status/current.md"
+    status_path = root / status_locator
+    spec_path = root / f".loom/specs/{active_item_id}/spec.md"
+    plan_path = root / f".loom/specs/{active_item_id}/plan.md"
 
     present_locators = {
-        "work_item": first_match(item_dir, ".md", root) if item_dir.exists() else "",
-        "recovery": first_match(recovery_dir, ".md", root) if recovery_dir.exists() else "",
-        "review": first_match(review_dir, ".json", root) if review_dir.exists() else "",
+        "work_item": active_or_first(root, active.get("work_item"), item_dir, ".md"),
+        "recovery": active_or_first(root, active.get("recovery_entry"), recovery_dir, ".md"),
+        "review": current_review_locator(root, review_dir, active_item_id),
         "status_surface": relative_locator(status_path, root) if status_path.exists() else "",
         "spec_path": relative_locator(spec_path, root) if spec_path.exists() else "",
         "plan_path": relative_locator(plan_path, root) if plan_path.exists() else "",
@@ -922,11 +964,11 @@ def detect_carrier_summary(root: Path, *, repository_mode: str, planning_mode: b
     return summary
 
 
-def detect_execution_entry(root: Path, loom_state: str, *, bootstrap_mode: bool) -> str:
+def detect_execution_entry(root: Path, loom_state: str, *, bootstrap_mode: bool, active_item_id: str = "INIT-0001") -> str:
     if bootstrap_mode:
-        return "python3 .loom/bin/loom_flow.py flow resume --target . --item INIT-0001"
+        return f"python3 .loom/bin/loom_flow.py flow resume --target . --item {active_item_id}"
     if loom_state == "active":
-        return f"{command_prefix(root, 'loom_flow.py')} flow resume --target . --item INIT-0001"
+        return f"{command_prefix(root, 'loom_flow.py')} flow resume --target . --item {active_item_id}"
     if loom_state == "partial":
         return f"{command_prefix(root, 'loom_init.py')} route --target <repo> --task \"请接手当前事项并恢复上下文后继续推进\""
     return "unknown"
@@ -942,16 +984,16 @@ def detect_validation_entry(loom_state: str, *, bootstrap_mode: bool) -> str:
     return "unknown"
 
 
-def detect_review_merge_surface(root: Path, loom_state: str, *, bootstrap_mode: bool) -> dict[str, str]:
+def detect_review_merge_surface(root: Path, loom_state: str, *, bootstrap_mode: bool, active_item_id: str = "INIT-0001") -> dict[str, str]:
     pr_template = ".github/PULL_REQUEST_TEMPLATE.md" if file_exists(root, ".github/PULL_REQUEST_TEMPLATE.md") else "unknown"
     validation_surface = ".loom/status/current.md" if file_exists(root, ".loom/status/current.md") else "unknown"
     if bootstrap_mode and validation_surface == "unknown":
         validation_surface = ".loom/status/current.md"
 
     if bootstrap_mode:
-        merge_surface = "python3 .loom/bin/loom_flow.py checkpoint merge --target . --item INIT-0001"
+        merge_surface = f"python3 .loom/bin/loom_flow.py checkpoint merge --target . --item {active_item_id}"
     elif loom_state == "active":
-        merge_surface = f"{command_prefix(root, 'loom_flow.py')} checkpoint merge --target . [--item <id>]"
+        merge_surface = f"{command_prefix(root, 'loom_flow.py')} checkpoint merge --target . --item {active_item_id}"
     else:
         merge_surface = "unknown"
     return {
@@ -1207,11 +1249,12 @@ def build_governance_surface(
     loom_state = detect_loom_state(root)
     repository_mode = detect_repository_mode(root, loom_state, scenario_override=scenario_override)
     planning_mode = bootstrap_mode and repository_mode == "new" and loom_state != "active"
+    active_item_id = active_entry_points(root).get("current_item_id", "INIT-0001")
     carrier_summary = detect_carrier_summary(root, repository_mode=repository_mode, planning_mode=planning_mode)
     github_control_plane, github_missing = detect_github_control_plane(root)
-    execution_entry = detect_execution_entry(root, loom_state, bootstrap_mode=bootstrap_mode)
+    execution_entry = detect_execution_entry(root, loom_state, bootstrap_mode=bootstrap_mode, active_item_id=active_item_id)
     validation_entry = detect_validation_entry(loom_state, bootstrap_mode=bootstrap_mode)
-    review_merge_surface = detect_review_merge_surface(root, loom_state, bootstrap_mode=bootstrap_mode)
+    review_merge_surface = detect_review_merge_surface(root, loom_state, bootstrap_mode=bootstrap_mode, active_item_id=active_item_id)
     repo_interface, repo_interface_missing = detect_repo_interface(root)
     repo_interop, repo_interop_missing = detect_repo_interop(root)
     host_binding = detect_host_binding_surface(

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3468,6 +3468,72 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         elif payload.get("result") != "pass":
             failures.append(Failure("daily-execution-cli", "`work-item update` must pass on a clean temp copy"))
 
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_init.py",
+                "verify",
+                "--target",
+                str(authoring_target),
+            ],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`loom-init verify` active item rollover failed: {error}"))
+        elif payload.get("ok") is not True:
+            failures.append(Failure("daily-execution-cli", "`loom-init verify` must pass after active item rollover"))
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_status.py",
+                "--target",
+                str(authoring_target),
+                "--item",
+                "NEXT-0001",
+            ],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`loom-status` active item rollover failed: {error}"))
+        else:
+            current_item = payload.get("item", {}).get("id") if isinstance(payload.get("item"), dict) else None
+            if current_item != "NEXT-0001":
+                failures.append(Failure("daily-execution-cli", "`loom-status` must report the rolled-over active item"))
+            governance_surface = payload.get("governance_surface")
+            if isinstance(governance_surface, dict):
+                carrier_summary = governance_surface.get("carrier_summary")
+                if isinstance(carrier_summary, dict):
+                    work_item = carrier_summary.get("work_item")
+                    recovery = carrier_summary.get("recovery")
+                    if isinstance(work_item, dict) and work_item.get("locator") != ".loom/work-items/NEXT-0001.md":
+                        failures.append(Failure("daily-execution-cli", "`loom-status` carrier summary must point to the active Work Item"))
+                    if isinstance(recovery, dict) and recovery.get("locator") != ".loom/progress/NEXT-0001.md":
+                        failures.append(Failure("daily-execution-cli", "`loom-status` carrier summary must point to the active recovery entry"))
+                execution_entry = str(governance_surface.get("execution_entry", ""))
+                if "--item NEXT-0001" not in execution_entry:
+                    failures.append(Failure("daily-execution-cli", "`loom-status` execution entry must resume the active Work Item"))
+
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "flow",
+                "spec-review",
+                "--target",
+                str(authoring_target),
+                "--item",
+                "NEXT-0001",
+            ],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`flow spec-review` active item rollover failed: {error}"))
+        elif payload.get("result") not in {"block", "fallback"}:
+            failures.append(Failure("daily-execution-cli", "`flow spec-review` must not pass when the active item has no spec suite"))
+        elif ".loom/specs/INIT-0001/spec.md" in json.dumps(payload, ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`flow spec-review` must not fall back to the bootstrap spec suite for a rolled-over active item"))
+
         findings_path = authoring_target / ".loom" / "review-findings.json"
         findings_path.parent.mkdir(parents=True, exist_ok=True)
         findings_path.write_text(

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1169,7 +1169,7 @@ def formal_spec_path(context: dict[str, Any]) -> str | None:
             return artifact
 
     fallback = context["target_root"] / ".loom/specs/INIT-0001/spec.md"
-    if fallback.exists():
+    if context["item_id"] == "INIT-0001" and fallback.exists():
         return ".loom/specs/INIT-0001/spec.md"
     return None
 
@@ -1182,12 +1182,15 @@ def spec_suite_paths(context: dict[str, Any]) -> dict[str, str]:
             "plan": f".loom/specs/{item_id}/plan.md",
             "implementation_contract": f".loom/specs/{item_id}/implementation-contract.md",
         },
-        {
-            "spec": ".loom/specs/INIT-0001/spec.md",
-            "plan": ".loom/specs/INIT-0001/plan.md",
-            "implementation_contract": ".loom/specs/INIT-0001/implementation-contract.md",
-        },
     ]
+    if item_id == "INIT-0001":
+        candidates.append(
+            {
+                "spec": ".loom/specs/INIT-0001/spec.md",
+                "plan": ".loom/specs/INIT-0001/plan.md",
+                "implementation_contract": ".loom/specs/INIT-0001/implementation-contract.md",
+            }
+        )
     for suite in candidates:
         if (context["target_root"] / suite["spec"]).exists():
             return suite

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -1627,24 +1627,23 @@ def verify_target(target_root: Path, output_path: Path) -> list[str]:
                 ):
                     if field not in runtime_evidence_report:
                         errors.append(f"fact-chain: runtime_evidence is missing `{field}`")
-            matching_work_item = None
-            for work_item in validated_work_items:
-                if work_item.get("id") == current_item_id:
-                    matching_work_item = work_item
-                    break
-            if matching_work_item is None:
-                errors.append(f"init-result is missing the current work item `{current_item_id}`")
-            else:
+            bootstrap_work_item = next(
+                (work_item for work_item in validated_work_items if work_item.get("id") == WORK_ITEM_ID),
+                None,
+            )
+            if bootstrap_work_item is None:
+                errors.append(f"init-result is missing the bootstrap work item `{WORK_ITEM_ID}`")
+            elif current_item_id == WORK_ITEM_ID:
                 expected_init_fields = {
                     "recovery_entry": fact_chain_report["fact_chain"]["entry_points"]["recovery_entry"],
                     "validation_entry": fact_chain_report["facts"]["validation_entry"]["value"],
                     "workspace_entry": fact_chain_report["facts"]["workspace_entry"]["value"],
                 }
                 for field, expected_value in expected_init_fields.items():
-                    actual_value = matching_work_item.get(field)
+                    actual_value = bootstrap_work_item.get(field)
                     if actual_value != expected_value:
                         errors.append(
-                            f"init-result work item `{current_item_id}` has inconsistent `{field}`: "
+                            f"init-result bootstrap work item `{WORK_ITEM_ID}` has inconsistent `{field}`: "
                             f"expected `{expected_value}`, got `{actual_value}`"
                         )
 


### PR DESCRIPTION
## Summary
- 保留 `INIT-0001` 作为 bootstrap seed，但 verify 不再把 `initial_work_items` 当作当前 active item 真相源。
- governance surface 从 `init-result.fact_chain.entry_points` 读取当前 active item/recovery/status，并生成当前 item 的 resume/merge entry。
- 非 `INIT-0001` active item 不再静默 fallback 到 `.loom/specs/INIT-0001/*` spec suite。
- `loom_check` 增加 `NEXT-0001` active item rollover 样本，覆盖 verify/status/spec-review。

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- Targeted rollover smoke: create `NEXT-0001 --activate`, `loom_init verify` passes, `loom_status --item NEXT-0001` points carrier summary/execution entry at `NEXT-0001`, spec-review does not consume bootstrap spec suite.

Closes #351