### PR TITLE
feat(carrier): add unified Loom carrier refresh

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/Users/mc/dev/Loom/examples/new-project",
+    "target": "/private/tmp/Loom-zero-friction/examples/new-project",
     "scenario": "新项目",
     "scenario_key": "new",
     "integration_mode": "root",
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "9376481f98f539c0b6aaf72df42e647f320a0e6050e14cd2e1cf0c37240b79cd"
+      "sha256": "02f9b19b65ad580aaee0431a1f5151ac87a4755c95d4045168efb9624f44a558"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "9a8b31917b244172681a542256994d97de9a7b54869e7e9e7bf5747e8759ae69"
+      "sha256": "984cb68a9c5c95e268810b1a6a3c90590bb410b399b2d7ea60efe3da5c377689"
     },
     {
       "path": "AGENTS.md",
@@ -263,12 +263,12 @@
     "scene": "repo-local-demo",
     "carrier": "repo-local-wrapper",
     "entry_family": "loom-init",
-    "install_root": "/Users/mc/dev/Loom/skills",
-    "runtime_root": "/Users/mc/dev/Loom/skills/shared/scripts",
-    "registry_path": "/Users/mc/dev/Loom/skills/registry.json",
-    "layout_or_manifest_path": "/Users/mc/dev/Loom/skills/install-layout.json",
-    "source_repo_root": "/Users/mc/dev/Loom",
-    "target_root": "/Users/mc/dev/Loom/examples/new-project",
+    "install_root": "/private/tmp/Loom-zero-friction/skills",
+    "runtime_root": "/private/tmp/Loom-zero-friction/skills/shared/scripts",
+    "registry_path": "/private/tmp/Loom-zero-friction/skills/registry.json",
+    "layout_or_manifest_path": "/private/tmp/Loom-zero-friction/skills/install-layout.json",
+    "source_repo_root": "/private/tmp/Loom-zero-friction",
+    "target_root": "/private/tmp/Loom-zero-friction/examples/new-project",
     "checks": {
       "scene_marker": {
         "status": "pass",
@@ -278,21 +278,21 @@
         "status": "pass",
         "summary": "carrier layout exposes an installed skills root and shared runtime tree.",
         "evidence": {
-          "install_root": "/Users/mc/dev/Loom/skills"
+          "install_root": "/private/tmp/Loom-zero-friction/skills"
         }
       },
       "registry_contract": {
         "status": "pass",
         "summary": "registry, upgrade contract, and skill entrypoints are consistent.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom/skills/registry.json"
+          "path": "/private/tmp/Loom-zero-friction/skills/registry.json"
         }
       },
       "shared_runtime": {
         "status": "pass",
         "summary": "shared runtime scripts are present and executable roots can be resolved.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom/skills/shared/scripts"
+          "path": "/private/tmp/Loom-zero-friction/skills/shared/scripts"
         }
       },
       "referenced_resources": {
@@ -438,12 +438,12 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-369-adopt-verify",
+            "locator": "issue-370-carrier-refresh",
             "authority": "git"
           },
           "worktree": {
             "status": "present",
-            "locator": "/Users/mc/dev/Loom",
+            "locator": "/private/tmp/Loom-zero-friction",
             "authority": "git"
           },
           "implementation_pr": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "9376481f98f539c0b6aaf72df42e647f320a0e6050e14cd2e1cf0c37240b79cd"
