### PR TITLE
fix: 阻断 work-item 激活前 locator 污染

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "2a0e0c49c268e6d00cffbabc11f985a00b7a700adbe7bb6efa4f2da7c08c10fd"
+      "sha256": "e5f386988863d970ebf5415bfdb3a91159b120a84d3acd82ca3435be6f9af19c"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "5fbb3018d4ac1764d711bca30f5d4ce1a0466015856a99c59fa4a1d25f732a7b"
+      "sha256": "f5119cf04e195c79dfeb58c33c5d4c8e524c2eb2b162b5906cc04a655465543e"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-388-structured-path-boundary-errors",
+            "locator": "issue-390-work-item-update-activate-fail-closed",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "2a0e0c49c268e6d00cffbabc11f985a00b7a700adbe7bb6efa4f2da7c08c10fd"
+      "sha256": "e5f386988863d970ebf5415bfdb3a91159b120a84d3acd82ca3435be6f9af19c"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "5fbb3018d4ac1764d711bca30f5d4ce1a0466015856a99c59fa4a1d25f732a7b"
+      "sha256": "f5119cf04e195c79dfeb58c33c5d4c8e524c2eb2b162b5906cc04a655465543e"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3690,6 +3690,42 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         elif payload.get("result") != "pass":
             failures.append(Failure("daily-execution-cli", "`work-item update` must pass on a clean temp copy"))
 
