### PR TITLE
fix(carrier): ignore shadow-parity summary during carrier refresh

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/private/tmp/Loom-zero-friction/examples/new-project",
+    "target": "/Users/mc/dev/Loom/examples/new-project",
     "scenario": "新项目",
     "scenario_key": "new",
     "integration_mode": "root",
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "55f9d625dfb3cf35e7d0f849878700b29a099975831b5caccb3ce87fa4134def"
+      "sha256": "bf786adc12a26073ab1bc613bff32ee28bf6fde360ec0b32f1005476e7ab4fd7"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a5916d824ef9d6ef2d8f18378758cc072b3af7ba5cb67923b32dea16c2c5786d"
+      "sha256": "a9dd05951078041b280b03791dfb5f55d1da9cf038e76801bae8533dda1b2c97"
     },
     {
       "path": "AGENTS.md",
@@ -263,12 +263,12 @@
     "scene": "repo-local-demo",
     "carrier": "repo-local-wrapper",
     "entry_family": "loom-init",
-    "install_root": "/private/tmp/Loom-zero-friction/skills",
-    "runtime_root": "/private/tmp/Loom-zero-friction/skills/shared/scripts",
-    "registry_path": "/private/tmp/Loom-zero-friction/skills/registry.json",
-    "layout_or_manifest_path": "/private/tmp/Loom-zero-friction/skills/install-layout.json",
-    "source_repo_root": "/private/tmp/Loom-zero-friction",
-    "target_root": "/private/tmp/Loom-zero-friction/examples/new-project",
+    "install_root": "/Users/mc/dev/Loom/skills",
+    "runtime_root": "/Users/mc/dev/Loom/skills/shared/scripts",
+    "registry_path": "/Users/mc/dev/Loom/skills/registry.json",
+    "layout_or_manifest_path": "/Users/mc/dev/Loom/skills/install-layout.json",
+    "source_repo_root": "/Users/mc/dev/Loom",
+    "target_root": "/Users/mc/dev/Loom/examples/new-project",
     "checks": {
       "scene_marker": {
         "status": "pass",
@@ -278,21 +278,21 @@
         "status": "pass",
         "summary": "carrier layout exposes an installed skills root and shared runtime tree.",
         "evidence": {
-          "install_root": "/private/tmp/Loom-zero-friction/skills"
+          "install_root": "/Users/mc/dev/Loom/skills"
         }
       },
       "registry_contract": {
         "status": "pass",
         "summary": "registry, upgrade contract, and skill entrypoints are consistent.",
         "evidence": {
-          "path": "/private/tmp/Loom-zero-friction/skills/registry.json"
+          "path": "/Users/mc/dev/Loom/skills/registry.json"
         }
       },
       "shared_runtime": {
         "status": "pass",
         "summary": "shared runtime scripts are present and executable roots can be resolved.",
         "evidence": {
-          "path": "/private/tmp/Loom-zero-friction/skills/shared/scripts"
+          "path": "/Users/mc/dev/Loom/skills/shared/scripts"
         }
       },
       "referenced_resources": {
@@ -438,12 +438,12 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-373-zero-friction-evidence",
+            "locator": "issue-380-carrier-refresh-shadow-summary",
             "authority": "git"
           },
           "worktree": {
             "status": "present",
-            "locator": "/private/tmp/Loom-zero-friction",
+            "locator": "/Users/mc/dev/Loom",
             "authority": "git"
           },
           "implementation_pr": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "55f9d625dfb3cf35e7d0f849878700b29a099975831b5caccb3ce87fa4134def"
+      "sha256": "bf786adc12a26073ab1bc613bff32ee28bf6fde360ec0b32f1005476e7ab4fd7"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a5916d824ef9d6ef2d8f18378758cc072b3af7ba5cb67923b32dea16c2c5786d"
+      "sha256": "a9dd05951078041b280b03791dfb5f55d1da9cf038e76801bae8533dda1b2c97"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.35",
+      "version": "0.1.36",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -6514,6 +6514,14 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
 
         carrier_refresh_target = base / "carrier-refresh"
         shutil.copytree(baseline, carrier_refresh_target)
+        write_json(
+            carrier_refresh_target / ".loom/shadow/shadow-parity.json",
+            {
+                "schema_version": "loom-shadow-parity/v1",
+                "result": "pass",
+                "summary": "Aggregate shadow parity output is not per-surface hash evidence.",
+            },
+        )
         carrier_manifest_path = carrier_refresh_target / ".loom/bootstrap/manifest.json"
         carrier_manifest = load_json_file(carrier_manifest_path)
         carrier_artifacts = carrier_manifest.get("artifacts") if isinstance(carrier_manifest, dict) else []
@@ -6533,6 +6541,16 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
             refresh_needed = dry_run_payload.get("refresh_needed")
             if dry_run_payload.get("result") != "pass" or not isinstance(refresh_needed, list) or not refresh_needed:
                 failures.append(Failure("adversarial-adoption", "carrier refresh dry-run must report runtime provenance refresh-needed"))
+            actions = dry_run_payload.get("actions")
+            summary_actions = [
+                action
+                for action in actions
+                if isinstance(action, dict)
+                and action.get("path") == ".loom/shadow/shadow-parity.json"
+                and action.get("status") == "skipped"
+            ] if isinstance(actions, list) else []
+            if not summary_actions:
+                failures.append(Failure("adversarial-adoption", "carrier refresh must skip aggregate shadow-parity.json without requiring source hashes"))
         write_payload, write_error = load_command_json(
             root,
             ["python3", "tools/loom_flow.py", "carrier", "refresh", "--target", str(carrier_refresh_target), "--write"],

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -4044,6 +4044,16 @@ def refresh_shadow_evidence_actions(target_root: Path) -> list[dict[str, Any]]:
         return actions
     for path in sorted(shadow_root.glob("*.json")):
         relative = path.relative_to(target_root).as_posix()
+        if relative == ".loom/shadow/shadow-parity.json":
+            actions.append(
+                {
+                    "path": relative,
+                    "kind": "shadow-evidence-summary",
+                    "status": "skipped",
+                    "summary": "shadow-parity.json is an aggregate command output; per-surface evidence carries source hashes.",
+                }
+            )
+            continue
         try:
             payload = load_json_file(path)
         except (OSError, ValueError, json.JSONDecodeError) as exc:


### PR DESCRIPTION
## Summary
- make `carrier refresh` skip `.loom/shadow/shadow-parity.json` as an aggregate command output
- keep per-surface `.loom/shadow/*.json` evidence subject to source_files/source_sha256 closure
- extend the adversarial adoption fixture to cover this downstream adoption case

Closes #380

## Validation
- python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py
- python3 tools/loom_check.py .
- make loom-check
- npm --prefix packages/loom-installer test
- node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main