### PR TITLE
feat: 定义 external-runtime 与 de-vendor 迁移路径

### DIFF
--- a/docs/adoption/deep-existing-repo-default.md
+++ b/docs/adoption/deep-existing-repo-default.md
@@ -64,3 +64,16 @@
 - repo-native carriers 无法稳定承接 recovery / review / closeout 真相
 - companion 之外还需要 Loom-owned status surface 承接统一读面
 - repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity
+
+## 7. Attach-only 之后的 external runtime 路径
+
+成熟既有仓库第一轮可以继续提交 vendored `.loom/bin`，因为它提供可审计 runtime provenance。
+
+只有在以下条件满足后，才应考虑 de-vendor：
+
+- `.loom/companion` 与 `interop.json` 已稳定
+- `runtime-state`、`governance-profile status`、`runtime-parity validate`、`shadow-parity` 都能读取同一治理载体
+- external runtime locator 已按 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md) 版本化声明
+- rollback 能回到 vendored `.loom/bin` 或重新 bootstrap
+
+de-vendor 不得删除 repo-owned residue，也不得替代 guardian、integration contract、release / sprint 等仓库私有规则。

--- a/docs/adoption/external-runtime-companion-contract.md
+++ b/docs/adoption/external-runtime-companion-contract.md
@@ -1,0 +1,110 @@
+# External Runtime Companion Contract
+
+本文定义从 vendored `.loom/bin` runtime 迁移到 versioned external Loom runtime 的路径。
+
+本轮只冻结合同和迁移纪律，不要求任何 adopted repo 立即 de-vendor。
+
+## 1. 目标
+
+external-runtime 的目标是让成熟 adopted repo 最终可以：
+
+- 保留 `.loom/companion`、status、work item、review、shadow evidence 等仓内治理载体
+- 停止长期提交 vendored `.loom/bin/*` runtime 文件
+- 通过版本化 Loom runtime locator 执行同一组 Loom 命令
+- 在迁移失败时可回滚到 vendored `.loom/bin` carrier
+
+## 2. 当前默认
+
+当前稳定默认仍是 vendored `.loom/bin` runtime。
+
+原因：
+
+- `loom_init verify` 已经要求 `.loom/bin/*` 与 `.loom/bootstrap/manifest.json` 一致
+- manifest 中的 runtime artifact `sha256` 是当前 fail-closed trust boundary
+- Syvert-style strong adoption 仍需要本地可审计 runtime provenance
+
+因此，external-runtime 只是一条显式迁移路径，不是当前默认安装形态。
+
+## 3. Companion 保留面
+
+迁移到 external-runtime 时，以下仓内载体必须保持稳定，不得因为 runtime locator 改变而重写语义：
+
+- `.loom/companion/manifest.json`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/status/current.md`
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/reviews/*`
+- `.loom/shadow/*`
+
+这些文件继续是 repo-local governance carrier。external runtime 只能替换执行入口，不能替代仓内治理真相。
+
+## 4. External runtime locator
+
+external-runtime companion 必须显式声明 runtime locator，而不是依赖环境变量猜测。
+
+最小字段：
+
+```json
+{
+  "schema_version": "loom-external-runtime/v1",
+  "runtime_locator": "loom://github/MC-and-his-Agents/Loom@v1.3",
+  "runtime_version": "v1.3",
+  "fallback_runtime": ".loom/bin",
+  "companion_manifest": ".loom/companion/manifest.json",
+  "interop_contract": ".loom/companion/interop.json",
+  "rollback_mode": "vendored-runtime"
+}
+```
+
+稳定约束：
+
+- `runtime_locator` 必须是版本化 locator，不能是浮动 `main`
+- `fallback_runtime` 必须指向可恢复的 vendored `.loom/bin` 或明确声明需要 rebootstrap
+- `companion_manifest` 与 `interop_contract` 必须继续指向仓内相对路径
+- external-runtime 不得通过 `LOOM_SOURCE_REPO_ROOT` 覆盖 bootstrapped target runtime 的判定
+
+## 5. Migration sequence
+
+推荐迁移顺序：
+
+1. 保持 vendored `.loom/bin`，先确认 runtime provenance hash 全部通过
+2. 记录 external runtime locator 与版本
+3. 在 rehearsal 中运行：
+   - `runtime-state`
+   - `governance-profile status`
+   - `runtime-parity validate`
+   - `shadow-parity`
+   - `shadow-parity --blocking`，仅限显式 strong profile smoke
+4. 确认 `.loom/companion`、status、work item、review、shadow evidence 均未因 runtime locator 改变而漂移
+5. 只在以上检查通过后删除或停止提交 vendored `.loom/bin`
+
+## 6. Rollback
+
+任一条件失败时必须回滚到 vendored runtime 或 rebootstrap：
+
+- external runtime locator 不可解析
+- runtime version 与期望不一致
+- `.loom/companion` 或 `interop.json` 不可读
+- shadow evidence source hash 漂移
+- active item、review head binding 或 metadata parsing 出现不一致
+
+Rollback 操作必须：
+
+- 保留 evidence
+- 恢复 `.loom/bin` 或重新运行 `loom_init bootstrap --write --force --verify`
+- 回到 `advisory` gate rollout mode
+- 重新运行 adversarial adoption checks 后才允许恢复 blocking 消费
+
+## 7. 边界
+
+external-runtime 迁移不改变：
+
+- repo companion 的 repo-specific residue ownership
+- repo interop 的只读 locator 语义
+- host action ownership
+- review / merge-ready / closeout 的 gate 语义
+- shadow parity 默认 validation-only 的边界
+
+它只改变 Loom runtime 的执行来源。

