### PR TITLE
fix: 收紧 runtime 与 governance 路径边界

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -125,7 +125,7 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "902bba15e9da421b9a48a051940a67a2b019cd14b938d8acd2679c760734b2f5"
+      "sha256": "02e6f66afcfad5b117ea9a801c7153466f24c6d5721da1546f286aa046c548f1"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -149,13 +149,13 @@
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/runtime_state.py",
-      "sha256": "3375830ede9bec65083d9ee6cfac5f5a7e3bd781ef90c78a087c39d37f2cfab2"
+      "sha256": "e4de653a5206269faa731808a0f44667a7db811053b8488e8b61a6393917815b"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "f5119cf04e195c79dfeb58c33c5d4c8e524c2eb2b162b5906cc04a655465543e"
+      "sha256": "43d96461db5e300ee40f44d0ed0cf29cf610aa8bf7343a98ff93cb7a54e36ffe"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-390-work-item-update-activate-fail-closed",
+            "locator": "issue-392-runtime-governance-path-containment",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -47,7 +47,7 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "902bba15e9da421b9a48a051940a67a2b019cd14b938d8acd2679c760734b2f5"
+      "sha256": "02e6f66afcfad5b117ea9a801c7153466f24c6d5721da1546f286aa046c548f1"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -71,13 +71,13 @@
       "path": ".loom/bin/runtime_state.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/runtime_state.py",
