### PR TITLE
feat(runtime): harden repo-relative carrier path boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ go.work.sum
 plugins/loom/
 packages/skills/
 packages/loom-installer/payload/
+.worktrees/

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -113,25 +113,25 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "8fc0f350f55fa068b4b69854fb81f3b45fbace5bf384f900a63aeb9adfd87c1b"
+      "sha256": "059440a394dd4e92356addeab830f536497e0180d85e0be053e56442594410af"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "0e215e1c83443c8688c984241a8008e5b419f68b8838eecbcfb695857e212923"
+      "sha256": "406352215e9ff1c582d750761b911bd227c99b3cc29d3710143554ced7f9e080"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "2f873ee4ddd170af4a835da24bafa59f6e5561ee74360faf71e98e8480100a72"
+      "sha256": "82109bad507ea760c7df3a401b648b34c35da03f8f85eb40481834e44b29ed0f"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "7d4f476d8117a6b9d264a71f8300f229bf511dd9e1fb2b29636990c16c6d197d"
+      "sha256": "e5ff7344c5d62306ee30254113538739137a175350847ed51e9fff8270c77505"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "17fae648df2977fddfed4c7d1dc2ec1fef648799fbfd73ba8fa36cfd73b8e925"
+      "sha256": "7cb6094384b6d6c6ad1842e9197e9d1211230adbae068f524ea1c8360bc87712"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-357-syvert-adversarial-fixture",
+            "locator": "issue-368-path-boundary-hardening",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -35,25 +35,25 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "8fc0f350f55fa068b4b69854fb81f3b45fbace5bf384f900a63aeb9adfd87c1b"
+      "sha256": "059440a394dd4e92356addeab830f536497e0180d85e0be053e56442594410af"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "0e215e1c83443c8688c984241a8008e5b419f68b8838eecbcfb695857e212923"
+      "sha256": "406352215e9ff1c582d750761b911bd227c99b3cc29d3710143554ced7f9e080"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "2f873ee4ddd170af4a835da24bafa59f6e5561ee74360faf71e98e8480100a72"
+      "sha256": "82109bad507ea760c7df3a401b648b34c35da03f8f85eb40481834e44b29ed0f"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "7d4f476d8117a6b9d264a71f8300f229bf511dd9e1fb2b29636990c16c6d197d"
+      "sha256": "e5ff7344c5d62306ee30254113538739137a175350847ed51e9fff8270c77505"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "17fae648df2977fddfed4c7d1dc2ec1fef648799fbfd73ba8fa36cfd73b8e925"
+      "sha256": "7cb6094384b6d6c6ad1842e9197e9d1211230adbae068f524ea1c8360bc87712"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/fact_chain_support.py
+++ b/skills/shared/scripts/fact_chain_support.py
@@ -183,7 +183,25 @@ def parse_list_section(sections: dict[str, list[str]], section_name: str, relati
 
 
 def _relative(path: Path, root: Path) -> str:
-    return str(path.relative_to(root))
+    return str(path.resolve().relative_to(root.resolve()))
+
+
+def resolve_repo_relative_path(target_root: Path, relative: str, *, label: str) -> tuple[Path | None, list[str]]:
+    """Resolve a repository locator while rejecting absolute paths and path escapes."""
+    if not isinstance(relative, str) or not relative.strip():
+        return None, [f"{label} must be a non-empty repo-relative path"]
+    locator = relative.strip()
+    candidate_raw = Path(locator)
+    if candidate_raw.is_absolute():
+        return None, [f"{label} must be repo-relative, got absolute path: {locator}"]
+    if ".." in candidate_raw.parts:
+        return None, [f"{label} must stay inside the target repository: {locator}"]
+    candidate = (target_root / candidate_raw).resolve()
+    try:
+        candidate.relative_to(target_root.resolve())
+    except ValueError:
+        return None, [f"{label} must stay inside the target repository: {locator}"]
+    return candidate, []
 
 
 def parse_work_item(path: Path, root: Path) -> tuple[dict[str, object], list[str]]:
@@ -301,7 +319,10 @@ def inspect_fact_chain(
     output_relative: str = ".loom/bootstrap/init-result.json",
 ) -> tuple[dict[str, object], list[str]]:
     errors: list[str] = []
-    output_path = target_root / output_relative
+    output_path, output_errors = resolve_repo_relative_path(target_root, output_relative, label="init-result locator")
+    if output_errors:
+        return {}, output_errors
+    assert output_path is not None
     if not output_path.exists():
         return {}, [f"missing init-result: {output_relative}"]
 
@@ -346,9 +367,29 @@ def inspect_fact_chain(
     if errors:
         return {}, errors
 
-    work_item_path = target_root / str(work_item_ref)
-    recovery_path = target_root / str(recovery_ref)
-    status_path = target_root / str(status_ref)
+    work_item_path, work_item_path_errors = resolve_repo_relative_path(
+        target_root,
+        str(work_item_ref),
+        label="init-result.fact_chain.entry_points.work_item",
+    )
+    recovery_path, recovery_path_errors = resolve_repo_relative_path(
+        target_root,
+        str(recovery_ref),
+        label="init-result.fact_chain.entry_points.recovery_entry",
+    )
+    status_path, status_path_errors = resolve_repo_relative_path(
+        target_root,
+        str(status_ref),
+        label="init-result.fact_chain.entry_points.status_surface",
+    )
+    errors.extend(work_item_path_errors)
+    errors.extend(recovery_path_errors)
+    errors.extend(status_path_errors)
+    if errors:
+        return {}, errors
+    assert work_item_path is not None
+    assert recovery_path is not None
+    assert status_path is not None
     for label, path in (
         ("work_item", work_item_path),
         ("recovery_entry", recovery_path),

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -468,10 +468,9 @@ def relative_locator_from_value(root: Path, raw_locator: object) -> str | None:
         return None
     locator_path = Path(locator)
     if locator_path.is_absolute():
-        try:
-            return str(locator_path.relative_to(root))
-        except ValueError:
-            return str(locator_path)
+        return None
+    if ".." in locator_path.parts:
+        return None
     return str(locator_path)
 
 
@@ -479,7 +478,12 @@ def resolve_locator(root: Path, raw_locator: object) -> tuple[str | None, Path |
     locator = relative_locator_from_value(root, raw_locator)
     if locator is None:
         return None, None
-    return locator, (root / locator).resolve()
+    target = (root / locator).resolve()
+    try:
+        target.relative_to(root.resolve())
+    except ValueError:
+        return None, None
+    return locator, target
 
 
 def locator_status_entry(

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -272,6 +272,7 @@ def check_required_paths(root: Path, category: str, paths: tuple[str, ...]) -> l
 def iter_markdown_files(root: Path) -> list[Path]:
     skipped_parts = {
         ".git",
+        ".worktrees",
         "node_modules",
         "dist",
         "payload",
@@ -6336,6 +6337,66 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 failures.append(Failure("adversarial-adoption", f"`{label}` baseline failed: {error}"))
             elif payload.get("result") != expected:
                 failures.append(Failure("adversarial-adoption", f"`{label}` baseline must return `{expected}`"))
+
+        path_escape_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(baseline), "--output", "../outside-init-result.json"],
+        )
+        if error:
+            failures.append(Failure("adversarial-adoption", f"path escape fact-chain sample failed: {error}"))
+        elif path_escape_payload.get("result") != "block":
+            failures.append(Failure("adversarial-adoption", "fact-chain must block init-result locators that escape the target root"))
+
+        escape_work_item_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "work-item",
+                "create",
+                "--target",
+                str(baseline),
+                "--item",
+                "ESCAPE-0001",
+                "--goal",
+                "Reject path escape",
+                "--scope",
+                "Exercise repo-relative locator hardening",
+                "--execution-path",
+                "execution/support",
+                "--workspace-entry",
+                ".",
+                "--validation-entry",
+                "python3 .loom/bin/loom_init.py verify --target .",
+                "--closing-condition",
+                "Unsafe locators are blocked.",
+                "--recovery-entry",
+                "../escape.md",
+                "--init-recovery",
+            ],
+        )
+        if error:
+            failures.append(Failure("adversarial-adoption", f"path escape work-item sample failed: {error}"))
+        elif escape_work_item_payload.get("result") != "block":
+            failures.append(Failure("adversarial-adoption", "work-item create must block recovery locators that escape the target root"))
+
+        shadow_escape_target = base / "shadow-locator-escape"
+        shutil.copytree(baseline, shadow_escape_target)
+        interop_path = shadow_escape_target / ".loom/companion/interop.json"
+        interop_payload = load_json_file(interop_path)
+        shadow_surfaces = interop_payload.get("shadow_surfaces") if isinstance(interop_payload, dict) else None
+        review_surface = shadow_surfaces.get("review") if isinstance(shadow_surfaces, dict) else None
+        if isinstance(review_surface, dict):
+            review_surface["loom_locator"] = "/tmp/outside-shadow-evidence.json"
+            write_json(interop_path, interop_payload)
+        shadow_escape_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(shadow_escape_target), "--surface", "review", "--blocking"],
+        )
+        if error:
+            failures.append(Failure("adversarial-adoption", f"path escape shadow-parity sample failed: {error}"))
+        elif shadow_escape_payload.get("result") != "block":
+            failures.append(Failure("adversarial-adoption", "shadow-parity blocking mode must reject absolute shadow locators"))
 
         poisoned_payload, error = load_command_json(
             root,

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -24,6 +24,7 @@ from fact_chain_support import (
     parse_key_value_section,
     parse_recovery_entry,
     parse_work_item,
+    resolve_repo_relative_path,
 )
 from governance_surface import build_governance_surface
 from runtime_paths import shared_asset, shared_script
@@ -440,7 +441,20 @@ def repo_specific_requirements_payload(
         if isinstance(repo_specific_locator, dict)
         else ".loom/companion/repo-interface.json"
     )
-    repo_specific_path = target_root / str(declared_locator)
+    repo_specific_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        str(declared_locator),
+        label="repo companion requirements locator",
+    )
+    if locator_errors:
+        return {
+            **empty_payload,
+            "result": "block",
+            "summary": "repo companion requirements locator is unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": repo_specific_default_fallback(surface),
+        }
+    assert repo_specific_path is not None
     blocking: list[dict[str, Any]] = []
     advisory: list[dict[str, Any]] = []
     declared: list[dict[str, Any]] = []
