### PR TITLE
feat: 定义 advisory/blocking rollout 与 rollback switch

### DIFF
--- a/docs/adoption/github-profile-upgrade.md
+++ b/docs/adoption/github-profile-upgrade.md
@@ -83,3 +83,28 @@ GitHub strong governance 的目标不是复制 Syvert 的文件名，而是达�
 - 不把 Syvert 的 repo-local 命名直接抄成 Loom 默认规则
 - 不要求所有 adopted repo 一次性切到 `strong`
 - 不把 validation-only parity 直接升级成 blocking host policy
+
+## 8. Gate rollout 合同
+
+GitHub profile adoption 的 gate 消费模式固定为三态：
+
+- `advisory`
+  - 新接入仓库的默认模式。
+  - Loom 可以报告 review、merge-ready、closeout、shadow parity 与 reconciliation 信号，但不得直接成为 blocking authority。
+- `blocking`
+  - 只能由 strong governance profile 显式启用。
+  - 启用前必须满足 strong maturity、adversarial adoption checks、rollback switch 三个前置条件。
+  - 不能把新仓库或未完成 hardening 的仓库直接切到 blocking。
+- `rollback`
+  - 当 runtime、evidence、host binding、review head 或 metadata parsing 出现漂移时，必须能回退到 advisory。
+  - rollback 不删除证据，只暂停 blocking 消费，直到重新通过 adversarial adoption checks。
+
+`governance-profile upgrade-plan` 必须输出：
+
+- `gate_rollout.default_mode`
+- `gate_rollout.current_mode`
+- `gate_rollout.recommended_mode`
+- `gate_rollout.blocking_preconditions`
+- `gate_rollout.rollback`
+
+默认建议必须保持 `advisory`。只有当所有 blocking 前置条件都有版本控制内证据时，才允许建议进入 `blocking`。

--- a/docs/evidence/validations/validation-adoption-gate-rollout.md
+++ b/docs/evidence/validations/validation-adoption-gate-rollout.md
@@ -1,0 +1,55 @@
+# Validation: adoption gate rollout
+
+本记录证明 `#355` 把 adoption gate rollout 从说明收成机器可读合同。
+
+## Scope
+
+本轮只定义 adoption gate 的 rollout / rollback 消费语义，不把任何 adopted repo 默认切到 blocking。
+
+稳定模式固定为：
+
+- `advisory`
+- `blocking`
+- `rollback`
+
+## Runtime contract
+
+`governance-profile status` 与 `governance-profile upgrade-plan` 必须通过 `governance_control_plane.maturity.gate_rollout` 暴露：
+
+- `schema_version: loom-adoption-gate-rollout/v1`
+- `default_mode: advisory`
+- `current_mode`
+- `recommended_mode`
+- `allowed_modes`
+- `blocking_allowed`
+- `blocking_preconditions`
+- `rollback`
+
+`governance-profile upgrade --dry-run` 必须输出同一 `gate_rollout`，让 adoption 工具和后续 gate 消费同一个 rollout 判断。
+
+## Blocking preconditions
+
+进入 `blocking` 前必须同时满足：
+
+- `strong_maturity`
+- `adversarial_adoption_checks`
+- `rollback_switch`
+
+新下游仓库默认仍是 `advisory`。只有 adversarial adoption checks 有版本控制内证据后，profile 才允许显式启用 blocking。
+
+## Rollback rule
+
+`rollback` 必须切回 `advisory`，并保留 evidence。rollback 的目标不是删除 Loom，而是在 runtime、evidence、host binding、review head 或 metadata parsing 漂移时暂停 blocking 消费。
+
+## Validation commands
+
+```bash
+python3 tools/loom_flow.py governance-profile status --target examples/new-project
+python3 tools/loom_flow.py governance-profile upgrade-plan --target examples/new-project
+python3 tools/loom_flow.py governance-profile upgrade --target examples/new-project --to standard --dry-run
+python3 tools/loom_check.py .
+```
+
+## Result
+
+`loom_check` 现在验证 `gate_rollout` 的 schema、三态模式、blocking 前置条件、rollback switch 和 upgrade 输出一致性。

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -113,7 +113,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "fc819d8172a1525c4fb86cbee680110c655101b6d6db7471a4d6c50d5c0bc1fc"
+      "sha256": "8fc0f350f55fa068b4b69854fb81f3b45fbace5bf384f900a63aeb9adfd87c1b"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -125,13 +125,13 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "d12f21d009a5127a4b0aba70bc23e111a51a490017879ee59d51c22db65b5f0a"
+      "sha256": "2f873ee4ddd170af4a835da24bafa59f6e5561ee74360faf71e98e8480100a72"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "b35e0e598743b84c21d8ec9b56ff0146a411c0aaf8c29a982d7a21d53044a808"
+      "sha256": "7d4f476d8117a6b9d264a71f8300f229bf511dd9e1fb2b29636990c16c6d197d"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "8a5c1ccde7193facdb348896a3dda9f19b42ea874da1c4744e402e07f951ba50"
+      "sha256": "1acd2461b1150b9d4c328571c849556e1b3b36dd9595254643aa046367b66009"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-354-review-head-binding",
+            "locator": "issue-355-adoption-gate-rollout",
             "authority": "git"
           },
           "worktree": {
@@ -742,6 +742,52 @@
               "recommended_action": "enable controlled merge binding and required host gates"
             }
           ]