--- a/docs/adoption/repo-companion-contract.md
+++ b/docs/adoption/repo-companion-contract.md
@@ -261,14 +261,17 @@
 - retained host action result 的 locator
 - repo-native carrier truth 的 locator
 - `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
 这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
 
 - 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
 - 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
 ### 4.5 `context_schema`
 

--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -230,6 +230,8 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
   - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
 - `interop.json`
   - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
 - [host-action-contract.md](../methodology/harness/host-action-contract.md)
   - 承接宿主动作 ownership、结果语义与 fallback discipline
 
@@ -237,5 +239,18 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
 
 - 不把 interop 细节塞回 `repo-interface.json`
 - 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
 - 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
 - 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/docs/evidence/validations/validation-external-runtime-devendor-migration.md
+++ b/docs/evidence/validations/validation-external-runtime-devendor-migration.md
@@ -1,0 +1,67 @@
+# Validation: external runtime de-vendor migration
+
+本记录证明 `#356` 只定义 external-runtime / de-vendor 路径，不把任何 adopted repo 默认切换到 external runtime。
+
+## Scope
+
+本轮冻结：
+
+- external-runtime companion contract
+- vendored `.loom/bin` 到 versioned external runtime 的迁移顺序
+- companion / interop / shadow evidence 在 runtime carrier 切换期间的保留边界
+- rollback 条件与 advisory fallback
+
+本轮不做：
+
+- 不删除任何下游仓库的 `.loom/bin`
+- 不把 external runtime 设成 Loom 默认 carrier
+- 不把 runtime locator 塞进 `repo-interface.json` 或 `interop.json`
+
+## Contract anchors
+
+必备合同：
+
+- `docs/adoption/external-runtime-companion-contract.md`
+- `docs/adoption/repo-interop-contract.md`
+- `docs/adoption/repo-companion-contract.md`
+- `skills/shared/references/harness/runtime-state.md`
+- `docs/adoption/deep-existing-repo-default.md`
+
+## Migration rule
+
+迁移必须保留：
+
+- `.loom/companion/manifest.json`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/status/current.md`
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/reviews/*`
+- `.loom/shadow/*`
+
+external runtime 只替换执行入口，不替换治理真相源。
+
+## Rollback rule
+
+以下任一失败必须回到 vendored runtime 或 rebootstrap：
+
+- external runtime locator 不可解析
+- runtime version 不匹配
+- companion / interop 不可读
+- shadow evidence hash 漂移
+- active item、review head binding 或 metadata parsing 不一致
+
+Rollback 后 gate rollout 必须回到 `advisory`，并保留 evidence。
+
+## Validation commands
+
+```bash
+python3 tools/loom_check.py .
+python3 tools/loom_flow.py governance-profile status --target examples/new-project
+python3 examples/new-project/.loom/bin/loom_init.py runtime-state --target examples/new-project
+```
+
+## Result
+
+`loom_check` 现在要求 external-runtime / de-vendor contract 与 validation evidence 存在，并检查这些文档包含 runtime locator、vendored fallback、repo interop 边界和 rollback 语义。

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "1acd2461b1150b9d4c328571c849556e1b3b36dd9595254643aa046367b66009"
+      "sha256": "8a5ee386532ac7772563ced89cb644ffb1eb00087d7c77ee1a661de88ce717b3"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-355-adoption-gate-rollout",
+            "locator": "issue-356-external-runtime-devendor",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "1acd2461b1150b9d4c328571c849556e1b3b36dd9595254643aa046367b66009"
+      "sha256": "8a5ee386532ac7772563ced89cb644ffb1eb00087d7c77ee1a661de88ce717b3"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.27",
+      "version": "0.1.28",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/references/adoption/deep-existing-repo-default.md
+++ b/skills/shared/references/adoption/deep-existing-repo-default.md
@@ -2,14 +2,14 @@
 
 本文件定义 Loom 面向成熟既有治理重仓的默认接入策略。
 
