### PR TITLE
fix: 补齐 repository 边界错误锚点

### DIFF
--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -481,8 +481,8 @@ def locator_boundary_error(raw_locator: object, *, label: str) -> str:
     locator = raw_locator.strip()
     locator_path = Path(locator)
     if locator_path.is_absolute() or ".." in locator_path.parts:
-        return f"{label} must stay inside the repository and within the repository root: {locator}"
-    return f"{label} must stay inside the repository and within the repository root: {locator}"
+        return f"{label} must stay within the repository root and must stay inside the repository: {locator}"
+    return f"{label} must stay within the repository root and must stay inside the repository: {locator}"
 
 
 def resolve_locator(root: Path, raw_locator: object) -> tuple[str | None, Path | None]:

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -6453,7 +6453,11 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "repo_locator": "../outside.json",
             },
         )
-        if not any("must stay inside the repository" in error for error in shadow_anchor_errors):
+        if not any(
+            "must stay inside the repository" in error
+            and "must stay within the repository root" in error
+            for error in shadow_anchor_errors
+        ):
             failures.append(Failure("adversarial-adoption", "shadow surface path-boundary errors must expose a stable repository anchor"))
 
         spec_contract_target = base / "spec-contract"


### PR DESCRIPTION
## Summary
- Add both stable repository path-boundary anchors to Loom locator errors.
- Keep fail-closed behavior unchanged.
- Extend adversarial adoption checks so downstream projects do not need local wording patches.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`

Closes #386