@@ -522,7 +536,14 @@ def load_repo_interop_contract(repo_interop: object, *, target_root: Path) -> tu
         if isinstance(contract_locator, dict)
         else ".loom/companion/interop.json"
     )
-    interop_path = target_root / str(declared_locator)
+    interop_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        str(declared_locator),
+        label="repo interop contract locator",
+    )
+    if locator_errors:
+        return None, locator_errors
+    assert interop_path is not None
     try:
         payload = load_json_file(interop_path)
     except (FileNotFoundError, json.JSONDecodeError, OSError):
@@ -541,12 +562,8 @@ def sha256_file(path: Path) -> str:
 
 
 def repo_relative_path(target_root: Path, relative: str) -> Path | None:
-    candidate = (target_root / relative).resolve()
-    try:
-        candidate.relative_to(target_root.resolve())
-    except ValueError:
-        return None
-    return candidate
+    candidate, errors = resolve_repo_relative_path(target_root, relative, label="repo locator")
+    return None if errors else candidate
 
 
 def validate_shadow_sources(payload: dict[str, Any], *, path: Path, target_root: Path) -> tuple[dict[str, Any], list[str]]:
@@ -726,8 +743,26 @@ def shadow_parity_report(
 
     loom_locator = declared_surface.get("loom_locator")
     repo_locator = declared_surface.get("repo_locator")
-    loom_path = target_root / str(loom_locator)
-    repo_path = target_root / str(repo_locator)
+    loom_path, loom_locator_errors = resolve_repo_relative_path(
+        target_root,
+        str(loom_locator),
+        label=f"shadow surface `{surface}` loom_locator",
+    )
+    repo_path, repo_locator_errors = resolve_repo_relative_path(
+        target_root,
+        str(repo_locator),
+        label=f"shadow surface `{surface}` repo_locator",
+    )
+    if loom_locator_errors or repo_locator_errors:
+        return {
+            **empty_report,
+            "summary": "shadow parity is unavailable because a declared surface locator is unsafe.",
+            "missing_inputs": [*loom_locator_errors, *repo_locator_errors],
+            "host_adapters": relevant_host_adapters,
+            "repo_native_carriers": relevant_repo_native_carriers,
+        }
+    assert loom_path is not None
+    assert repo_path is not None
 
     loom_surface = {
         "status": "missing",
@@ -1166,7 +1201,10 @@ def render_status_surface(report: dict[str, Any], runtime_evidence: dict[str, di
 
 
 def sync_status_surface(target_root: Path, output_relative: str, runtime_evidence: dict[str, dict[str, Any]]) -> tuple[dict[str, Any], list[str]]:
-    output_path = target_root / output_relative
+    output_path, output_errors = resolve_repo_relative_path(target_root, output_relative, label="init-result locator")
+    if output_errors:
+        return {}, output_errors
+    assert output_path is not None
     try:
         init_result = load_json_file(output_path)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
@@ -1182,9 +1220,15 @@ def sync_status_surface(target_root: Path, output_relative: str, runtime_evidenc
     work_item_ref = str(entry_points.get("work_item", ""))
     recovery_ref = str(entry_points.get("recovery_entry", ""))
     status_ref = str(entry_points.get("status_surface", ""))
-    work_item_path = target_root / work_item_ref
-    recovery_path = target_root / recovery_ref
-    status_path = target_root / status_ref
+    work_item_path, work_item_errors = resolve_repo_relative_path(target_root, work_item_ref, label="work item locator")
+    recovery_path, recovery_errors = resolve_repo_relative_path(target_root, recovery_ref, label="recovery entry locator")
+    status_path, status_errors = resolve_repo_relative_path(target_root, status_ref, label="status surface locator")
+    locator_errors = [*work_item_errors, *recovery_errors, *status_errors]
+    if locator_errors:
+        return {}, locator_errors
+    assert work_item_path is not None
+    assert recovery_path is not None
+    assert status_path is not None
     if not work_item_path.exists() or not recovery_path.exists():
         return {}, ["fact-chain carrier is missing during status sync"]
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
@@ -1228,7 +1272,10 @@ def sync_status_surface(target_root: Path, output_relative: str, runtime_evidenc
 
 
 def read_runtime_evidence(target_root: Path, status_relative: str) -> tuple[dict[str, dict[str, Any]], list[str]]:
-    status_path = target_root / status_relative
+    status_path, locator_errors = resolve_repo_relative_path(target_root, status_relative, label="status surface locator")
+    if locator_errors:
+        return {}, locator_errors
+    assert status_path is not None
     if not status_path.exists():
         return {}, [f"missing status surface: {status_relative}"]
     sections = markdown_sections(status_path)
@@ -1690,10 +1737,10 @@ def target_relative_label(target_root: Path, path: Path) -> str:
 
 
 def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict[str, Any]] | None, list[str]]:
-    findings_path = Path(findings_file).expanduser()
-    if not findings_path.is_absolute():
-        findings_path = (target_root / findings_path).resolve()
-
+    findings_path, locator_errors = resolve_repo_relative_path(target_root, findings_file, label="findings file locator")
+    if locator_errors:
+        return None, locator_errors
+    assert findings_path is not None
     label = target_relative_label(target_root, findings_path)
     try:
         payload = json.loads(findings_path.read_text(encoding="utf-8"))
@@ -1715,7 +1762,10 @@ def load_review_record(
     review_file: str | None = None,
 ) -> tuple[dict[str, Any] | None, str, list[str]]:
     relative = review_file or default_review_path(item_id)
-    review_path = target_root / relative
+    review_path, locator_errors = resolve_repo_relative_path(target_root, relative, label="review artifact locator")
+    if locator_errors:
+        return None, relative, locator_errors
+    assert review_path is not None
     if not review_path.exists():
         return None, relative, []
     try:
@@ -2322,7 +2372,14 @@ def active_workspace_conflicts(target_root: Path, item_id: str, workspace_entry:
         if str(parsed_item["workspace_entry"]) != workspace_entry:
             continue
         recovery_rel = str(parsed_item["recovery_entry"])
-        recovery_path = target_root / recovery_rel
+        recovery_path, recovery_errors = resolve_repo_relative_path(
+            target_root,
+            recovery_rel,
+            label="work item recovery entry locator",
+        )
+        if recovery_errors or recovery_path is None:
+            conflicts.append(other_item_id)
+            continue
         if not recovery_path.exists():
             conflicts.append(other_item_id)
             continue
@@ -2445,14 +2502,36 @@ def load_context(target_root: Path, output_relative: str, expected_item: str | N
     if workspace_path is None:
         return {}, [f"unable to resolve workspace entry: {workspace_entry}"]
 
+    work_item_path, work_item_errors = resolve_repo_relative_path(
+        target_root,
+        str(report["fact_chain"]["entry_points"]["work_item"]),
+        label="work item locator",
+    )
+    recovery_path, recovery_errors = resolve_repo_relative_path(
+        target_root,
+        str(report["fact_chain"]["entry_points"]["recovery_entry"]),
+        label="recovery entry locator",
+    )
+    status_path, status_errors = resolve_repo_relative_path(
+        target_root,
+        str(report["fact_chain"]["entry_points"]["status_surface"]),
+        label="status surface locator",
+    )
+    locator_errors = [*work_item_errors, *recovery_errors, *status_errors]
+    if locator_errors:
+        return {}, locator_errors
+    assert work_item_path is not None
+    assert recovery_path is not None
+    assert status_path is not None
+
     context = {
         "target_root": target_root,
         "output_relative": output_relative,
         "report": report,
         "item_id": item_id,
-        "work_item_path": target_root / report["fact_chain"]["entry_points"]["work_item"],
-        "recovery_path": target_root / report["fact_chain"]["entry_points"]["recovery_entry"],
-        "status_path": target_root / report["fact_chain"]["entry_points"]["status_surface"],
+        "work_item_path": work_item_path,
+        "recovery_path": recovery_path,
+        "status_path": status_path,
         "workspace_entry": workspace_entry,
         "workspace_path": workspace_path,
         "validation_entry": str(facts["validation_entry"]["value"]),
@@ -2659,7 +2738,10 @@ def load_fact_chain_report(target_root: Path, output_relative: str) -> tuple[dic
 
 def inspect_fact_chain_legacy(target_root: Path, output_relative: str) -> tuple[dict[str, Any], list[str]]:
     errors: list[str] = []
-    output_path = target_root / output_relative
+    output_path, output_errors = resolve_repo_relative_path(target_root, output_relative, label="init-result locator")
+    if output_errors:
+        return {}, output_errors
+    assert output_path is not None
     if not output_path.exists():
         return {}, [f"missing init-result: {output_relative}"]
 
@@ -2698,9 +2780,17 @@ def inspect_fact_chain_legacy(target_root: Path, output_relative: str) -> tuple[
     if errors:
         return {}, errors
 
-    work_item_path = target_root / str(work_item_ref)
-    recovery_path = target_root / str(recovery_ref)
-    status_path = target_root / str(status_ref)
+    work_item_path, work_item_path_errors = resolve_repo_relative_path(target_root, str(work_item_ref), label="work item locator")
+    recovery_path, recovery_path_errors = resolve_repo_relative_path(target_root, str(recovery_ref), label="recovery entry locator")
+    status_path, status_path_errors = resolve_repo_relative_path(target_root, str(status_ref), label="status surface locator")
+    errors.extend(work_item_path_errors)
+    errors.extend(recovery_path_errors)
+    errors.extend(status_path_errors)
+    if errors:
+        return {}, errors
+    assert work_item_path is not None
+    assert recovery_path is not None
+    assert status_path is not None
     for label, path in (
         ("work_item", work_item_path),
         ("recovery_entry", recovery_path),
@@ -5991,7 +6081,19 @@ def handle_review(args: argparse.Namespace) -> int:
             "normalized_findings": args.normalized_findings,
         },
     }
-    review_abs = target_root / review_path
+    review_abs, review_path_errors = resolve_repo_relative_path(target_root, review_path, label="review artifact locator")
+    if review_path_errors:
+        return emit(
+            {
+                "command": "review",
+                "operation": "record",
+                "result": "block",
+                "summary": "review record refused an unsafe review artifact locator.",
+                "missing_inputs": review_path_errors,
+                "fallback_to": "build",
+            }
+        )
+    assert review_abs is not None
     review_abs.parent.mkdir(parents=True, exist_ok=True)
     write_json_file(review_abs, review_payload)
 
@@ -6124,7 +6226,10 @@ def update_active_entry_points(
     recovery_entry: str,
     status_surface: str,
 ) -> None:
-    output_path = target_root / output_relative
+    output_path, output_errors = resolve_repo_relative_path(target_root, output_relative, label="init-result locator")
+    if output_errors:
+        raise RuntimeError("; ".join(output_errors))
+    assert output_path is not None
     payload = load_json_file(output_path)
     fact_chain = payload.get("fact_chain")
     if not isinstance(fact_chain, dict):
@@ -6141,7 +6246,19 @@ def update_active_entry_points(
 
 def handle_work_item(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
-    output_path = target_root / args.output
+    output_path, output_errors = resolve_repo_relative_path(target_root, args.output, label="init-result locator")
+    if output_errors:
+        return emit(
+            {
+                "command": "work-item",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "work-item command requires a safe init-result fact-chain locator.",
+                "missing_inputs": output_errors,
+                "fallback_to": "admission",
+            }
+        )
+    assert output_path is not None
     if not output_path.exists():
         return emit(
             {
@@ -6155,11 +6272,37 @@ def handle_work_item(args: argparse.Namespace) -> int:
         )
 
     work_item_relative = f".loom/work-items/{args.item}.md"
-    work_item_path = target_root / work_item_relative
+    work_item_path, work_item_path_errors = resolve_repo_relative_path(
+        target_root,
+        work_item_relative,
+        label="work item locator",
+    )
     recovery_relative = args.recovery_entry or f".loom/progress/{args.item}.md"
-    recovery_path = target_root / recovery_relative
+    recovery_path, recovery_path_errors = resolve_repo_relative_path(
+        target_root,
+        recovery_relative,
+        label="recovery entry locator",
+    )
     review_relative = default_review_path(args.item)
+    review_path, review_path_errors = resolve_repo_relative_path(target_root, review_relative, label="review locator")
     status_relative = ".loom/status/current.md"
+    status_path, status_path_errors = resolve_repo_relative_path(target_root, status_relative, label="status surface locator")
+    locator_errors = [*work_item_path_errors, *recovery_path_errors, *review_path_errors, *status_path_errors]
+    if locator_errors:
+        return emit(
+            {
+                "command": "work-item",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "work-item command refused unsafe repo locator input.",
+                "missing_inputs": locator_errors,
+                "fallback_to": "admission",
+            }
+        )
+    assert work_item_path is not None
+    assert recovery_path is not None
+    assert review_path is not None
+    assert status_path is not None
     runtime_evidence: dict[str, dict[str, Any]] | None = None
 
     if args.operation == "create":
@@ -6218,7 +6361,6 @@ def handle_work_item(args: argparse.Namespace) -> int:
         }
         work_item_path.parent.mkdir(parents=True, exist_ok=True)
         work_item_path.write_text(render_work_item(work_item_payload), encoding="utf-8")
-        review_path = target_root / review_relative
         review_path.parent.mkdir(parents=True, exist_ok=True)
         review_path.write_text(
             json.dumps(

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -204,7 +204,14 @@ def resolve_output_path(target_root: Path, raw_output: str) -> Path:
     output_path = Path(raw_output)
     if output_path.is_absolute():
         raise RuntimeError("--output must be relative to the target root")
-    return target_root / output_path
+    if ".." in output_path.parts:
+        raise RuntimeError("--output must stay inside the target root")
+    resolved = (target_root / output_path).resolve()
+    try:
+        resolved.relative_to(target_root.resolve())
+    except ValueError as exc:
+        raise RuntimeError("--output must stay inside the target root") from exc
+    return resolved
 
 
 def runtime_state_payload(target_root: Path) -> dict[str, object]:


### PR DESCRIPTION
## Summary
- harden Loom repo-relative locators across fact-chain, companion, interop, shadow, review, and work-item carriers
- reject absolute paths and target-root escapes before reading or writing carrier files
- extend the Syvert-style adversarial adoption fixture with path escape regressions

Closes #368

## Validation
- python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py
- python3 tools/loom_check.py .
- make loom-check
- npm --prefix packages/loom-installer test