### PR TITLE
feat: 阻断重复 metadata 字段伪造

### DIFF
--- a/docs/evidence/validations/validation-metadata-parser-hardening.md
+++ b/docs/evidence/validations/validation-metadata-parser-hardening.md
@@ -1,0 +1,31 @@
+# Validation: Metadata Parser Hardening
+
+## Goal
+
+验证 Loom fact-chain parser 不再允许 canonical section 内重复字段通过 last-write-wins 覆盖事实。
+
+## Scope
+
+本验证覆盖：
+
+- `Static Facts` 重复字段必须失败
+- `Runtime Evidence` 重复字段必须失败
+- Runtime Evidence 仅在缺失整个 section 时允许 legacy fallback
+- Runtime Evidence 已存在但字段重复时不得 fallback 成功
+
+## Validation Entry
+
+```bash
+python3 tools/loom_check.py .
+```
+
+## Runtime Evidence
+
+`loom_check` 的 metadata spoofing fixture 会：
+
+- 在 work item `Static Facts` 中插入重复 `Goal`，确认 `inspect_fact_chain()` 报 duplicate field
+- 在 status `Runtime Evidence` 中插入重复 `Run Entry`，确认 `loom_flow.py fact-chain` 返回 `block`，而不是被 legacy parser 吞掉
+
+## Result
+
+Pass. Canonical metadata blocks now fail closed on duplicate fields.

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -119,7 +119,7 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "9ba73a76710189a2306f3ced374ea99c7ef43d4df10f25fef929e874b006fa22"
+      "sha256": "0e215e1c83443c8688c984241a8008e5b419f68b8838eecbcfb695857e212923"
     },
     {
       "path": ".loom/bin/governance_surface.py",
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "e8bc02d131b1007889b7f9b394b5b2d605c8bf790ba1baccc37da1e6aecbf46c"
+      "sha256": "f74afa96460de82ef279ec78a0468906ca1db26b867a4fc810025164ae8f7146"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "e834612a8da8cd22cc13679b61529bc0074d0399004f4e4f45540d6b8f314c9a"
+      "sha256": "48bf635cb9fb4f28b38309a81ecb67a48b489d72f83c4907d972230481848ddb"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-352-shadow-evidence-closure",
+            "locator": "issue-353-metadata-parser-hardening",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -41,7 +41,7 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "9ba73a76710189a2306f3ced374ea99c7ef43d4df10f25fef929e874b006fa22"
+      "sha256": "0e215e1c83443c8688c984241a8008e5b419f68b8838eecbcfb695857e212923"
     },
     {
       "path": ".loom/bin/governance_surface.py",
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "e8bc02d131b1007889b7f9b394b5b2d605c8bf790ba1baccc37da1e6aecbf46c"
+      "sha256": "f74afa96460de82ef279ec78a0468906ca1db26b867a4fc810025164ae8f7146"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "e834612a8da8cd22cc13679b61529bc0074d0399004f4e4f45540d6b8f314c9a"
+      "sha256": "48bf635cb9fb4f28b38309a81ecb67a48b489d72f83c4907d972230481848ddb"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/fact_chain_support.py
+++ b/skills/shared/scripts/fact_chain_support.py
@@ -131,6 +131,7 @@ def parse_key_value_section(
         return {}, [f"{relative_path}: missing section `{section_name}`"]
 
     values: dict[str, str] = {}
+    seen: dict[str, str] = {}
     for raw_line in lines:
         stripped = raw_line.strip()
         if not stripped:
@@ -143,7 +144,15 @@ def parse_key_value_section(
         if label not in field_map:
             errors.append(f"{relative_path}: unexpected field `{label}` in `{section_name}`")
             continue
-        values[field_map[label]] = _clean_value(match.group(2))
+        canonical = field_map[label]
+        if canonical in seen:
+            errors.append(
+                f"{relative_path}: duplicate field `{label}` in `{section_name}` "
+                f"(canonical `{canonical}` already set by `{seen[canonical]}`)"
+            )
+            continue
+        seen[canonical] = label
+        values[canonical] = _clean_value(match.group(2))
 
     for label, canonical in field_map.items():
         if canonical not in values:

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -2211,6 +2211,43 @@ def check_demo_fact_chain(root: Path) -> list[Failure]:
         failures.append(Failure("demo-fact-chain", detail))
     if report and report.get("fact_chain", {}).get("entry_points", {}).get("status_surface") != ".loom/status/current.md":
         failures.append(Failure("demo-fact-chain", "demo fact chain must point status_surface to `.loom/status/current.md`"))
+    with tempfile.TemporaryDirectory(prefix="loom-check-metadata-spoof-") as tmp:
+        spoof_target = Path(tmp) / "new-project"
+        shutil.copytree(target, spoof_target)
+        work_item_path = spoof_target / ".loom/work-items/INIT-0001.md"
+        work_item_text = work_item_path.read_text(encoding="utf-8")
+        work_item_path.write_text(
+            work_item_text.replace(
+                "- Goal: Bootstrap the first executable Loom path for this repository\n",
+                "- Goal: wrong spoofed goal\n- Goal: Bootstrap the first executable Loom path for this repository\n",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        _, spoof_errors = inspect_fact_chain(spoof_target)
+        if not any("duplicate field `Goal`" in error for error in spoof_errors):
+            failures.append(Failure("demo-fact-chain", "fact-chain parser must reject duplicate canonical metadata fields"))
+
+        runtime_spoof_target = Path(tmp) / "runtime-spoof"
+        shutil.copytree(target, runtime_spoof_target)
+        status_path = runtime_spoof_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Run Entry: not_applicable\n",
+                "- Run Entry: wrong-spoofed-run\n- Run Entry: not_applicable\n",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(runtime_spoof_target)],
+        )
+        if error:
+            failures.append(Failure("demo-fact-chain", f"`flow fact-chain` metadata spoof sample failed unexpectedly: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("demo-fact-chain", "`flow fact-chain` must not legacy-fallback past duplicate Runtime Evidence fields"))
     return failures
 
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -2643,7 +2643,7 @@ def build_default_review_prompt(
 
 def load_fact_chain_report(target_root: Path, output_relative: str) -> tuple[dict[str, Any], list[str]]:
     report, errors = inspect_fact_chain(target_root, output_relative)
-    if errors and all("Runtime Evidence" in message for message in errors):
+    if errors and all("missing section `Runtime Evidence`" in message for message in errors):
         report, errors = inspect_fact_chain_legacy(target_root, output_relative)
     if errors:
         return {}, errors

--- a/tools/fact_chain_support.py
+++ b/tools/fact_chain_support.py
@@ -131,6 +131,7 @@ def parse_key_value_section(
         return {}, [f"{relative_path}: missing section `{section_name}`"]
 
     values: dict[str, str] = {}
+    seen: dict[str, str] = {}
     for raw_line in lines:
         stripped = raw_line.strip()
         if not stripped:
@@ -143,7 +144,15 @@ def parse_key_value_section(
         if label not in field_map:
             errors.append(f"{relative_path}: unexpected field `{label}` in `{section_name}`")
             continue
-        values[field_map[label]] = _clean_value(match.group(2))
+        canonical = field_map[label]
+        if canonical in seen:
+            errors.append(
+                f"{relative_path}: duplicate field `{label}` in `{section_name}` "
+                f"(canonical `{canonical}` already set by `{seen[canonical]}`)"
+            )
+            continue
+        seen[canonical] = label
+        values[canonical] = _clean_value(match.group(2))
 
     for label, canonical in field_map.items():
         if canonical not in values:


### PR DESCRIPTION
## Summary
- `parse_key_value_section` 按 canonical key 检测重复字段，并保留第一次事实，不允许后续 bullet 覆盖。
- `load_fact_chain_report` 只在缺失整个 `Runtime Evidence` section 时 legacy fallback；Runtime Evidence 存在但字段重复时必须 fail closed。
- 增加 metadata spoofing fixture 与 validation evidence。

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- metadata spoof samples: duplicate `Goal` in `Static Facts`; duplicate `Run Entry` in `Runtime Evidence` does not legacy-fallback to success.

Closes #353