-      "sha256": "3375830ede9bec65083d9ee6cfac5f5a7e3bd781ef90c78a087c39d37f2cfab2"
+      "sha256": "e4de653a5206269faa731808a0f44667a7db811053b8488e8b61a6393917815b"
     },
     {
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "f5119cf04e195c79dfeb58c33c5d4c8e524c2eb2b162b5906cc04a655465543e"
+      "sha256": "43d96461db5e300ee40f44d0ed0cf29cf610aa8bf7343a98ff93cb7a54e36ffe"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -320,9 +320,9 @@ def file_exists(root: Path, relative: str) -> bool:
 
 def relative_locator(path: Path, root: Path) -> str:
     try:
-        return str(path.relative_to(root))
-    except ValueError:
-        return str(path)
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return ""
 
 
 def safe_read_json(path: Path) -> dict[str, Any] | None:
@@ -961,19 +961,24 @@ def first_match(directory: Path, suffix: str, root: Path) -> str:
 
 
 def existing_locator(root: Path, relative: str | None) -> str:
-    if not relative:
+    locator, target = resolve_locator(root, relative)
+    if locator is None or target is None:
         return ""
-    return relative if (root / relative).exists() else ""
+    return locator if target.exists() else ""
 
 
 def active_or_first(root: Path, relative: str | None, directory: Path, suffix: str) -> str:
-    return existing_locator(root, relative) or (first_match(directory, suffix, root) if directory.exists() else "")
+    if relative is not None and str(relative).strip():
+        return existing_locator(root, relative)
+    return first_match(directory, suffix, root) if directory.exists() else ""
 
 
 def current_review_locator(root: Path, review_dir: Path, item_id: str) -> str:
     review_path = review_dir / f"{item_id}.json"
     if review_path.exists():
         return relative_locator(review_path, root)
+    if item_id:
+        return ""
     return first_match(review_dir, ".json", root) if review_dir.exists() else ""
 
 
@@ -1006,7 +1011,6 @@ def detect_carrier_summary(root: Path, *, repository_mode: str, planning_mode: b
     recovery_dir = root / ".loom/progress"
     review_dir = root / ".loom/reviews"
     status_locator = active.get("status_surface") or ".loom/status/current.md"
-    status_path = root / status_locator
     spec_path = root / f".loom/specs/{active_item_id}/spec.md"
     plan_path = root / f".loom/specs/{active_item_id}/plan.md"
 
@@ -1014,7 +1018,7 @@ def detect_carrier_summary(root: Path, *, repository_mode: str, planning_mode: b
         "work_item": active_or_first(root, active.get("work_item"), item_dir, ".md"),
         "recovery": active_or_first(root, active.get("recovery_entry"), recovery_dir, ".md"),
         "review": current_review_locator(root, review_dir, active_item_id),
-        "status_surface": relative_locator(status_path, root) if status_path.exists() else "",
+        "status_surface": existing_locator(root, status_locator),
         "spec_path": relative_locator(spec_path, root) if spec_path.exists() else "",
         "plan_path": relative_locator(plan_path, root) if plan_path.exists() else "",
     }

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -3995,6 +3995,31 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
         elif payload.get("result") != "block":
             failures.append(Failure("daily-execution-cli", "`installed runtime-state` must block on scene/carrier conflict"))
 
+        source_repo = tmp_root / "source"
+        sibling_prefix_install = tmp_root / "source-evil" / "skills"
+        source_repo.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(root / "skills", sibling_prefix_install)
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                str(sibling_prefix_install / "shared" / "scripts" / "loom_flow.py"),
+                "runtime-state",
+                "--target",
+                str(target_root),
+            ],
+            env={"LOOM_SOURCE_REPO_ROOT": str(source_repo)},
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`repo-local runtime-state` sibling-prefix escape failed unexpectedly: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`repo-local runtime-state` must block sibling-prefix install roots outside the source repo"))
+        else:
+            runtime_state = payload.get("runtime_state")
+            missing_inputs = runtime_state.get("missing_inputs") if isinstance(runtime_state, dict) else []
+            if not any("install root must stay inside the source repository" in str(item) for item in missing_inputs):
+                failures.append(Failure("daily-execution-cli", "`repo-local runtime-state` sibling-prefix escape must expose the source-repo containment error"))
+
         payload, error = load_command_json(
             root,
             ["python3", ".loom/bin/loom_init.py", "runtime-state", "--target", "."],
@@ -4055,6 +4080,35 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             failures.append(Failure("daily-execution-cli", f"`bootstrapped runtime-state` provenance hash drift failed unexpectedly: {error}"))
         elif payload.get("result") != "block":
             failures.append(Failure("daily-execution-cli", "`bootstrapped runtime-state` must block when runtime provenance hashes drift"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-governance-surface-boundary-") as tmp:
+        tmp_root = Path(tmp)
+        outside = tmp_root / "outside.md"
+        outside.write_text("# outside\n", encoding="utf-8")
+        for label, unsafe_locator in (
+            ("parent escape", "../outside.md"),
+            ("absolute locator", str(outside)),
+        ):
+            poisoned_target = tmp_root / f"governance-{label.replace(' ', '-')}"
+            shutil.copytree(example_target, poisoned_target)
+            init_result_path = poisoned_target / ".loom/bootstrap/init-result.json"
+            init_result = load_json_file(init_result_path)
+            if isinstance(init_result, dict):
+                entry_points = init_result.get("fact_chain", {}).get("entry_points")
+                if isinstance(entry_points, dict):
+                    entry_points["work_item"] = unsafe_locator
+                    entry_points["recovery_entry"] = unsafe_locator
+                    entry_points["status_surface"] = unsafe_locator
+                init_result_path.write_text(json.dumps(init_result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            governance_surface = build_governance_surface(poisoned_target)
+            carrier_summary = governance_surface.get("carrier_summary") if isinstance(governance_surface, dict) else None
+            if not isinstance(carrier_summary, dict):
+                failures.append(Failure("daily-execution-cli", f"`governance surface` {label} fixture must expose carrier summary"))
+                continue
+            for carrier in ("work_item", "recovery", "status_surface"):
+                entry = carrier_summary.get(carrier)
+                if isinstance(entry, dict) and entry.get("status") == "present":
+                    failures.append(Failure("daily-execution-cli", f"`governance surface` must not report unsafe {label} `{carrier}` fact-chain locators as present"))
 
     if shutil.which("git") is not None:
         with tempfile.TemporaryDirectory(prefix="loom-check-installed-pre-merge-") as tmp:

--- a/skills/shared/scripts/runtime_state.py
+++ b/skills/shared/scripts/runtime_state.py
@@ -105,6 +105,14 @@ def _resolve_inside(root: Path, relative: str, *, label: str) -> tuple[Path | No
     return candidate, None
 
 
+def _path_is_inside(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+    return True
+
+
 def _default_scene_for_carrier(carrier: str) -> str:
     if carrier == "repo-local-wrapper":
         return "repo-local-demo"
@@ -378,7 +386,7 @@ def detect_runtime_state(caller_file: str, entry_family: str, *, target_root: Pa
                 repo_root = repo_local_root(caller_file)
                 if repo_root is None:
                     carrier_errors.append("repo-local wrapper is missing `LOOM_SOURCE_REPO_ROOT`")
-                elif not str(install_root).startswith(str(repo_root)):
+                elif not _path_is_inside(install_root, repo_root):
                     carrier_errors.append("repo-local wrapper install root must stay inside the source repository")
             if not shared.exists():
                 carrier_errors.append(f"shared runtime root is missing: {shared}")


### PR DESCRIPTION
## Summary
- Replace string-prefix repo containment in runtime-state detection with resolved path containment.
- Make governance surface carrier locators fail closed for unsafe active fact-chain locators instead of falling back to the first matching carrier.
- Add adversarial loom_check coverage for sibling-prefix install roots and poisoned work_item / recovery_entry / status_surface locators.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`

Closes #392