### PR TITLE
fix: 强化下游 carrier 兼容合同

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -119,19 +119,19 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "406352215e9ff1c582d750761b911bd227c99b3cc29d3710143554ced7f9e080"
+      "sha256": "8ec28a37277dbf4e6e0af5965cf98da4ec3e8a0b29cb325309c08b22ab976a91"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "82109bad507ea760c7df3a401b648b34c35da03f8f85eb40481834e44b29ed0f"
+      "sha256": "fcd116cdadbe674f13fbe841e5af86d8bb48fe6c924305949ea1ed1abc955d44"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "bf786adc12a26073ab1bc613bff32ee28bf6fde360ec0b32f1005476e7ab4fd7"
+      "sha256": "e9b376551600383e95e4f707557bb957edf51cd9ee2263587b8b6109088b737c"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -149,13 +149,13 @@
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/runtime_state.py",
-      "sha256": "5c5e096dbea072ab8e4f305ac06ee5d983e0bade519f6bea7fd119a92de52f09"
+      "sha256": "3375830ede9bec65083d9ee6cfac5f5a7e3bd781ef90c78a087c39d37f2cfab2"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a9dd05951078041b280b03791dfb5f55d1da9cf038e76801bae8533dda1b2c97"
+      "sha256": "6c31df1995034f10c7dd769b5c174a3e580f3078e586d53faa6b9994c3d7bb98"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-380-carrier-refresh-shadow-summary",
+            "locator": "issue-382-downstream-carrier-compat",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -41,19 +41,19 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "406352215e9ff1c582d750761b911bd227c99b3cc29d3710143554ced7f9e080"
+      "sha256": "8ec28a37277dbf4e6e0af5965cf98da4ec3e8a0b29cb325309c08b22ab976a91"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "82109bad507ea760c7df3a401b648b34c35da03f8f85eb40481834e44b29ed0f"
+      "sha256": "fcd116cdadbe674f13fbe841e5af86d8bb48fe6c924305949ea1ed1abc955d44"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "bf786adc12a26073ab1bc613bff32ee28bf6fde360ec0b32f1005476e7ab4fd7"
+      "sha256": "e9b376551600383e95e4f707557bb957edf51cd9ee2263587b8b6109088b737c"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -71,13 +71,13 @@
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/runtime_state.py",
-      "sha256": "5c5e096dbea072ab8e4f305ac06ee5d983e0bade519f6bea7fd119a92de52f09"
+      "sha256": "3375830ede9bec65083d9ee6cfac5f5a7e3bd781ef90c78a087c39d37f2cfab2"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a9dd05951078041b280b03791dfb5f55d1da9cf038e76801bae8533dda1b2c97"
+      "sha256": "6c31df1995034f10c7dd769b5c174a3e580f3078e586d53faa6b9994c3d7bb98"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/fact_chain_support.py
+++ b/skills/shared/scripts/fact_chain_support.py
@@ -195,12 +195,12 @@ def resolve_repo_relative_path(target_root: Path, relative: str, *, label: str) 
     if candidate_raw.is_absolute():
         return None, [f"{label} must be repo-relative, got absolute path: {locator}"]
     if ".." in candidate_raw.parts:
-        return None, [f"{label} must stay inside the target repository: {locator}"]
+        return None, [f"{label} must stay inside the target repository and within the target root: {locator}"]
     candidate = (target_root / candidate_raw).resolve()
     try:
         candidate.relative_to(target_root.resolve())
     except ValueError:
-        return None, [f"{label} must stay inside the target repository: {locator}"]
+        return None, [f"{label} must stay inside the target repository and within the target root: {locator}"]
     return candidate, []
 
 

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 from runtime_paths import installed_skill_script
 
@@ -357,7 +358,7 @@ def detect_github_repo(root: Path) -> tuple[str | None, str | None]:
     remote = git_remote_origin(root)
     if not remote:
         return None, None