+      "sha256": "02f9b19b65ad580aaee0431a1f5151ac87a4755c95d4045168efb9624f44a558"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "9a8b31917b244172681a542256994d97de9a7b54869e7e9e7bf5747e8759ae69"
+      "sha256": "984cb68a9c5c95e268810b1a6a3c90590bb410b399b2d7ea60efe3da5c377689"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -2540,6 +2540,11 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             {"pass"},
         ),
         (
+            "carrier-refresh",
+            ["python3", "tools/loom_flow.py", "carrier", "refresh", "--target", "examples/new-project", "--item", "INIT-0001", "--dry-run"],
+            {"pass"},
+        ),
+        (
             "governance-profile-status",
             ["python3", "tools/loom_flow.py", "governance-profile", "status", "--target", "examples/new-project"],
             {"pass"},
@@ -2818,6 +2823,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`adopt verify` generated body must pass consumer validation"))
                 if not isinstance(bypass, dict) or bypass.get("result") != "pass":
                     failures.append(Failure("daily-execution-cli", "`adopt verify` must prove required section deletion blocks"))
+        if label == "carrier-refresh":
+            if payload.get("command") != "carrier" or payload.get("operation") != "refresh":
+                failures.append(Failure("daily-execution-cli", "`carrier refresh` must report command/operation"))
+            if payload.get("schema_version") != "loom-carrier-refresh/v1":
+                failures.append(Failure("daily-execution-cli", "`carrier refresh` must report schema v1"))
+            if not isinstance(payload.get("actions"), list):
+                failures.append(Failure("daily-execution-cli", "`carrier refresh` must include actions"))
         if label in {"governance-profile-status", "governance-profile-upgrade-plan"}:
             if payload.get("command") != "governance-profile":
                 failures.append(Failure("daily-execution-cli", f"`{label}` must report `command: governance-profile`"))
@@ -6450,6 +6462,43 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
             failures.append(Failure("adversarial-adoption", f"runtime provenance drift sample failed: {error}"))
         elif payload.get("result") != "block":
             failures.append(Failure("adversarial-adoption", "runtime provenance drift must block runtime-parity"))
+
+        carrier_refresh_target = base / "carrier-refresh"
+        shutil.copytree(baseline, carrier_refresh_target)
+        carrier_manifest_path = carrier_refresh_target / ".loom/bootstrap/manifest.json"
+        carrier_manifest = load_json_file(carrier_manifest_path)
+        carrier_artifacts = carrier_manifest.get("artifacts") if isinstance(carrier_manifest, dict) else []
+        if isinstance(carrier_artifacts, list):
+            for artifact in carrier_artifacts:
+                if isinstance(artifact, dict) and artifact.get("path") == ".loom/bin/loom_flow.py":
+                    artifact["sha256"] = "1" * 64
+                    break
+        write_json(carrier_manifest_path, carrier_manifest)
+        dry_run_payload, dry_run_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "carrier", "refresh", "--target", str(carrier_refresh_target), "--dry-run"],
+        )
+        if dry_run_error:
+            failures.append(Failure("adversarial-adoption", f"carrier refresh dry-run sample failed: {dry_run_error}"))
+        else:
+            refresh_needed = dry_run_payload.get("refresh_needed")
+            if dry_run_payload.get("result") != "pass" or not isinstance(refresh_needed, list) or not refresh_needed:
+                failures.append(Failure("adversarial-adoption", "carrier refresh dry-run must report runtime provenance refresh-needed"))
+        write_payload, write_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "carrier", "refresh", "--target", str(carrier_refresh_target), "--write"],
+        )
+        if write_error:
+            failures.append(Failure("adversarial-adoption", f"carrier refresh write sample failed: {write_error}"))
+        else:
+            after_payload, after_error = load_command_json(
+                root,
+                ["python3", "tools/loom_flow.py", "carrier", "refresh", "--target", str(carrier_refresh_target), "--dry-run"],
+            )
+            if after_error:
+                failures.append(Failure("adversarial-adoption", f"carrier refresh after-write sample failed: {after_error}"))
+            elif after_payload.get("refresh_needed"):
+                failures.append(Failure("adversarial-adoption", "carrier refresh --write must clear runtime provenance drift"))
 
         rollover_target = base / "active-rollover"
         shutil.copytree(baseline, rollover_target)

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -179,6 +179,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Init-result path relative to the target root",
     )
 