+        },
+        "gate_rollout": {
+          "schema_version": "loom-adoption-gate-rollout/v1",
+          "default_mode": "advisory",
+          "current_mode": "advisory",
+          "recommended_mode": "advisory",
+          "allowed_modes": {
+            "advisory": {
+              "summary": "Default mode for newly adopted repositories; Loom reports gate signals without becoming the blocking authority.",
+              "blocking": false
+            },
+            "blocking": {
+              "summary": "Explicit opt-in mode for strong governance repositories after adversarial adoption checks pass.",
+              "blocking": true
+            },
+            "rollback": {
+              "summary": "Emergency switch back to advisory consumption when runtime, evidence, or host bindings drift.",
+              "blocking": false
+            }
+          },
+          "blocking_allowed": false,
+          "blocking_preconditions": [
+            {
+              "id": "strong_maturity",
+              "status": "missing",
+              "layer": "github-profile",
+              "recommended_action": "upgrade the repository to strong maturity before enabling blocking gates"
+            },
+            {
+              "id": "adversarial_adoption_checks",
+              "status": "missing",
+              "layer": "core",
+              "recommended_action": "run the Loom-owned Syvert-style adversarial adoption fixture and record the validation evidence"
+            },
+            {
+              "id": "rollback_switch",
+              "status": "pass",
+              "layer": "core",
+              "recommended_action": "keep rollback available by switching gate mode back to advisory and rerunning governance-profile status"
+            }
+          ],
+          "rollback": {
+            "mode": "rollback",
+            "switch_to": "advisory",
+            "recommended_action": "disable blocking consumption, preserve evidence, repair drift, then rerun adversarial adoption checks before re-enabling blocking"
+          }
         }
       }
     },