-它不替代 `lightweight-retrofit-default`，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
+它不替代 [lightweight-retrofit-default.md](./lightweight-retrofit-default.md)，而是作为 `complex-existing` 下的保守 attach path，服务已经拥有稳定根规则、统一验证入口与沉重 repo-specific gates 的仓库。
 
 ## 1. 适用场景
 
 当目标仓库同时满足以下条件时，默认采用本策略：
 
-- 属于既有仓库，且 `loom-init` 判断仍为 `复杂既有仓库`
-- 已有清晰的根级边界文档
+- 属于既有仓库，且 `loom-init` 判断仍为 `complex-existing`
+- 已有清晰的根级边界文档，例如 `AGENTS.md`、`WORKFLOW.md` 或等价根规则
 - 已有统一的仓库级验证入口
 - 已出现 `merge_review_semantic_overload`
 - 当前复杂度主要来自 review / guardian 负载、repo-specific gates、retained host actions 或 repo-native carriers，而不是 Loom 缺少 recovery/status carriers
@@ -44,6 +44,8 @@
 - 保留 repo-native carriers
 - 只追加 Loom-owned attach metadata 与 companion 入口
 
+换句话说，Loom 这一步接管的是入口与读面，不是宿主动作底层实现。
+
 ## 5. 默认不装配
 
 第一轮默认不装配：
@@ -60,5 +62,18 @@
 
 - 当前仓库需要 Loom-owned recovery carrier 承接多轮执行停点
 - repo-native carriers 无法稳定承接 recovery / review / closeout 真相
-- companion 之外还需要 Loom-owned `status control plane` 承接统一读面
+- companion 之外还需要 Loom-owned status surface 承接统一读面
 - repo-local attach 入口已经稳定，但下一轮需要 typed machine contract、interop 或 shadow parity
+
+## 7. Attach-only 之后的 external runtime 路径
+
+成熟既有仓库第一轮可以继续提交 vendored `.loom/bin`，因为它提供可审计 runtime provenance。
+
+只有在以下条件满足后，才应考虑 de-vendor：
+
+- `.loom/companion` 与 `interop.json` 已稳定
+- `runtime-state`、`governance-profile status`、`runtime-parity validate`、`shadow-parity` 都能读取同一治理载体
+- external runtime locator 已按 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md) 版本化声明
+- rollback 能回到 vendored `.loom/bin` 或重新 bootstrap
+
+de-vendor 不得删除 repo-owned residue，也不得替代 guardian、integration contract、release / sprint 等仓库私有规则。

