### PR TITLE
feat: 固化 review head binding 语义

### DIFF
--- a/docs/evidence/validations/validation-review-head-binding.md
+++ b/docs/evidence/validations/validation-review-head-binding.md
@@ -1,0 +1,30 @@
+# Validation: Review Head Binding
+
+## Goal
+
+验证 `loom-review/v1` 的 head binding 能区分 review artifact freshness、carrier-only refresh、implementation drift 与 mixed stale drift。
+
+## Semantics
+
+- `fresh`: review artifact recorded against current `HEAD`
+- `carrier-only`: current `HEAD` differs only by allowed Loom carrier paths after review
+- `implementation-drift-only`: implementation files changed after review and must not be treated as fresh
+- `stale`: mixed or otherwise unsafe drift after review
+
+## Validation Entry
+
+```bash
+python3 tools/loom_check.py .
+```
+
+## Runtime Evidence
+
+`loom_check` installed pre-merge fixture covers:
+
+- positive merge checkpoint exposes `fresh`
+- post-review carrier refresh remains passable and exposes `carrier-only`
+- post-review README implementation drift blocks merge and exposes `implementation-drift-only`
+
+## Result
+
+Pass. Merge-ready / checkpoint merge now consume review head binding semantics instead of treating all head drift as a generic stale state.

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "f74afa96460de82ef279ec78a0468906ca1db26b867a4fc810025164ae8f7146"
+      "sha256": "b35e0e598743b84c21d8ec9b56ff0146a411c0aaf8c29a982d7a21d53044a808"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "48bf635cb9fb4f28b38309a81ecb67a48b489d72f83c4907d972230481848ddb"
+      "sha256": "8a5c1ccde7193facdb348896a3dda9f19b42ea874da1c4744e402e07f951ba50"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-353-metadata-parser-hardening",
+            "locator": "issue-354-review-head-binding",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "f74afa96460de82ef279ec78a0468906ca1db26b867a4fc810025164ae8f7146"
+      "sha256": "b35e0e598743b84c21d8ec9b56ff0146a411c0aaf8c29a982d7a21d53044a808"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "48bf635cb9fb4f28b38309a81ecb67a48b489d72f83c4907d972230481848ddb"
+      "sha256": "8a5c1ccde7193facdb348896a3dda9f19b42ea874da1c4744e402e07f951ba50"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from fact_chain_support import inspect_fact_chain
 from governance_surface import build_governance_surface