@@ -777,6 +823,52 @@
     "validation_entries": [
       "python3 .loom/bin/loom_flow.py governance-profile status --target .",
       "python3 .loom/bin/loom_flow.py governance-profile upgrade-plan --target ."
-    ]
+    ],
+    "gate_rollout": {
+      "schema_version": "loom-adoption-gate-rollout/v1",
+      "default_mode": "advisory",
+      "current_mode": "advisory",
+      "recommended_mode": "advisory",
+      "allowed_modes": {
+        "advisory": {
+          "summary": "Default mode for newly adopted repositories; Loom reports gate signals without becoming the blocking authority.",
+          "blocking": false
+        },
+        "blocking": {
+          "summary": "Explicit opt-in mode for strong governance repositories after adversarial adoption checks pass.",
+          "blocking": true
+        },
+        "rollback": {
+          "summary": "Emergency switch back to advisory consumption when runtime, evidence, or host bindings drift.",
+          "blocking": false
+        }
+      },
+      "blocking_allowed": false,
+      "blocking_preconditions": [
+        {
+          "id": "strong_maturity",
+          "status": "missing",
+          "layer": "github-profile",
+          "recommended_action": "upgrade the repository to strong maturity before enabling blocking gates"
+        },
+        {
+          "id": "adversarial_adoption_checks",
+          "status": "missing",
+          "layer": "core",
+          "recommended_action": "run the Loom-owned Syvert-style adversarial adoption fixture and record the validation evidence"
+        },
+        {
+          "id": "rollback_switch",
+          "status": "pass",
+          "layer": "core",
+          "recommended_action": "keep rollback available by switching gate mode back to advisory and rerunning governance-profile status"
+        }
+      ],
+      "rollback": {
+        "mode": "rollback",
+        "switch_to": "advisory",
+        "recommended_action": "disable blocking consumption, preserve evidence, repair drift, then rerun adversarial adoption checks before re-enabling blocking"
+      }
+    }
   }
 }

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -35,7 +35,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "fc819d8172a1525c4fb86cbee680110c655101b6d6db7471a4d6c50d5c0bc1fc"
+      "sha256": "8fc0f350f55fa068b4b69854fb81f3b45fbace5bf384f900a63aeb9adfd87c1b"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -47,13 +47,13 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "d12f21d009a5127a4b0aba70bc23e111a51a490017879ee59d51c22db65b5f0a"
+      "sha256": "2f873ee4ddd170af4a835da24bafa59f6e5561ee74360faf71e98e8480100a72"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "b35e0e598743b84c21d8ec9b56ff0146a411c0aaf8c29a982d7a21d53044a808"
+      "sha256": "7d4f476d8117a6b9d264a71f8300f229bf511dd9e1fb2b29636990c16c6d197d"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "8a5c1ccde7193facdb348896a3dda9f19b42ea874da1c4744e402e07f951ba50"
+      "sha256": "1acd2461b1150b9d4c328571c849556e1b3b36dd9595254643aa046367b66009"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -252,6 +252,58 @@ MATURITY_REQUIRED_FIELDS = {
         },
     ],
 }
