### PR TITLE
feat: 增加结构化 path-boundary 错误合同

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -119,19 +119,19 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "e5c52cda01f1107cafcd00bf2d37feaa167f1acd5152fc8f41f28ee3255a7d52"
+      "sha256": "78cf0d0022a4c03933a5e46cba676e80cafa5d0802fb95191a761ec9f9417e65"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "c8be9d24fe9afad7ffce1d1e7eb7394ce28ae7f3eeb5243a9b7bc9a854e9871f"
+      "sha256": "902bba15e9da421b9a48a051940a67a2b019cd14b938d8acd2679c760734b2f5"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "e9b376551600383e95e4f707557bb957edf51cd9ee2263587b8b6109088b737c"
+      "sha256": "2a0e0c49c268e6d00cffbabc11f985a00b7a700adbe7bb6efa4f2da7c08c10fd"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "50a031d3cda589e4f020639d0305370281ce6d3e644e14aaa8c9ba090773d15f"
+      "sha256": "5fbb3018d4ac1764d711bca30f5d4ce1a0466015856a99c59fa4a1d25f732a7b"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-384-path-boundary-error-anchors",
+            "locator": "issue-388-structured-path-boundary-errors",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -41,19 +41,19 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "e5c52cda01f1107cafcd00bf2d37feaa167f1acd5152fc8f41f28ee3255a7d52"
+      "sha256": "78cf0d0022a4c03933a5e46cba676e80cafa5d0802fb95191a761ec9f9417e65"
     },
     {
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "c8be9d24fe9afad7ffce1d1e7eb7394ce28ae7f3eeb5243a9b7bc9a854e9871f"
+      "sha256": "902bba15e9da421b9a48a051940a67a2b019cd14b938d8acd2679c760734b2f5"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "e9b376551600383e95e4f707557bb957edf51cd9ee2263587b8b6109088b737c"
+      "sha256": "2a0e0c49c268e6d00cffbabc11f985a00b7a700adbe7bb6efa4f2da7c08c10fd"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "50a031d3cda589e4f020639d0305370281ce6d3e644e14aaa8c9ba090773d15f"
+      "sha256": "5fbb3018d4ac1764d711bca30f5d4ce1a0466015856a99c59fa4a1d25f732a7b"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/fact_chain_support.py
+++ b/skills/shared/scripts/fact_chain_support.py
@@ -204,6 +204,40 @@ def resolve_repo_relative_path(target_root: Path, relative: str, *, label: str) 
     return candidate, []
 
 
+def path_boundary_missing_details(*, label: str, locator: object, errors: list[str]) -> list[dict[str, object]]:
+    """Return stable machine-readable details for repo locator boundary failures."""
+    locator_text = "" if locator is None else str(locator)
+    details: list[dict[str, object]] = []
+    for message in errors:
+        if "non-empty" in message:
+            kind = "empty_locator"
+        elif "absolute path" in message or "repo-relative" in message:
+            kind = "absolute_locator"
+        else:
+            kind = "repo_locator_escape"
+
+        scopes: list[str] = []
+        if "target root" in message:
+            scopes.append("target_root")
+        if "repository" in message or "repo-relative" in message:
+            scopes.append("repository_root")
+        if not scopes:
+            scopes.append("repository_root")
+
+        for scope in scopes:
+            details.append(
+                {
+                    "category": "path_boundary",
+                    "kind": kind,
+                    "scope": scope,
+                    "label": label,
+                    "locator": locator_text,
+                    "message": message,
+                }
+            )
+    return details
+
+
 def parse_work_item(path: Path, root: Path) -> tuple[dict[str, object], list[str]]:
     relative_path = _relative(path, root)
     sections = markdown_sections(path)

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1062,6 +1062,26 @@ def require_repo_specific_requirements_payload(
             failures.append(Failure(category, f"{context} declared requirements must split cleanly into blocking and advisory"))
 
 
+def require_missing_details(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    details: object,
+) -> None:
+    if not isinstance(details, list):
+        failures.append(Failure(category, f"{context} must be a list"))
+        return
+    for index, detail in enumerate(details):
+        if not isinstance(detail, dict):
+            failures.append(Failure(category, f"{context}[{index}] must be an object"))
+            continue
+        for field in ("category", "kind", "scope", "label", "locator", "message"):
+            value = detail.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}[{index}] missing `{field}`"))
+
+
 def require_shadow_parity_payload(
     failures: list[Failure],
     *,
@@ -1090,6 +1110,14 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    top_level_details = payload.get("missing_details")
+    if top_level_details is not None:
+        require_missing_details(
+            failures,
+            category=category,
+            context=f"{context}.missing_details",
+            details=top_level_details,
+        )
     require_runtime_state_payload(
         failures,
         category=category,
@@ -1133,6 +1161,14 @@ def require_shadow_parity_payload(
             failures.append(Failure(category, f"{context} reports[{index}] must include non-empty `summary`"))
         if not isinstance(report.get("missing_inputs"), list):
             failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+        report_details = report.get("missing_details")
+        if report_details is not None:
+            require_missing_details(
+                failures,
+                category=category,
+                context=f"{context} reports[{index}].missing_details",
+                details=report_details,
+            )
         for key in ("host_adapters", "repo_native_carriers"):
             if not isinstance(report.get(key), list):
                 failures.append(Failure(category, f"{context} reports[{index}] must include `{key}` as a list"))
@@ -6460,6 +6496,43 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
         ):
             failures.append(Failure("adversarial-adoption", "shadow surface path-boundary errors must expose a stable repository anchor"))
 
+        shadow_boundary_target = base / "shadow-structured-boundary"
+        (shadow_boundary_target / ".loom/companion").mkdir(parents=True)
+        write_json(
+            shadow_boundary_target / ".loom/companion/interop.json",
+            {
+                "schema_version": "loom-repo-interop/v1",
+                "host_adapters": [],
+                "repo_native_carriers": [],
+                "shadow_surfaces": {
+                    "review": {
+                        "summary": "review parity",
+                        "loom_locator": "../outside-loom.json",
+                        "repo_locator": "../outside-repo.json",
+                    }
+                },
+            },
+        )
+        shadow_boundary_report = loom_flow_module.shadow_parity_report(
+            {
+                "availability": "present",
+                "contract": {"locator": ".loom/companion/interop.json"},
+            },
+            target_root=shadow_boundary_target,
+            surface="review",
+        )
+        shadow_boundary_details = shadow_boundary_report.get("missing_details")
+        if not isinstance(shadow_boundary_details, list) or not any(
+            isinstance(detail, dict)
+            and detail.get("category") == "path_boundary"
+            and detail.get("kind") == "repo_locator_escape"
+            and detail.get("scope") == "repository_root"
+            and detail.get("label") == "shadow surface `review` repo_locator"
+            and detail.get("locator") == "../outside-repo.json"
+            for detail in shadow_boundary_details
+        ):
+            failures.append(Failure("adversarial-adoption", "shadow parity path-boundary failures must expose structured missing_details"))
+
         spec_contract_target = base / "spec-contract"
         (spec_contract_target / ".loom/specs/INIT-0001").mkdir(parents=True)
         (spec_contract_target / ".loom/specs/INIT-0001/spec.md").write_text("bootstrap spec\n", encoding="utf-8")
@@ -6622,6 +6695,15 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
             failures.append(Failure("adversarial-adoption", f"path escape shadow-parity sample failed: {error}"))
         elif shadow_escape_payload.get("result") != "block":
             failures.append(Failure("adversarial-adoption", "shadow-parity blocking mode must reject absolute shadow locators"))
+        else:
+            shadow_escape_details = shadow_escape_payload.get("missing_details")
+            if not isinstance(shadow_escape_details, list) or not any(
+                isinstance(detail, dict)
+                and detail.get("category") == "path_boundary"
+                and "loom_locator" in str(detail.get("label", ""))
+                for detail in shadow_escape_details
+            ):
+                failures.append(Failure("adversarial-adoption", "shadow-parity CLI payload must aggregate structured path-boundary missing_details"))
 
         poisoned_payload, error = load_command_json(
             root,

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -26,6 +26,7 @@ from fact_chain_support import (
     parse_key_value_section,
     parse_recovery_entry,
     parse_work_item,
+    path_boundary_missing_details,
     resolve_repo_relative_path,
 )
 from governance_surface import build_governance_surface
@@ -609,6 +610,17 @@ def repo_relative_path(target_root: Path, relative: str) -> Path | None:
     return None if errors else candidate
 
 
+def path_boundary_details_from_messages(errors: list[str]) -> list[dict[str, object]]:
+    details: list[dict[str, object]] = []
+    for message in errors:
+        if "must stay" not in message and "repo-relative" not in message and "non-empty repo-relative" not in message:
+            continue
+        label = message.split(" must ", 1)[0] if " must " in message else "repo locator"
+        locator = message.rsplit(": ", 1)[-1] if ": " in message else ""
+        details.extend(path_boundary_missing_details(label=label, locator=locator, errors=[message]))
+    return details
+
+
 def validate_shadow_sources(payload: dict[str, Any], *, path: Path, target_root: Path) -> tuple[dict[str, Any], list[str]]:
     source_files = payload.get("source_files")
     source_sha256 = payload.get("source_sha256")
@@ -766,10 +778,16 @@ def shadow_parity_report(
     }
     interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
     if interop_errors:
-        return {
+        missing_details = path_boundary_details_from_messages(interop_errors)
+        payload = {
             **empty_report,
             "summary": "shadow parity is unavailable because the repo interop contract is missing or incomplete.",
             "missing_inputs": interop_errors,
+        }
+        if missing_details:
+            payload["missing_details"] = missing_details
+        return {
+            **payload,
         }
     if not isinstance(interop_payload, dict):
         return empty_report
@@ -813,10 +831,23 @@ def shadow_parity_report(
         label=f"shadow surface `{surface}` repo_locator",
     )
     if loom_locator_errors or repo_locator_errors:
+        missing_details = [
+            *path_boundary_missing_details(
+                label=f"shadow surface `{surface}` loom_locator",
+                locator=loom_locator,
+                errors=loom_locator_errors,
+            ),
+            *path_boundary_missing_details(
+                label=f"shadow surface `{surface}` repo_locator",
+                locator=repo_locator,
+                errors=repo_locator_errors,
+            ),
+        ]
         return {
             **empty_report,
             "summary": "shadow parity is unavailable because a declared surface locator is unsafe.",
             "missing_inputs": [*loom_locator_errors, *repo_locator_errors],
+            "missing_details": missing_details,
             "host_adapters": relevant_host_adapters,
             "repo_native_carriers": relevant_repo_native_carriers,
         }
@@ -7738,25 +7769,32 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             summary = "shadow parity could not fully read the declared governance surfaces."
 
     missing_inputs: list[str] = []
+    missing_details: list[Any] = []
     for report in reports:
         for message in report.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+        details = report.get("missing_details")
+        if isinstance(details, list):
+            for detail in details:
+                if detail not in missing_details:
+                    missing_details.append(detail)
 
-    return emit(
-        {
-            "command": "shadow-parity",
-            "mode": mode,
-            "blocking": mode == "blocking",
-            "result": result,
-            "summary": summary,
-            "missing_inputs": missing_inputs,
-            "fallback_to": "manual-reconciliation" if result == "block" else None,
-            "runtime_state": runtime_state,
-            "governance_surface": governance_surface,
-            "reports": reports,
-        }
-    )
+    payload = {
+        "command": "shadow-parity",
+        "mode": mode,
+        "blocking": mode == "blocking",
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "fallback_to": "manual-reconciliation" if result == "block" else None,
+        "runtime_state": runtime_state,
+        "governance_surface": governance_surface,
+        "reports": reports,
+    }
+    if missing_details:
+        payload["missing_details"] = missing_details
+    return emit(payload)
 
 
 def handle_runtime_parity(args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary
- closes #388
- adds machine-readable `missing_details` for path-boundary failures while preserving `missing_inputs` text
- aggregates shadow-parity report details into the top-level CLI payload
- extends adversarial adoption checks and refreshes generated example hashes

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`