-    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$", remote)
+    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$", remote)
     if not match:
         return None, None
     return match.group("owner"), match.group("repo")
@@ -474,6 +475,16 @@ def relative_locator_from_value(root: Path, raw_locator: object) -> str | None:
     return str(locator_path)
 
 
+def locator_boundary_error(raw_locator: object, *, label: str) -> str:
+    if not isinstance(raw_locator, str) or not raw_locator.strip():
+        return f"{label} must be a non-empty string"
+    locator = raw_locator.strip()
+    locator_path = Path(locator)
+    if locator_path.is_absolute() or ".." in locator_path.parts:
+        return f"{label} must stay within the repository root: {locator}"
+    return f"{label} must stay within the repository root: {locator}"
+
+
 def resolve_locator(root: Path, raw_locator: object) -> tuple[str | None, Path | None]:
     locator = relative_locator_from_value(root, raw_locator)
     if locator is None:
@@ -494,7 +505,7 @@ def locator_status_entry(
 ) -> tuple[dict[str, str], str | None]:
     locator, target = resolve_locator(root, raw_locator)
     if locator is None or target is None:
-        return carrier_entry("missing", "unknown", source), f"{source} is missing a valid locator"
+        return carrier_entry("missing", "unknown", source), locator_boundary_error(raw_locator, label=source)
     if not target.exists():
         return carrier_entry("missing", locator, source), f"{source} points to missing path `{locator}`"
     return carrier_entry("present", locator, source), None