+ADOPTION_GATE_ROLLOUT_MODES = {
+    "advisory": {
+        "summary": "Default mode for newly adopted repositories; Loom reports gate signals without becoming the blocking authority.",
+        "blocking": False,
+    },
+    "blocking": {
+        "summary": "Explicit opt-in mode for strong governance repositories after adversarial adoption checks pass.",
+        "blocking": True,
+    },
+    "rollback": {
+        "summary": "Emergency switch back to advisory consumption when runtime, evidence, or host bindings drift.",
+        "blocking": False,
+    },
+}
+
+
+def adoption_gate_rollout_status(*, maturity_current: str) -> dict[str, Any]:
+    blocking_preconditions = [
+        {
+            "id": "strong_maturity",
+            "status": "pass" if maturity_current == "strong" else "missing",
+            "layer": "github-profile",
+            "recommended_action": "upgrade the repository to strong maturity before enabling blocking gates",
+        },
+        {
+            "id": "adversarial_adoption_checks",
+            "status": "missing",
+            "layer": "core",
+            "recommended_action": "run the Loom-owned Syvert-style adversarial adoption fixture and record the validation evidence",
+        },
+        {
+            "id": "rollback_switch",
+            "status": "pass",
+            "layer": "core",
+            "recommended_action": "keep rollback available by switching gate mode back to advisory and rerunning governance-profile status",
+        },
+    ]
+    blocking_allowed = all(entry["status"] == "pass" for entry in blocking_preconditions)
+    return {
+        "schema_version": "loom-adoption-gate-rollout/v1",
+        "default_mode": "advisory",
+        "current_mode": "advisory",
+        "recommended_mode": "blocking" if blocking_allowed else "advisory",
+        "allowed_modes": ADOPTION_GATE_ROLLOUT_MODES,
+        "blocking_allowed": blocking_allowed,
+        "blocking_preconditions": blocking_preconditions,
+        "rollback": {
+            "mode": "rollback",
+            "switch_to": "advisory",
+            "recommended_action": "disable blocking consumption, preserve evidence, repair drift, then rerun adversarial adoption checks before re-enabling blocking",
+        },
+    }
 
 
 def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -1209,6 +1261,7 @@ def maturity_status(
         "required_fields": MATURITY_REQUIRED_FIELDS,
         "missing_by_level": missing_by_level,
         "missing_details_by_level": missing_details_by_level,
+        "gate_rollout": adoption_gate_rollout_status(maturity_current=current),
     }
 
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -97,6 +97,7 @@ CORE_DOCS = (
     "docs/evidence/validations/validation-adoption-maturity-upgrade-automation.md",
     "docs/evidence/validations/validation-adoption-maturity-required-fields.md",
     "docs/evidence/validations/validation-skills-consume-maturity-upgrade-path.md",
+    "docs/evidence/validations/validation-adoption-gate-rollout.md",
     "docs/evidence/validations/validation-github-profile-binding-orchestration.md",
     "docs/evidence/validations/validation-github-profile-drift-reconciliation.md",
     "docs/evidence/validations/validation-github-profile-graphql-budget-guard.md",
@@ -857,6 +858,71 @@ def require_governance_control_plane(
         missing_details = maturity.get("missing_details_by_level")
         if not isinstance(missing_details, dict) or set(missing_details) != {"light", "standard", "strong"}:
             failures.append(Failure(category, f"{context}.maturity missing_details_by_level must define light, standard, and strong"))
+        require_adoption_gate_rollout_payload(
+            failures,
+            category=category,
+            context=f"{context}.maturity.gate_rollout",
+            payload=maturity.get("gate_rollout"),
+        )
+
+
+def require_adoption_gate_rollout_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != "loom-adoption-gate-rollout/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-adoption-gate-rollout/v1`"))
+    if payload.get("default_mode") != "advisory":
+        failures.append(Failure(category, f"{context} default_mode must remain advisory"))
+    if payload.get("current_mode") not in {"advisory", "blocking", "rollback"}:
+        failures.append(Failure(category, f"{context} current_mode must stay within advisory/blocking/rollback"))
+    if payload.get("recommended_mode") not in {"advisory", "blocking", "rollback"}:
+        failures.append(Failure(category, f"{context} recommended_mode must stay within advisory/blocking/rollback"))
+    if not isinstance(payload.get("blocking_allowed"), bool):
+        failures.append(Failure(category, f"{context} blocking_allowed must be boolean"))
+    modes = payload.get("allowed_modes")
+    if not isinstance(modes, dict) or set(modes) != {"advisory", "blocking", "rollback"}:
+        failures.append(Failure(category, f"{context} allowed_modes must define advisory, blocking, and rollback"))
+    else:
+        for mode, entry in modes.items():
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context}.allowed_modes.{mode} must be an object"))
+                continue
+            if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+                failures.append(Failure(category, f"{context}.allowed_modes.{mode} must include summary"))
+            if not isinstance(entry.get("blocking"), bool):
+                failures.append(Failure(category, f"{context}.allowed_modes.{mode} must include boolean blocking"))
+    preconditions = payload.get("blocking_preconditions")
+    if not isinstance(preconditions, list) or not preconditions:
+        failures.append(Failure(category, f"{context} blocking_preconditions must be non-empty"))
+    else:
+        ids = {entry.get("id") for entry in preconditions if isinstance(entry, dict)}
+        if not {"strong_maturity", "adversarial_adoption_checks", "rollback_switch"}.issubset(ids):
+            failures.append(Failure(category, f"{context} blocking_preconditions must include strong maturity, adversarial checks, and rollback switch"))
+        for entry in preconditions:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} blocking_preconditions entries must be objects"))
+                continue
+            if entry.get("status") not in {"pass", "missing", "block"}:
+                failures.append(Failure(category, f"{context} blocking precondition status must be stable"))
+            if entry.get("layer") not in {"core", "github-profile", "repo-owned-residue"}:
+                failures.append(Failure(category, f"{context} blocking precondition layer must be stable"))
+            if not isinstance(entry.get("recommended_action"), str) or not entry.get("recommended_action"):
+                failures.append(Failure(category, f"{context} blocking preconditions must include recommended_action"))
+    rollback = payload.get("rollback")
+    if not isinstance(rollback, dict):
+        failures.append(Failure(category, f"{context} rollback must be an object"))
+    else:
+        if rollback.get("mode") != "rollback" or rollback.get("switch_to") != "advisory":
+            failures.append(Failure(category, f"{context} rollback must switch back to advisory"))
+        if not isinstance(rollback.get("recommended_action"), str) or not rollback.get("recommended_action"):
+            failures.append(Failure(category, f"{context} rollback must include recommended_action"))
 
 
 def require_locator_entry(
@@ -1385,6 +1451,12 @@ def require_governance_upgrade_payload(
         failures.append(Failure(category, f"{context} target_maturity must be standard/strong"))
     if not isinstance(payload.get("dry_run"), bool):
         failures.append(Failure(category, f"{context} dry_run must be boolean"))
+    require_adoption_gate_rollout_payload(
+        failures,
+        category=category,
+        context=f"{context}.gate_rollout",
+        payload=payload.get("gate_rollout"),
+    )
     actions = payload.get("actions")
     if not isinstance(actions, list) or not actions:
         failures.append(Failure(category, f"{context} must include non-empty actions"))
@@ -1428,6 +1500,12 @@ def require_maturity_upgrade_path(
     validation_entries = payload.get("validation_entries")
     if not isinstance(validation_entries, list) or not validation_entries:
         failures.append(Failure(category, f"{context} validation_entries must be non-empty"))
+    require_adoption_gate_rollout_payload(
+        failures,
+        category=category,
+        context=f"{context}.gate_rollout",
+        payload=payload.get("gate_rollout"),
+    )
 
 
 def require_review_record_contract(

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -3672,6 +3672,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
 
     current = maturity.get("current")
     next_level = maturity.get("next")
+    gate_rollout = maturity.get("gate_rollout")
     missing_by_level = maturity.get("missing_by_level")
     missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs: list[Any] = []
@@ -3700,6 +3701,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
         "recommended_action": "run governance-profile upgrade --dry-run" if result == "block" else None,
         "fallback_to": None if result == "pass" else "adoption",
         "maturity": maturity,
+        "gate_rollout": gate_rollout,
         "governance_control_plane": control_plane,
     }
 
@@ -3845,6 +3847,7 @@ def governance_profile_upgrade_payload(
         "actions": actions,
         "written_files": written_files,
         "maturity": maturity,
+        "gate_rollout": maturity.get("gate_rollout") if isinstance(maturity, dict) else None,
     }
 
 
@@ -3864,6 +3867,7 @@ def maturity_upgrade_path(governance_surface: dict[str, Any], target_root: Path)
         }
     current = maturity.get("current")
     next_level = maturity.get("next")
+    gate_rollout = maturity.get("gate_rollout")
     missing_by_level = maturity.get("missing_by_level")
     missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs = []
@@ -3889,6 +3893,7 @@ def maturity_upgrade_path(governance_surface: dict[str, Any], target_root: Path)
             f"python3 tools/loom_flow.py governance-profile status --target {target_root}",
             f"python3 tools/loom_flow.py governance-profile upgrade-plan --target {target_root}",
         ],
+        "gate_rollout": gate_rollout,
     }
 
 

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -1066,6 +1066,7 @@ def init_maturity_upgrade_path(governance_surface: dict[str, object]) -> dict[st
             "validation_entries": [],
         }
     next_level = maturity.get("next")
+    gate_rollout = maturity.get("gate_rollout")
     missing_by_level = maturity.get("missing_by_level")
     missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs: list[object] = []
@@ -1091,6 +1092,7 @@ def init_maturity_upgrade_path(governance_surface: dict[str, object]) -> dict[st
             "python3 .loom/bin/loom_flow.py governance-profile status --target .",
             "python3 .loom/bin/loom_flow.py governance-profile upgrade-plan --target .",
         ],
+        "gate_rollout": gate_rollout,
     }
 
 


### PR DESCRIPTION
## Summary
- Adds machine-readable adoption gate rollout semantics to the governance maturity surface.
- Exposes advisory/blocking/rollback mode, blocking preconditions, and rollback guidance through governance-profile status/upgrade-plan/upgrade.
- Documents the default advisory policy and adds validation evidence.

## Validation
- python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py
- python3 tools/loom_check.py .
- make loom-check
- npm --prefix packages/loom-installer test

Closes #355