+    carrier = subparsers.add_parser("carrier", help="Refresh Loom-owned carrier metadata")
+    carrier.add_argument("operation", choices=("refresh",))
+    carrier.add_argument("--target", required=True, help="Target repository root")
+    carrier.add_argument("--item", help="Expected current item id")
+    carrier.add_argument(
+        "--output",
+        default=".loom/bootstrap/init-result.json",
+        help="Init-result path relative to the target root",
+    )
+    carrier.add_argument("--dry-run", action="store_true", default=True, help="Preview refresh actions without writing files; this is the default")
+    carrier.add_argument("--write", dest="dry_run", action="store_false", help="Write Loom-owned carrier metadata refreshes")
+
     state = subparsers.add_parser(
         "state-check",
         help="Check active-state consistency, checkpoint completeness, and scope overflow signals",
@@ -3891,6 +3903,216 @@ def handle_adopt(args: argparse.Namespace) -> int:
     return emit(adoption_verify_payload(target_root, args.output, args.item))
 
 
+def runtime_artifact_updates(target_root: Path, payload: dict[str, Any], *, source: str) -> list[dict[str, Any]]:
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        artifacts = payload.get("initial_artifacts")
+    if not isinstance(artifacts, list):
+        return []
+    updates: list[dict[str, Any]] = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        relative = artifact.get("path")
+        if not isinstance(relative, str) or not relative.startswith(".loom/bin/"):
+            continue
+        path, errors = resolve_repo_relative_path(target_root, relative, label=f"{source} artifact path")
+        if errors or path is None or not path.exists() or not path.is_file():
+            updates.append(
+                {
+                    "path": relative,
+                    "source": source,
+                    "status": "block",
+                    "missing_inputs": errors or [f"missing runtime artifact: {relative}"],
+                }
+            )
+            continue
+        expected = sha256_file(path)
+        current = artifact.get("sha256")
+        updates.append(
+            {
+                "path": relative,
+                "source": source,
+                "status": "current" if current == expected else "refresh-needed",
+                "current_sha256": current if isinstance(current, str) else None,
+                "expected_sha256": expected,
+            }
+        )
+    return updates
+
+
+def apply_runtime_artifact_updates(payload: dict[str, Any], updates: list[dict[str, Any]], *, source: str) -> None:
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        artifacts = payload.get("initial_artifacts")
+    if not isinstance(artifacts, list):
+        return
+    expected_by_path = {
+        update["path"]: update.get("expected_sha256")
+        for update in updates
+        if update.get("source") == source and update.get("status") == "refresh-needed"
+    }
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        relative = artifact.get("path")
+        if isinstance(relative, str) and relative in expected_by_path:
+            artifact["sha256"] = expected_by_path[relative]
+
+
+def refresh_shadow_evidence_actions(target_root: Path) -> list[dict[str, Any]]:
+    actions: list[dict[str, Any]] = []
+    shadow_root = target_root / ".loom/shadow"
+    if not shadow_root.exists():
+        return actions
+    for path in sorted(shadow_root.glob("*.json")):
+        relative = path.relative_to(target_root).as_posix()
+        try:
+            payload = load_json_file(path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            actions.append({"path": relative, "kind": "shadow-evidence", "status": "block", "missing_inputs": [str(exc)]})
+            continue
+        if not isinstance(payload, dict):
+            actions.append({"path": relative, "kind": "shadow-evidence", "status": "block", "missing_inputs": ["shadow evidence must be a JSON object"]})
+            continue
+        source_files = payload.get("source_files")
+        if not isinstance(source_files, list) or not source_files:
+            actions.append({"path": relative, "kind": "shadow-evidence", "status": "block", "missing_inputs": ["source_files"]})
+            continue
+        refreshed: dict[str, str] = {}
+        missing: list[str] = []
+        for source in source_files:
+            if not isinstance(source, str):
+                missing.append("source_files entries must be strings")
+                continue
+            source_path, errors = resolve_repo_relative_path(target_root, source, label=f"{relative} source")
+            if errors or source_path is None or not source_path.exists() or source_path.is_dir():
+                missing.extend(errors or [f"missing source file: {source}"])
+                continue
+            refreshed[source] = sha256_file(source_path)
+        if missing:
+            actions.append({"path": relative, "kind": "shadow-evidence", "status": "block", "missing_inputs": missing})
+            continue
+        current = payload.get("source_sha256")
+        actions.append(
+            {
+                "path": relative,
+                "kind": "shadow-evidence",
+                "status": "current" if current == refreshed else "refresh-needed",
+                "expected_source_sha256": refreshed,
+            }
+        )
+    return actions
+
+
+def apply_shadow_evidence_actions(target_root: Path, actions: list[dict[str, Any]]) -> None:
+    for action in actions:
+        if action.get("kind") != "shadow-evidence" or action.get("status") != "refresh-needed":
+            continue
+        relative = action.get("path")
+        expected = action.get("expected_source_sha256")
+        if not isinstance(relative, str) or not isinstance(expected, dict):
+            continue
+        path, errors = resolve_repo_relative_path(target_root, relative, label="shadow evidence path")
+        if errors or path is None:
+            continue
+        payload = load_json_file(path)
+        if isinstance(payload, dict):
+            payload["source_sha256"] = expected
+            write_json_file(path, payload)
+
+
+def carrier_refresh_payload(target_root: Path, output_relative: str, expected_item: str | None, *, dry_run: bool) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    context, context_errors = load_context(target_root, output_relative, expected_item)
+    missing_inputs: list[str] = [f"fact-chain: {message}" for message in context_errors]
+
+    manifest_path, manifest_path_errors = resolve_repo_relative_path(target_root, ".loom/bootstrap/manifest.json", label="bootstrap manifest")
+    init_path, init_path_errors = resolve_repo_relative_path(target_root, output_relative, label="init-result locator")
+    missing_inputs.extend(manifest_path_errors)
+    missing_inputs.extend(init_path_errors)
+    manifest_payload: dict[str, Any] = {}
+    init_payload: dict[str, Any] = {}
+    for label, path in (("manifest", manifest_path), ("init-result", init_path)):
+        if path is None:
+            continue
+        try:
+            payload = load_json_file(path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            missing_inputs.append(f"invalid {label}: {exc}")
+            continue
+        if label == "manifest":
+            manifest_payload = payload
+        else:
+            init_payload = payload
+
+    actions: list[dict[str, Any]] = []
+    actions.extend(runtime_artifact_updates(target_root, manifest_payload, source="manifest"))
+    actions.extend(runtime_artifact_updates(target_root, init_payload, source="init-result"))
+    actions.extend(refresh_shadow_evidence_actions(target_root))
+    for action in actions:
+        if action.get("status") == "block":
+            missing_inputs.extend(str(message) for message in action.get("missing_inputs", []))
+
+    review_status: dict[str, Any] = {"status": "not_checked"}
+    if not context_errors:
+        assert context
+        review_record, review_path, review_errors = load_review_record(target_root, context["item_id"], context["review_entry"])
+        spec_review_path = default_spec_review_path(context["item_id"])
+        allowed_paths = allowed_post_review_carrier_paths(context, review_path, spec_review_path)
+        if review_errors or review_record is None:
+            review_status = {"status": "missing", "path": review_path, "missing_inputs": review_errors or [f"missing review artifact: {review_path}"]}
+        else:
+            binding, binding_errors = review_head_binding(
+                target_root,
+                reviewed_head=str(review_record.get("reviewed_head", "")),
+                allowed_paths=allowed_paths,
+            )
+            review_status = {"path": review_path, "head_binding": binding, "missing_inputs": binding_errors}
+            if binding.get("status") == "implementation-drift-only":
+                review_status["status"] = "block"
+                missing_inputs.append("review artifact is stale because implementation drift is present")
+            elif binding.get("status") == "carrier-only":
+                review_status["status"] = "refresh-needed"
+            else:
+                review_status["status"] = "current"
+
+    if not dry_run and not missing_inputs:
+        if manifest_path is not None:
+            apply_runtime_artifact_updates(manifest_payload, actions, source="manifest")
+            write_json_file(manifest_path, manifest_payload)
+        if init_path is not None:
+            apply_runtime_artifact_updates(init_payload, actions, source="init-result")
+            write_json_file(init_path, init_payload)
+        apply_shadow_evidence_actions(target_root, actions)
+
+    refresh_needed = [action for action in actions if action.get("status") == "refresh-needed"]
+    result = "block" if missing_inputs else "pass"
+    return {
+        "command": "carrier",
+        "operation": "refresh",
+        "schema_version": "loom-carrier-refresh/v1",
+        "result": result,
+        "summary": (
+            "carrier refresh completed." if result == "pass" and not dry_run
+            else "carrier refresh dry-run completed." if result == "pass"
+            else "carrier refresh found blocking drift."
+        ),
+        "missing_inputs": missing_inputs,
+        "fallback_to": None if result == "pass" else "adoption",
+        "dry_run": dry_run,
+        "runtime_state": runtime_state,
+        "actions": actions,
+        "refresh_needed": refresh_needed,
+        "review": review_status,
+    }
+
+
+def handle_carrier(args: argparse.Namespace) -> int:
+    target_root = Path(args.target).expanduser().resolve()
+    return emit(carrier_refresh_payload(target_root, args.output, args.item, dry_run=args.dry_run))
+
+
 def host_lifecycle_payload(context: dict[str, Any]) -> dict[str, Any]:
     branch = git_branch(context["target_root"])
     purity = purity_report_from_context(context)
@@ -7281,6 +7503,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_runtime_state(args)
     if args.command == "adopt":
         return handle_adopt(args)
+    if args.command == "carrier":
+        return handle_carrier(args)
     if args.command == "runtime-evidence":
         return handle_runtime_evidence(args)
     if args.command == "state-check":


### PR DESCRIPTION
## Summary
- add `loom_flow.py carrier refresh` with `loom-carrier-refresh/v1` output
- dry-run reports manifest/init-result runtime hash drift and shadow evidence hash drift
- `--write` only updates Loom-owned carrier metadata and keeps implementation review drift blocking
- extend adversarial fixture with dry-run/write provenance refresh regression

Closes #370

## Validation
- python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py
- python3 tools/loom_flow.py carrier refresh --target examples/new-project --item INIT-0001 --dry-run
- python3 tools/loom_check.py .
- make loom-check
- npm --prefix packages/loom-installer test