--- a/skills/shared/references/adoption/external-runtime-companion-contract.md
+++ b/skills/shared/references/adoption/external-runtime-companion-contract.md
@@ -1,0 +1,110 @@
+# External Runtime Companion Contract
+
+本文定义从 vendored `.loom/bin` runtime 迁移到 versioned external Loom runtime 的路径。
+
+本轮只冻结合同和迁移纪律，不要求任何 adopted repo 立即 de-vendor。
+
+## 1. 目标
+
+external-runtime 的目标是让成熟 adopted repo 最终可以：
+
+- 保留 `.loom/companion`、status、work item、review、shadow evidence 等仓内治理载体
+- 停止长期提交 vendored `.loom/bin/*` runtime 文件
+- 通过版本化 Loom runtime locator 执行同一组 Loom 命令
+- 在迁移失败时可回滚到 vendored `.loom/bin` carrier
+
+## 2. 当前默认
+
+当前稳定默认仍是 vendored `.loom/bin` runtime。
+
+原因：
+
+- `loom_init verify` 已经要求 `.loom/bin/*` 与 `.loom/bootstrap/manifest.json` 一致
+- manifest 中的 runtime artifact `sha256` 是当前 fail-closed trust boundary
+- Syvert-style strong adoption 仍需要本地可审计 runtime provenance
+
+因此，external-runtime 只是一条显式迁移路径，不是当前默认安装形态。
+
+## 3. Companion 保留面
+
+迁移到 external-runtime 时，以下仓内载体必须保持稳定，不得因为 runtime locator 改变而重写语义：
+
+- `.loom/companion/manifest.json`
+- `.loom/companion/repo-interface.json`
+- `.loom/companion/interop.json`
+- `.loom/status/current.md`
+- `.loom/work-items/*`
+- `.loom/progress/*`
+- `.loom/reviews/*`
+- `.loom/shadow/*`
+
+这些文件继续是 repo-local governance carrier。external runtime 只能替换执行入口，不能替代仓内治理真相。
+
+## 4. External runtime locator
+
+external-runtime companion 必须显式声明 runtime locator，而不是依赖环境变量猜测。
+
+最小字段：
+
+```json
+{
+  "schema_version": "loom-external-runtime/v1",
+  "runtime_locator": "loom://github/MC-and-his-Agents/Loom@v1.3",
+  "runtime_version": "v1.3",
+  "fallback_runtime": ".loom/bin",
+  "companion_manifest": ".loom/companion/manifest.json",
+  "interop_contract": ".loom/companion/interop.json",
+  "rollback_mode": "vendored-runtime"
+}
+```
+
+稳定约束：
+
+- `runtime_locator` 必须是版本化 locator，不能是浮动 `main`
+- `fallback_runtime` 必须指向可恢复的 vendored `.loom/bin` 或明确声明需要 rebootstrap
+- `companion_manifest` 与 `interop_contract` 必须继续指向仓内相对路径
+- external-runtime 不得通过 `LOOM_SOURCE_REPO_ROOT` 覆盖 bootstrapped target runtime 的判定
+
+## 5. Migration sequence
+
+推荐迁移顺序：
+
+1. 保持 vendored `.loom/bin`，先确认 runtime provenance hash 全部通过
+2. 记录 external runtime locator 与版本
+3. 在 rehearsal 中运行：
+   - `runtime-state`
+   - `governance-profile status`
+   - `runtime-parity validate`
+   - `shadow-parity`
+   - `shadow-parity --blocking`，仅限显式 strong profile smoke
+4. 确认 `.loom/companion`、status、work item、review、shadow evidence 均未因 runtime locator 改变而漂移
+5. 只在以上检查通过后删除或停止提交 vendored `.loom/bin`
+
+## 6. Rollback
+
+任一条件失败时必须回滚到 vendored runtime 或 rebootstrap：
+
+- external runtime locator 不可解析
+- runtime version 与期望不一致
+- `.loom/companion` 或 `interop.json` 不可读
+- shadow evidence source hash 漂移
+- active item、review head binding 或 metadata parsing 出现不一致
+
+Rollback 操作必须：
+
+- 保留 evidence
+- 恢复 `.loom/bin` 或重新运行 `loom_init bootstrap --write --force --verify`
+- 回到 `advisory` gate rollout mode
+- 重新运行 adversarial adoption checks 后才允许恢复 blocking 消费
+
+## 7. 边界
+
+external-runtime 迁移不改变：
+
+- repo companion 的 repo-specific residue ownership
+- repo interop 的只读 locator 语义
+- host action ownership
+- review / merge-ready / closeout 的 gate 语义
+- shadow parity 默认 validation-only 的边界
+
+它只改变 Loom runtime 的执行来源。