@@ -520,7 +531,7 @@ def validate_repo_specific_requirement(
         missing_inputs.append(f"{prefix} enforcement must be `blocking` or `advisory`")
     locator, target = resolve_locator(root, entry.get("locator"))
     if locator is None or target is None:
-        missing_inputs.append(f"{prefix} locator must be a non-empty string")
+        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
     elif not target.exists():
         missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
     return missing_inputs
@@ -542,7 +553,7 @@ def validate_specialized_gate(
             missing_inputs.append(f"{prefix} missing `{field}`")
     locator, target = resolve_locator(root, entry.get("locator"))
     if locator is None or target is None:
-        missing_inputs.append(f"{prefix} locator must be a non-empty string")
+        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
     elif not target.exists():
         missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
     gate_type = entry.get("gate_type")
@@ -582,7 +593,7 @@ def validate_metadata_contract(
         for locator_field in ("applicability_locator", "authority_locator"):
             locator, target = resolve_locator(root, field.get(locator_field))
             if locator is None or target is None:
-                missing_inputs.append(f"{field_prefix} `{locator_field}` must be a non-empty string")
+                missing_inputs.append(locator_boundary_error(field.get(locator_field), label=f"{field_prefix} `{locator_field}`"))
             elif not target.exists():
                 missing_inputs.append(f"{field_prefix} `{locator_field}` points to missing path `{locator}`")
     return missing_inputs
@@ -616,7 +627,7 @@ def validate_context_schema(
             missing_inputs.append(f"{field_prefix} `required` must be a boolean")
         locator, target = resolve_locator(root, field.get("mapping_rule_locator"))
         if locator is None or target is None:
-            missing_inputs.append(f"{field_prefix} `mapping_rule_locator` must be a non-empty string")
+            missing_inputs.append(locator_boundary_error(field.get("mapping_rule_locator"), label=f"{field_prefix} `mapping_rule_locator`"))
         elif not target.exists():
             missing_inputs.append(f"{field_prefix} `mapping_rule_locator` points to missing path `{locator}`")
     return missing_inputs
@@ -648,7 +659,7 @@ def validate_repo_interop_collection_entry(
                 )
     locator, target = resolve_locator(root, entry.get("locator"))
     if locator is None or target is None:
-        missing_inputs.append(f"{prefix} locator must be a non-empty string")
+        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
     elif not target.exists():
         missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
     return missing_inputs
@@ -670,7 +681,7 @@ def validate_shadow_surface(
     for locator_field in ("loom_locator", "repo_locator"):
         locator, target = resolve_locator(root, entry.get(locator_field))
         if locator is None or target is None:
-            missing_inputs.append(f"{prefix} `{locator_field}` must be a non-empty string")
+            missing_inputs.append(locator_boundary_error(entry.get(locator_field), label=f"{prefix} `{locator_field}`"))
         elif not target.exists():
             missing_inputs.append(f"{prefix} `{locator_field}` points to missing path `{locator}`")
     return missing_inputs
@@ -1089,7 +1100,8 @@ def detect_github_control_plane(root: Path) -> tuple[dict[str, Any], list[str]]:
         missing_inputs.append("github control plane: default branch is unavailable")
         return surface, missing_inputs
 
-    branch_payload, branch_errors = gh_json(root, ["api", f"repos/{owner}/{repo}/branches/{surface['default_branch']}"])
+    encoded_branch = quote(str(surface["default_branch"]), safe="")
+    branch_payload, branch_errors = gh_json(root, ["api", f"repos/{owner}/{repo}/branches/{encoded_branch}"])
     if branch_errors or branch_payload is None:
         missing_inputs.extend(f"github control plane: {message}" for message in branch_errors)
         return surface, missing_inputs

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -17,6 +17,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from fact_chain_support import inspect_fact_chain
+import governance_surface as governance_surface_module
+import loom_flow as loom_flow_module
+import runtime_state as runtime_state_module
 from governance_surface import build_governance_surface
 from loom_flow import repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
@@ -6346,6 +6349,109 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
 
     with tempfile.TemporaryDirectory(prefix="loom-check-syvert-adoption-") as tmp:
         base = Path(tmp)
+
+        original_governance_remote = governance_surface_module.git_remote_origin
+        original_flow_remote = loom_flow_module.git_remote_origin
+        try:
+            governance_surface_module.git_remote_origin = lambda _root: "git@github.com:owner/foo.bar.git"
+            loom_flow_module.git_remote_origin = lambda _root: "git@github.com:owner/foo.bar.git"
+            if governance_surface_module.detect_github_repo(base) != ("owner", "foo.bar"):
+                failures.append(Failure("adversarial-adoption", "governance surface must accept dotted GitHub repository names"))
+            if loom_flow_module.detect_github_repo(base) != ("owner", "foo.bar"):
+                failures.append(Failure("adversarial-adoption", "loom flow must accept dotted GitHub repository names"))
+        finally:
+            governance_surface_module.git_remote_origin = original_governance_remote
+            loom_flow_module.git_remote_origin = original_flow_remote
+
+        branch_calls: list[list[str]] = []
+        original_detect_repo = governance_surface_module.detect_github_repo
+        original_rest_json = governance_surface_module.gh_rest_json
+        original_gh_json = governance_surface_module.gh_json
+        try:
+            governance_surface_module.detect_github_repo = lambda _root: ("owner", "foo.bar")
+            governance_surface_module.gh_rest_json = lambda _root, _path: ({"full_name": "owner/foo.bar", "default_branch": "release/main"}, [])
+
+            def fake_gh_json(_root: Path, args: list[str]) -> tuple[dict[str, object], list[str]]:
+                branch_calls.append(args)
+                return {"protected": False}, []
+
+            governance_surface_module.gh_json = fake_gh_json
+            _, errors = governance_surface_module.detect_github_control_plane(base)
+            if errors:
+                failures.append(Failure("adversarial-adoption", f"governance surface slash-branch fixture failed: {'; '.join(errors)}"))
+            elif not branch_calls or "repos/owner/foo.bar/branches/release%2Fmain" not in branch_calls[0]:
+                failures.append(Failure("adversarial-adoption", "GitHub branch REST endpoint must encode slash-containing branch names"))
+        finally:
+            governance_surface_module.detect_github_repo = original_detect_repo
+            governance_surface_module.gh_rest_json = original_rest_json
+            governance_surface_module.gh_json = original_gh_json
+
+        merge_calls: list[list[str]] = []
+        original_run_git = loom_flow_module.run_git
+        try:
+            def fake_run_git(_root: Path, args: list[str]):
+                merge_calls.append(args)
+
+                class Result:
+                    returncode = 0
+
+                return Result()
+
+            loom_flow_module.run_git = fake_run_git
+            if not loom_flow_module.contains_merged_commit(base, "abc123", "release/main"):
+                failures.append(Failure("adversarial-adoption", "target-branch merge containment fixture unexpectedly failed"))
+            expected_fetch = ["fetch", "origin", "refs/heads/release/main:refs/remotes/origin/release/main"]
+            if not merge_calls or merge_calls[0] != expected_fetch:
+                failures.append(Failure("adversarial-adoption", "merge commit containment must fetch the explicit target branch"))
+        finally:
+            loom_flow_module.run_git = original_run_git
+
+        path_contract_target = base / "path-contract"
+        path_contract_target.mkdir()
+        (path_contract_target / "install-layout.json").write_text('{"required_paths":["../outside"]}', encoding="utf-8")
+        payload, errors, _ = runtime_state_module._validate_install_layout(path_contract_target)
+        if payload.get("status") != "block" or not any("must stay inside" in error for error in errors):
+            failures.append(Failure("adversarial-adoption", "install-layout runtime paths must not escape the runtime root"))
+
+        (path_contract_target / "upgrade-contract.json").write_text('{"upgrade_policy":{"refresh_required":["layout_manifest"]}}', encoding="utf-8")
+        (path_contract_target / "registry.json").write_text(
+            '{"install_layout":"install-layout.json","upgrade_contract":"upgrade-contract.json","entries":[{"id":"x","executable":"../outside-exec","manifest":"../outside-manifest.json"}]}',
+            encoding="utf-8",
+        )
+        payload, errors, _ = runtime_state_module._validate_registry_contract(path_contract_target)
+        if payload.get("status") != "block" or not any("must stay inside" in error for error in errors):
+            failures.append(Failure("adversarial-adoption", "registry executable and manifest paths must not escape the runtime root"))
+
+        spec_contract_target = base / "spec-contract"
+        (spec_contract_target / ".loom/specs/INIT-0001").mkdir(parents=True)
+        (spec_contract_target / ".loom/specs/INIT-0001/spec.md").write_text("bootstrap spec\n", encoding="utf-8")
+        context = {
+            "item_id": "WORK-0002",
+            "target_root": spec_contract_target,
+            "associated_artifacts": [".loom/specs/INIT-0001/spec.md"],
+        }
+        if loom_flow_module.formal_spec_path(context) is not None:
+            failures.append(Failure("adversarial-adoption", "active Work Items must not fall back to bootstrap INIT specs"))
+
+        semantics_target = base / "shadow-semantics"
+        (semantics_target / ".loom/shadow").mkdir(parents=True)
+        (semantics_target / "loom.md").write_text("loom\n", encoding="utf-8")
+        write_json(
+            semantics_target / ".loom/shadow/review-loom.json",
+            {
+                "parity_value": "review-v1",
+                "source_semantics": "requires spec review",
+                "source_files": ["loom.md"],
+                "source_sha256": {"loom.md": sha256_file(semantics_target / "loom.md")},
+            },
+        )
+        normalized, _ = loom_flow_module.normalized_shadow_value(
+            semantics_target / ".loom/shadow/review-loom.json",
+            target_root=semantics_target,
+        )
+        if "requires spec review" not in str(normalized.get("normalized_value")):
+            failures.append(Failure("adversarial-adoption", "shadow parity normalization must retain declared source semantics"))
+
         baseline = base / "baseline"
         current_head = prepare_strong_target(baseline)
         if current_head is None:

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -707,7 +707,23 @@ def normalized_shadow_value(path: Path, *, target_root: Path) -> tuple[dict[str,
         for key in ("parity_value", "result", "decision", "status", "verdict", "value"):
             value = payload.get(key)
             if isinstance(value, (str, int, float, bool)) and str(value).strip():
-                return {**source_evidence, "normalized_value": str(value).strip().lower()}, "; ".join(source_errors) if source_errors else None
+                comparable: object = str(value).strip().lower()
+                semantic_evidence = {
+                    semantic_key: payload[semantic_key]
+                    for semantic_key in ("source_semantics", "evidence_body")
+                    if semantic_key in payload
+                }
+                if semantic_evidence:
+                    comparable = {
+                        "value": comparable,
+                        **semantic_evidence,
+                    }
+                normalized = (
+                    comparable
+                    if isinstance(comparable, str)
+                    else json.dumps(comparable, ensure_ascii=False, sort_keys=True)
+                )
+                return {**source_evidence, "normalized_value": normalized}, "; ".join(source_errors) if source_errors else None
         return {**source_evidence, "normalized_value": json.dumps(payload, ensure_ascii=False, sort_keys=True)}, "; ".join(source_errors) if source_errors else None
     if isinstance(payload, list):
         return {"normalized_value": json.dumps(payload, ensure_ascii=False, sort_keys=True)}, f"shadow evidence `{path}` must be a JSON object with source_files/source_sha256"
@@ -978,7 +994,7 @@ def detect_github_repo(root: Path) -> tuple[str | None, str | None]:
     remote = git_remote_origin(root)
     if not remote:
         return None, None
-    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/.]+)(?:\.git)?$", remote)
+    match = re.search(r"github\.com[:/](?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$", remote)
     if not match:
         return None, None
     return match.group("owner"), match.group("repo")
@@ -1431,7 +1447,11 @@ def formal_spec_path(context: dict[str, Any]) -> str | None:
         return preferred
 
     for artifact in context.get("associated_artifacts", []):
-        if isinstance(artifact, str) and artifact.endswith("/spec.md") and (context["target_root"] / artifact).exists():
+        if (
+            isinstance(artifact, str)
+            and artifact == preferred
+            and (context["target_root"] / artifact).exists()
+        ):
             return artifact
 
     fallback = context["target_root"] / ".loom/specs/INIT-0001/spec.md"
@@ -5139,9 +5159,13 @@ query($owner:String!, $name:String!, $number:Int!) {
     return issue, []
 
 
-def contains_merged_commit(root: Path, merge_commit_sha: str) -> bool:
-    run_git(root, ["fetch", "origin", "main"])
-    contains = run_git(root, ["merge-base", "--is-ancestor", merge_commit_sha, "origin/main"])
+def contains_merged_commit(root: Path, merge_commit_sha: str, target_branch: str = "main") -> bool:
+    remote_ref = f"refs/remotes/origin/{target_branch}"
+    fetched_ref = f"refs/heads/{target_branch}:{remote_ref}"
+    fetched = run_git(root, ["fetch", "origin", fetched_ref])
+    if fetched is None or fetched.returncode != 0:
+        return False
+    contains = run_git(root, ["merge-base", "--is-ancestor", merge_commit_sha, remote_ref])
     return contains is not None and contains.returncode == 0
 
 
@@ -5266,7 +5290,9 @@ def reconciliation_audit_payload(
                 oid = merge_commit.get("oid")
                 if isinstance(oid, str) and oid:
                     merge_commit_sha = oid
-                    merge_commit_in_main = contains_merged_commit(target_root, merge_commit_sha)
+                    base_ref = pr_payload.get("baseRefName")
+                    target_branch = base_ref if isinstance(base_ref, str) and base_ref else "main"
+                    merge_commit_in_main = contains_merged_commit(target_root, merge_commit_sha, target_branch)
             if pr_payload.get("state") == "MERGED" and (not merge_commit_sha or not merge_commit_in_main):
                 findings.append(
                     make_reconciliation_finding(
@@ -6755,7 +6781,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "normalized_findings": args.normalized_findings,
         },
     }
-    review_abs, review_path_errors = resolve_repo_relative_path(target_root, review_path, label="review artifact locator")
+    review_abs, review_path_errors = resolve_repo_relative_path(target_root, review_path, label="review artifact path")
     if review_path_errors:
         return emit(
             {

--- a/skills/shared/scripts/runtime_state.py
+++ b/skills/shared/scripts/runtime_state.py
@@ -94,6 +94,17 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _resolve_inside(root: Path, relative: str, *, label: str) -> tuple[Path | None, str | None]:
+    if Path(relative).is_absolute():
+        return None, f"{label} must stay inside the runtime root: {relative}"
+    try:
+        candidate = (root / relative).resolve()
+        candidate.relative_to(root.resolve())
+    except ValueError:
+        return None, f"{label} must stay inside the runtime root: {relative}"
+    return candidate, None
+
+
 def _default_scene_for_carrier(carrier: str) -> str:
     if carrier == "repo-local-wrapper":
         return "repo-local-demo"
@@ -144,7 +155,11 @@ def _validate_install_layout(skills_root: Path) -> tuple[dict[str, Any], list[st
             if not isinstance(relative, str) or not relative:
                 errors.append("`install-layout.json` required paths must be non-empty strings")
                 continue
-            if not (skills_root / relative).exists():
+            path, path_error = _resolve_inside(skills_root, relative, label="install layout required path")
+            if path_error:
+                errors.append(path_error)
+                continue
+            if path is None or not path.exists():
                 missing.append(relative)
         if missing:
             errors.append("install layout is missing required paths: " + ", ".join(sorted(missing)))
@@ -186,12 +201,28 @@ def _validate_registry_contract(skills_root: Path) -> tuple[dict[str, Any], list
                 continue
             if not isinstance(executable, str) or not executable:
                 errors.append(f"registry entry `{skill_id}` must declare a non-empty `executable`")
-            elif not (skills_root / executable).exists():
-                errors.append(f"registry entry `{skill_id}` points to missing executable `{executable}`")
+            else:
+                executable_path, executable_error = _resolve_inside(
+                    skills_root,
+                    executable,
+                    label=f"registry entry `{skill_id}` executable",
+                )
+                if executable_error:
+                    errors.append(executable_error)
+                elif executable_path is None or not executable_path.exists():
+                    errors.append(f"registry entry `{skill_id}` points to missing executable `{executable}`")
             if not isinstance(manifest, str) or not manifest:
                 errors.append(f"registry entry `{skill_id}` must declare a non-empty `manifest`")
-            elif not (skills_root / manifest).exists():
-                errors.append(f"registry entry `{skill_id}` points to missing manifest `{manifest}`")
+            else:
+                manifest_path, manifest_error = _resolve_inside(
+                    skills_root,
+                    manifest,
+                    label=f"registry entry `{skill_id}` manifest",
+                )
+                if manifest_error:
+                    errors.append(manifest_error)
+                elif manifest_path is None or not manifest_path.exists():
+                    errors.append(f"registry entry `{skill_id}` points to missing manifest `{manifest}`")
 
     upgrade_path = skills_root / "upgrade-contract.json"
     upgrade_contract, upgrade_error = _load_json(upgrade_path)


### PR DESCRIPTION
## Summary
- Fix downstream carrier compatibility gaps exposed while resuming Syvert PR #259.
- Keep the fixes in Loom upstream instead of patching Syvert-specific runtime behavior.
- Strengthen the Loom-owned adversarial adoption fixture so these regressions are caught before downstream adoption.

## Changes
- Accept dotted GitHub repository names in remote parsing.
- URL-encode slash-containing branch names for REST branch reads.
- Let merge-commit containment checks use an explicit target branch.
- Block runtime install-layout and registry path escapes.
- Prevent active Work Items from falling back to bootstrap INIT specs through stale associated artifacts.
- Preserve declared shadow source semantics in normalized parity values.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`

Closes #382