+        poisoned_authoring_target = temp_root / "authoring-poisoned-workspace"
+        shutil.copytree(authoring_target, poisoned_authoring_target)
+        poisoned_work_item = poisoned_authoring_target / ".loom/work-items/NEXT-0001.md"
+        poisoned_before = poisoned_work_item.read_text(encoding="utf-8").replace(
+            "- Workspace Entry: .",
+            "- Workspace Entry: ../outside.md",
+        )
+        poisoned_work_item.write_text(poisoned_before, encoding="utf-8")
+        poisoned_init = poisoned_authoring_target / ".loom/bootstrap/init-result.json"
+        poisoned_init_before = load_json_file(poisoned_init)
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "work-item",
+                "update",
+                "--target",
+                str(poisoned_authoring_target),
+                "--item",
+                "NEXT-0001",
+                "--scope",
+                "This update must not persist because the workspace locator is unsafe",
+                "--activate",
+            ],
+        )
+        poisoned_init_after = load_json_file(poisoned_init)
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`work-item update --activate` poisoned workspace sample failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`work-item update --activate` must block poisoned workspace locators"))
+        elif poisoned_work_item.read_text(encoding="utf-8") != poisoned_before:
+            failures.append(Failure("daily-execution-cli", "`work-item update --activate` must not rewrite a poisoned Work Item before locator validation passes"))
+        elif poisoned_init_after.get("fact_chain", {}).get("entry_points") != poisoned_init_before.get("fact_chain", {}).get("entry_points"):
+            failures.append(Failure("daily-execution-cli", "`work-item update --activate` must not mutate active fact-chain locators when locator validation blocks"))
+
         payload, error = load_command_json(
             root,
             [
@@ -6677,6 +6713,38 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
             failures.append(Failure("adversarial-adoption", f"path escape work-item sample failed: {error}"))
         elif escape_work_item_payload.get("result") != "block":
             failures.append(Failure("adversarial-adoption", "work-item create must block recovery locators that escape the target root"))
+
+        poisoned_work_item_target = base / "work-item-update-poisoned-locator"
+        shutil.copytree(baseline, poisoned_work_item_target)
+        poisoned_work_item_path = poisoned_work_item_target / ".loom/work-items/INIT-0001.md"
+        poisoned_work_item_text = poisoned_work_item_path.read_text(encoding="utf-8").replace(
+            "- Recovery Entry: .loom/progress/INIT-0001.md",
+            "- Recovery Entry: ../outside.md",
+        )
+        poisoned_work_item_path.write_text(poisoned_work_item_text, encoding="utf-8")
+        poisoned_init_path = poisoned_work_item_target / ".loom/bootstrap/init-result.json"
+        poisoned_init_before = poisoned_init_path.read_text(encoding="utf-8")
+        poisoned_update_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "work-item",
+                "update",
+                "--target",
+                str(poisoned_work_item_target),
+                "--item",
+                "INIT-0001",
+                "--activate",
+            ],
+        )
+        poisoned_init_after = poisoned_init_path.read_text(encoding="utf-8")
+        if error:
+            failures.append(Failure("adversarial-adoption", f"poisoned work-item update sample failed: {error}"))
+        elif poisoned_update_payload.get("result") != "block":
+            failures.append(Failure("adversarial-adoption", "work-item update --activate must block poisoned recovery locators"))
+        elif poisoned_init_before != poisoned_init_after:
+            failures.append(Failure("adversarial-adoption", "work-item update --activate must not mutate init-result before locator validation passes"))
 
         shadow_escape_target = base / "shadow-locator-escape"
         shutil.copytree(baseline, shadow_escape_target)

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -6975,6 +6975,39 @@ def update_active_entry_points(
     output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
+def validate_work_item_payload_locators(
+    target_root: Path,
+    work_item_payload: dict[str, Any],
+) -> tuple[dict[str, Path], list[str]]:
+    """Validate final authored locator truth before any Work Item carrier write."""
+    locators: dict[str, str] = {
+        "recovery_entry": str(work_item_payload.get("recovery_entry", "")),
+        "review_entry": str(work_item_payload.get("review_entry", "")),
+    }
+    associated_artifacts = work_item_payload.get("associated_artifacts", [])
+    if isinstance(associated_artifacts, list):
+        for index, artifact in enumerate(associated_artifacts, start=1):
+            locators[f"associated_artifacts[{index}]"] = str(artifact)
+    else:
+        return {}, ["associated_artifacts must be a list of repo-relative locators"]
+
+    resolved: dict[str, Path] = {}
+    errors: list[str] = []
+    workspace_path, workspace_errors = resolve_workspace_path(
+        target_root,
+        str(work_item_payload.get("workspace_entry", "")),
+    )
+    errors.extend(f"work item workspace_entry: {message}" for message in workspace_errors)
+    if workspace_path is not None:
+        resolved["workspace_entry"] = workspace_path
+    for label, locator in locators.items():
+        path, locator_errors = resolve_repo_relative_path(target_root, locator, label=f"work item {label}")
+        errors.extend(locator_errors)
+        if path is not None:
+            resolved[label] = path
+    return resolved, errors
+
+
 def handle_work_item(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     output_path, output_errors = resolve_repo_relative_path(target_root, args.output, label="init-result locator")
@@ -7090,6 +7123,23 @@ def handle_work_item(args: argparse.Namespace) -> int:
             "closing_condition": args.closing_condition,
             "associated_artifacts": deduped_artifacts,
         }
+        resolved_payload_locators, payload_locator_errors = validate_work_item_payload_locators(
+            target_root,
+            work_item_payload,
+        )
+        if payload_locator_errors:
+            return emit(
+                {
+                    "command": "work-item",
+                    "operation": "create",
+                    "result": "block",
+                    "summary": "work-item create refused unsafe authored locator input.",
+                    "missing_inputs": payload_locator_errors,
+                    "fallback_to": "admission",
+                }
+            )
+        recovery_path = resolved_payload_locators["recovery_entry"]
+        review_path = resolved_payload_locators["review_entry"]
         work_item_path.parent.mkdir(parents=True, exist_ok=True)
         work_item_path.write_text(render_work_item(work_item_payload), encoding="utf-8")
         review_path.parent.mkdir(parents=True, exist_ok=True)
@@ -7199,7 +7249,22 @@ def handle_work_item(args: argparse.Namespace) -> int:
                 entry for entry in work_item_payload["associated_artifacts"] if entry != artifact
             ]
         recovery_relative = work_item_payload["recovery_entry"]
-        recovery_path = target_root / recovery_relative
+        resolved_payload_locators, payload_locator_errors = validate_work_item_payload_locators(
+            target_root,
+            work_item_payload,
+        )
+        if payload_locator_errors:
+            return emit(
+                {
+                    "command": "work-item",
+                    "operation": "update",
+                    "result": "block",
+                    "summary": "work-item update refused unsafe authored locator input.",
+                    "missing_inputs": payload_locator_errors,
+                    "fallback_to": "admission",
+                }
+            )
+        recovery_path = resolved_payload_locators["recovery_entry"]
         work_item_path.write_text(render_work_item(work_item_payload), encoding="utf-8")
 
     if args.activate:


### PR DESCRIPTION
## Summary
- closes #390
- validates final Work Item locator payload before create/update writes
- blocks poisoned `work-item update --activate` before Work Item or init-result mutation
- refreshes generated example bootstrap hashes and installer version

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`