-from loom_flow import repo_specific_requirements_payload
+from loom_flow import repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
 TOP_LEVEL_DIRS = (
@@ -2211,6 +2211,15 @@ def check_demo_fact_chain(root: Path) -> list[Failure]:
         failures.append(Failure("demo-fact-chain", detail))
     if report and report.get("fact_chain", {}).get("entry_points", {}).get("status_surface") != ".loom/status/current.md":
         failures.append(Failure("demo-fact-chain", "demo fact chain must point status_surface to `.loom/status/current.md`"))
+    head_result = run_command(root, ["git", "rev-parse", "HEAD"], timeout_seconds=30)
+    if head_result.returncode == 0:
+        head_binding, head_errors = review_head_binding(
+            root,
+            reviewed_head=head_result.stdout.strip(),
+            allowed_paths=set(),
+        )
+        if head_errors or head_binding.get("status") != "fresh":
+            failures.append(Failure("demo-fact-chain", "review head binding must report `fresh` for the current HEAD"))
     with tempfile.TemporaryDirectory(prefix="loom-check-metadata-spoof-") as tmp:
         spoof_target = Path(tmp) / "new-project"
         shutil.copytree(target, spoof_target)
@@ -4421,6 +4430,65 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif checkpoint_merge_payload.get("result") != "pass":
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` must pass for the positive chain"))
 
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "recovery",
+                        "writeback",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                        "--current-checkpoint",
+                        "merge checkpoint",
+                        "--current-stop",
+                        "Only Loom carrier status changed after review.",
+                        "--next-step",
+                        "Confirm carrier-only review head binding remains consumable.",
+                        "--latest-validation-summary",
+                        positive_summary,
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed recovery writeback carrier-only` failed: {error}"))
+                elif payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed recovery writeback carrier-only` must pass"))
+                git_add = run_command(root, ["git", "add", "-f", ".loom/progress/INIT-0001.md", ".loom/status/current.md"], cwd=positive_target)
+                if git_add.returncode != 0:
+                    detail = git_add.stderr.strip() or git_add.stdout.strip() or "git add failed"
+                    failures.append(Failure("daily-execution-cli", f"`installed carrier-only commit` add failed: {detail}"))
+                else:
+                    git_commit = run_command(
+                        root,
+                        ["git", "commit", "-m", "refresh carriers after review for #354"],
+                        cwd=positive_target,
+                    )
+                    if git_commit.returncode != 0:
+                        detail = git_commit.stderr.strip() or git_commit.stdout.strip() or "git commit failed"
+                        failures.append(Failure("daily-execution-cli", f"`installed carrier-only commit` failed: {detail}"))
+
+                payload, error = load_command_json(
+                    root,
+                    [
+                        "python3",
+                        str(install_root / "shared" / "scripts" / "loom_flow.py"),
+                        "checkpoint",
+                        "merge",
+                        "--target",
+                        str(positive_target),
+                        "--item",
+                        "INIT-0001",
+                    ],
+                )
+                if error:
+                    failures.append(Failure("daily-execution-cli", f"`installed checkpoint merge` carrier-only failed: {error}"))
+                elif payload.get("result") != "pass":
+                    failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` must pass for carrier-only review head drift"))
+                elif "carrier-only" not in json.dumps(payload, ensure_ascii=False):
+                    failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` must expose carrier-only review head binding"))
+
                 broken_install = tmp_root / "broken-install" / "skills"
                 shutil.copytree(root / "skills", broken_install)
                 (broken_install / "install-layout.json").unlink()
@@ -4601,6 +4669,8 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", f"`installed checkpoint merge` drift negative failed: {error}"))
                 elif payload.get("result") != "block":
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` must block when HEAD drifts beyond Loom carriers"))
+                elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
+                    failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
     gh_auth_probe = None
     if shutil.which("gh") is not None:

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1329,7 +1329,7 @@ def review_head_binding(
     if not isinstance(current_head, str) or not current_head.strip():
         return payload, ["current HEAD is unavailable"]
     if reviewed_head == current_head:
-        payload["status"] = "current"
+        payload["status"] = "fresh"
         payload["stale"] = False
         return payload, []
 
@@ -1344,6 +1344,11 @@ def review_head_binding(
         payload["status"] = "carrier-only"
         payload["stale"] = False
         return payload, []
+
+    if disallowed_paths and len(disallowed_paths) == len(changed_paths):
+        payload["status"] = "implementation-drift-only"
+        payload["stale"] = True
+        return payload, ["review artifact has implementation drift after review"]
 
     payload["status"] = "stale"
     payload["stale"] = True
@@ -1372,7 +1377,7 @@ def spec_review_head_binding(
     if not isinstance(current_head, str) or not current_head.strip():
         return payload, ["current HEAD is unavailable"]
     if reviewed_head == current_head:
-        payload["status"] = "current"
+        payload["status"] = "fresh"
         payload["stale"] = False
         return payload, []
 


### PR DESCRIPTION
## Summary
- 将 review head binding 状态固化为 `fresh`、`carrier-only`、`implementation-drift-only`、`stale`。
- `carrier-only` 允许 Loom carrier refresh 后继续消费 review；implementation drift 不再伪装成 fresh。
- `merge-ready` / checkpoint merge 继续消费 head binding 错误并 fail closed。
- 增加 validation evidence 与 installed pre-merge fixture 覆盖。

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `loom_check` installed pre-merge fixture covers fresh, carrier-only, and implementation-drift-only paths.

Closes #354