### PR TITLE
docs(evidence): record zero-friction adoption hardening validation

### DIFF
--- a/docs/evidence/validations/validation-zero-friction-adoption-hardening.md
+++ b/docs/evidence/validations/validation-zero-friction-adoption-hardening.md
@@ -1,0 +1,90 @@
+# Validation: zero-friction downstream adoption hardening
+
+本记录归档 `#367` 这一轮 zero-friction downstream adoption hardening 的验证结论。
+
+## 目标
+
+本轮目标不是继续修 Syvert PR #259，而是把 Syvert strong-governance adoption 暴露出的通用阻力 upstream 到 Loom。
+
+完成后，下游仓库接入 Loom 时应能依靠 Loom 自身能力完成以下动作：
+
+- 验证 downstream producer / consumer round-trip。
+- 统一刷新 Loom-owned carrier metadata。
+- 校验 host binding 的 branch / issue / PR / SHA 推断边界。
+- 在 Loom 仓内复现 Syvert-style 强治理接入压力。
+
+## 合并记录
+
+- `#374` / `#368`: `feat(runtime): harden repo-relative carrier path boundaries`
+- `#375` / `#369`: `feat(adoption): add downstream adopt verify round-trip contract`
+- `#376` / `#370`: `feat(carrier): add unified Loom carrier refresh`
+- `#377` / `#371`: `feat(host-binding): validate SHA branch issue and PR inference`
+- `#378` / `#372`: `test(adoption): extend Syvert-style zero-friction fixture`
+- `#373`: 本 evidence closeout
+
+## Runtime Interfaces
+
+本轮新增或固化的 public runtime entry：
+
+```bash
+python3 tools/loom_flow.py adopt verify --target examples/new-project --item INIT-0001
+python3 tools/loom_flow.py carrier refresh --target examples/new-project --dry-run
+python3 tools/loom_flow.py host-binding validate --target . --owner MC-and-his-Agents --repo Loom --branch main
+python3 tools/loom_flow.py host-binding validate --target . --owner MC-and-his-Agents --repo Loom --head-sha <sha>
+```
+
+稳定输出 schema：
+
+- `loom-adoption-verify/v1`
+- `loom-carrier-refresh/v1`
+- `loom-host-binding/v1`
+
+## 已覆盖的风险
+
+- repo locator 必须是 target-root 内的 repo-relative path。
+- 绝对路径、`..` escape、target-root 外 locator 必须返回 `block`。
+- `Review Artifacts` required section 被删除时，consumer 必须返回 `block`。
+- manifest 与 init-result 的 `.loom/bin/*` artifact hash 漂移可由 `carrier refresh --dry-run` 报告，并由 `--write` 修复。
+- shadow evidence 的 `source_files` 与 `source_sha256` 必须闭包一致。
+- missing hash、partial hash、hash drift、undeclared evidence 都进入 adversarial fixture。
+- carrier-only review metadata 可以刷新；implementation drift 或 mixed drift 必须 `block`，要求重新 review。
+- SHA-only host binding 无法通过 REST 证明 issue / PR 归属时必须 fail closed。
+- CI 无 `GH_TOKEN` 时，公开 GitHub REST 读取可以 fallback 到 HTTPS REST，不重新引入高频 GraphQL。
+
+## 验证命令
+
+每个 Work Item PR 合并前均通过：
+
+```bash
+python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py
+python3 tools/loom_check.py .
+make loom-check
+npm --prefix packages/loom-installer test
+```
+
+本轮新增接口的显式验证包括：
+
+```bash
+python3 tools/loom_flow.py adopt verify --target examples/new-project --item INIT-0001
+python3 tools/loom_flow.py carrier refresh --target examples/new-project --dry-run
+python3 tools/loom_flow.py host-binding validate --target . --owner MC-and-his-Agents --repo Loom --branch main
+GH_CONFIG_DIR=/tmp/loom-empty-gh-config python3 tools/loom_flow.py host-binding validate --target . --owner MC-and-his-Agents --repo Loom --branch main
+```
+
+## 剩余边界
+
+- 本轮不把 Syvert guardian、integration contract、release / sprint 语义迁入 Loom core。
+- 本轮不恢复或修改 Syvert PR #259。
+- Syvert official adoption 的下一步应先刷新 vendored `.loom/bin/*` 到包含本轮 hardening 的 Loom `main`，再运行上述 Loom-on-downstream 验证。
+- ProjectV2 与 native sub-issues 仍属于 GitHub profile 的 GraphQL-only 路径，只允许在明确预算边界内使用。
+
+## 结论
+
+Loom 已经把 Syvert PR #259 暴露的接入阻力收成 upstream runtime 能力与 Loom-owned fixture。
+
+后续恢复 Syvert official adoption 时，预期流程应是：
+
+1. refresh Loom runtime carrier。
+2. run `adopt verify`、`carrier refresh --dry-run`、`host-binding validate`、`loom_check`。
+3. 只修复这些命令明确报告的问题。
+4. 再进入 Syvert guardian 与 controlled merge。

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "0c3378d7c3da8caede613f26c5d4d705117bde4c69df24653b54c99b143f4b97"
+      "sha256": "a5916d824ef9d6ef2d8f18378758cc072b3af7ba5cb67923b32dea16c2c5786d"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-372-zero-friction-fixture",
+            "locator": "issue-373-zero-friction-evidence",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "0c3378d7c3da8caede613f26c5d4d705117bde4c69df24653b54c99b143f4b97"
+      "sha256": "a5916d824ef9d6ef2d8f18378758cc072b3af7ba5cb67923b32dea16c2c5786d"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -100,6 +100,7 @@ CORE_DOCS = (
     "docs/evidence/validations/validation-adoption-gate-rollout.md",
     "docs/evidence/validations/validation-external-runtime-devendor-migration.md",
     "docs/evidence/validations/validation-syvert-adversarial-adoption-fixture.md",
+    "docs/evidence/validations/validation-zero-friction-adoption-hardening.md",
     "docs/evidence/validations/validation-github-profile-binding-orchestration.md",
     "docs/evidence/validations/validation-github-profile-drift-reconciliation.md",
     "docs/evidence/validations/validation-github-profile-graphql-budget-guard.md",


### PR DESCRIPTION
## Summary
- add validation evidence for the zero-friction downstream adoption hardening phase
- include merged Work Item PRs, runtime interfaces, covered risks, validation commands, and remaining boundaries
- require the evidence file from loom_check so the closeout stays version-controlled

Closes #373

## Validation
- python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py
- python3 tools/loom_check.py .
- make loom-check
- npm --prefix packages/loom-installer test
- node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main