### PR TITLE
fix: 稳定 carrier 路径边界错误锚点

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -119,13 +119,13 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "8ec28a37277dbf4e6e0af5965cf98da4ec3e8a0b29cb325309c08b22ab976a91"
+      "sha256": "e5c52cda01f1107cafcd00bf2d37feaa167f1acd5152fc8f41f28ee3255a7d52"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "fcd116cdadbe674f13fbe841e5af86d8bb48fe6c924305949ea1ed1abc955d44"
+      "sha256": "c8be9d24fe9afad7ffce1d1e7eb7394ce28ae7f3eeb5243a9b7bc9a854e9871f"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "6c31df1995034f10c7dd769b5c174a3e580f3078e586d53faa6b9994c3d7bb98"
+      "sha256": "50a031d3cda589e4f020639d0305370281ce6d3e644e14aaa8c9ba090773d15f"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-382-downstream-carrier-compat",
+            "locator": "issue-384-path-boundary-error-anchors",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -41,13 +41,13 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "8ec28a37277dbf4e6e0af5965cf98da4ec3e8a0b29cb325309c08b22ab976a91"
+      "sha256": "e5c52cda01f1107cafcd00bf2d37feaa167f1acd5152fc8f41f28ee3255a7d52"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "fcd116cdadbe674f13fbe841e5af86d8bb48fe6c924305949ea1ed1abc955d44"
+      "sha256": "c8be9d24fe9afad7ffce1d1e7eb7394ce28ae7f3eeb5243a9b7bc9a854e9871f"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "6c31df1995034f10c7dd769b5c174a3e580f3078e586d53faa6b9994c3d7bb98"
+      "sha256": "50a031d3cda589e4f020639d0305370281ce6d3e644e14aaa8c9ba090773d15f"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/fact_chain_support.py
+++ b/skills/shared/scripts/fact_chain_support.py
@@ -195,12 +195,12 @@ def resolve_repo_relative_path(target_root: Path, relative: str, *, label: str) 
     if candidate_raw.is_absolute():
         return None, [f"{label} must be repo-relative, got absolute path: {locator}"]
     if ".." in candidate_raw.parts:
-        return None, [f"{label} must stay inside the target repository and within the target root: {locator}"]
+        return None, [f"{label} must stay within the target root and inside the target repository: {locator}"]
     candidate = (target_root / candidate_raw).resolve()
     try:
         candidate.relative_to(target_root.resolve())
     except ValueError:
-        return None, [f"{label} must stay inside the target repository and within the target root: {locator}"]
+        return None, [f"{label} must stay within the target root and inside the target repository: {locator}"]
     return candidate, []
 
 

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -481,8 +481,8 @@ def locator_boundary_error(raw_locator: object, *, label: str) -> str:
     locator = raw_locator.strip()
     locator_path = Path(locator)
     if locator_path.is_absolute() or ".." in locator_path.parts:
-        return f"{label} must stay within the repository root: {locator}"
-    return f"{label} must stay within the repository root: {locator}"
+        return f"{label} must stay inside the repository and within the repository root: {locator}"
+    return f"{label} must stay inside the repository and within the repository root: {locator}"
 
 
 def resolve_locator(root: Path, raw_locator: object) -> tuple[str | None, Path | None]:

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -6422,6 +6422,40 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
         if payload.get("status") != "block" or not any("must stay inside" in error for error in errors):
             failures.append(Failure("adversarial-adoption", "registry executable and manifest paths must not escape the runtime root"))
 
+        fact_chain_escape = base / "fact-chain-error-anchor"
+        (fact_chain_escape / ".loom/bootstrap").mkdir(parents=True)
+        write_json(
+            fact_chain_escape / ".loom/bootstrap/init-result.json",
+            {
+                "schema_version": "loom-init-output/v1",
+                "fact_chain": {
+                    "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
+                    "mode": "work-item + recovery-entry + derived status-surface",
+                    "entry_points": {
+                        "current_item_id": "INIT-0001",
+                        "work_item": "../outside.md",
+                        "recovery_entry": ".loom/progress/INIT-0001.md",
+                        "status_surface": ".loom/status/current.md",
+                    }
+                },
+            },
+        )
+        _, errors = inspect_fact_chain(fact_chain_escape)
+        if not any("must stay within the target root" in error for error in errors):
+            failures.append(Failure("adversarial-adoption", "fact-chain path-boundary errors must expose a stable target-root anchor"))
+
+        shadow_anchor_errors = governance_surface_module.validate_shadow_surface(
+            root=base,
+            surface="review",
+            entry={
+                "summary": "review parity",
+                "loom_locator": ".loom/shadow/review-loom.json",
+                "repo_locator": "../outside.json",
+            },
+        )
+        if not any("must stay inside the repository" in error for error in shadow_anchor_errors):
+            failures.append(Failure("adversarial-adoption", "shadow surface path-boundary errors must expose a stable repository anchor"))
+
         spec_contract_target = base / "spec-contract"
         (spec_contract_target / ".loom/specs/INIT-0001").mkdir(parents=True)
         (spec_contract_target / ".loom/specs/INIT-0001/spec.md").write_text("bootstrap spec\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Stabilize Loom path-boundary error anchors exposed by Syvert official adoption.
- Keep fail-closed behavior unchanged; only make target-root and repository-boundary messages mechanically consumable by downstream carrier tests.
- Add Loom-owned adversarial fixture coverage for these anchors.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`

Closes #384