--- a/skills/shared/references/harness/runtime-state.md
+++ b/skills/shared/references/harness/runtime-state.md
@@ -101,3 +101,17 @@
   - 回答仓库 Loom 装配态与治理载体/宿主控制面的落位
 
 这三者不得互相伪装成别名。
+
+## 7. Carrier transition invariants
+
+从 vendored `.loom/bin` runtime 迁移到 external runtime 时，`runtime-state` 必须保持 fail-closed：
+
+- bootstrapped target runtime 优先由当前入口路径和 `.loom/bootstrap/manifest.json` 判定
+- 外部 `LOOM_SOURCE_REPO_ROOT` 不得抢先改判 bootstrapped target runtime
+- `.loom/bootstrap/manifest.json` 中声明的 `.loom/bin/*` artifact 必须继续有 `sha256`
+- 若 vendored runtime 被删除，external runtime 必须提供 versioned runtime locator 和 rollback path
+- external runtime rehearsal 不得改写 `.loom/companion`、status、work item、review 或 shadow evidence 的 truth
+
+当前默认 carrier 仍是 vendored `.loom/bin`。external runtime 只能作为显式迁移目标，不能通过环境变量隐式启用。
+
+迁移合同见 [external-runtime-companion-contract.md](../adoption/external-runtime-companion-contract.md)。

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -98,6 +98,7 @@ CORE_DOCS = (
     "docs/evidence/validations/validation-adoption-maturity-required-fields.md",
     "docs/evidence/validations/validation-skills-consume-maturity-upgrade-path.md",
     "docs/evidence/validations/validation-adoption-gate-rollout.md",
+    "docs/evidence/validations/validation-external-runtime-devendor-migration.md",
     "docs/evidence/validations/validation-github-profile-binding-orchestration.md",
     "docs/evidence/validations/validation-github-profile-drift-reconciliation.md",
     "docs/evidence/validations/validation-github-profile-graphql-budget-guard.md",
@@ -111,6 +112,7 @@ CORE_DOCS = (
     "docs/adoption/routing-and-checkpoints.md",
     "docs/adoption/github-profile.md",
     "docs/adoption/github-profile-upgrade.md",
+    "docs/adoption/external-runtime-companion-contract.md",
     "docs/adoption/lightweight-retrofit-default.md",
     "docs/adoption/repo-companion-contract.md",
     "docs/adoption/repo-interop-contract.md",
@@ -6028,6 +6030,53 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
     return failures
 
 
+def check_external_runtime_devendor_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/adoption/external-runtime-companion-contract.md": [
+            "vendored `.loom/bin`",
+            "runtime_locator",
+            "versioned external Loom runtime",
+            "rollback",
+            ".loom/companion/interop.json",
+        ],
+        "docs/adoption/repo-interop-contract.md": [
+            "external-runtime",
+            "de-vendor",
+            "runtime locator",
+            "interop",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "external-runtime",
+            "runtime locator",
+            "repo-interface.json",
+        ],
+        "skills/shared/references/harness/runtime-state.md": [
+            "Carrier transition invariants",
+            "LOOM_SOURCE_REPO_ROOT",
+            "external runtime",
+            "vendored `.loom/bin`",
+        ],
+        "docs/evidence/validations/validation-external-runtime-devendor-migration.md": [
+            "external-runtime",
+            "de-vendor",
+            "rollback",
+            "advisory",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("external-runtime-devendor", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("external-runtime-devendor", f"`{relative}` must mention `{anchor}`"))
+    return failures
+
+
 def check_node_installer(root: Path) -> list[Failure]:
     category = "node-installer"
     failures: list[Failure] = []
@@ -6139,6 +6188,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_daily_execution_cli(root))
     failures.extend(check_repo_companion_interface_contracts(root))
     failures.extend(check_repo_interop_contracts(root))
+    failures.extend(check_external_runtime_devendor_contract(root))
     failures.extend(check_node_installer(root))
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))


### PR DESCRIPTION
## Summary
- Adds the external-runtime companion contract for migrating from vendored `.loom/bin` to a versioned external Loom runtime.
- Freezes companion/interop/shadow evidence preservation and rollback boundaries.
- Adds loom_check anchors so de-vendor guidance remains version-controlled and checked.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`

Closes #356