### PR TITLE
fix: 收紧 closeout 与 reconciliation 边界

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "e5f386988863d970ebf5415bfdb3a91159b120a84d3acd82ca3435be6f9af19c"
+      "sha256": "334a8df4ef8400125b6e7c311d386ac98c15f34c5be91befb9499215ee4ba0c4"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "43d96461db5e300ee40f44d0ed0cf29cf610aa8bf7343a98ff93cb7a54e36ffe"
+      "sha256": "71f0b9a7d55526b119af75b06c9787d875c27e19bbea70853ebc3df11f43eee7"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-392-runtime-governance-path-containment",
+            "locator": "issue-394-closeout-reconciliation-boundaries",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "e5f386988863d970ebf5415bfdb3a91159b120a84d3acd82ca3435be6f9af19c"
+      "sha256": "334a8df4ef8400125b6e7c311d386ac98c15f34c5be91befb9499215ee4ba0c4"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "43d96461db5e300ee40f44d0ed0cf29cf610aa8bf7343a98ff93cb7a54e36ffe"
+      "sha256": "71f0b9a7d55526b119af75b06c9787d875c27e19bbea70853ebc3df11f43eee7"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.42",
+      "version": "0.1.43",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -6915,6 +6915,120 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
             elif after_payload.get("refresh_needed"):
                 failures.append(Failure("adversarial-adoption", "carrier refresh --write must clear runtime provenance drift"))
 
+        outside_comment = base / "outside-comment.md"
+        outside_comment.write_text("sensitive local text\n", encoding="utf-8")
+        comment_escape_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "reconciliation",
+                "sync",
+                "--target",
+                str(baseline),
+                "--comment-file",
+                str(outside_comment),
+                "--dry-run",
+            ],
+        )
+        if error:
+            failures.append(Failure("adversarial-adoption", f"reconciliation comment-file boundary sample failed: {error}"))
+        elif comment_escape_payload.get("result") != "block":
+            failures.append(Failure("adversarial-adoption", "reconciliation --comment-file must block absolute paths outside the target root"))
+        else:
+            missing_inputs = comment_escape_payload.get("missing_inputs")
+            if not isinstance(missing_inputs, list) or not any(
+                "reconciliation comment file" in str(item) and "must be repo-relative" in str(item)
+                for item in missing_inputs
+            ):
+                failures.append(Failure("adversarial-adoption", "reconciliation --comment-file boundary block must report the comment file locator boundary error"))
+
+        original_pr_payload = loom_flow_module.github_pr_payload
+        original_issue_payload = loom_flow_module.github_issue_payload
+        original_reconciliation_audit = loom_flow_module.reconciliation_audit_payload
+        original_contains = loom_flow_module.contains_merged_commit
+        seen_target_branches: list[str] = []
+        try:
+            loom_flow_module.github_pr_payload = lambda *_args, **_kwargs: (
+                {
+                    "state": "MERGED",
+                    "baseRefName": "release/main",
+                    "mergeCommit": {"oid": "abc123"},
+                },
+                [],
+            )
+            loom_flow_module.github_issue_payload = lambda *_args, **_kwargs: (
+                {"state": "CLOSED", "id": "issue-id"},
+                [],
+            )
+            loom_flow_module.reconciliation_audit_payload = lambda **_kwargs: (
+                {
+                    "result": "pass",
+                    "findings": [],
+                    "missing_inputs": [],
+                    "fallback_to": None,
+                },
+                [],
+            )
+
+            def fake_contains(_root: Path, _merge_commit_sha: str, target_branch: str = "main") -> bool:
+                seen_target_branches.append(target_branch)
+                return target_branch == "release/main"
+
+            loom_flow_module.contains_merged_commit = fake_contains
+            closeout_target_branch_payload, closeout_errors = loom_flow_module.closeout_payload(
+                target_root=baseline,
+                phase_number=None,
+                fr_number=None,
+                issue_number=1,
+                pr_number=2,
+                project_number=None,
+                branch_name=None,
+                owner="owner",
+                repo_name="repo",
+                skip_gate=True,
+            )
+            if closeout_errors:
+                failures.append(Failure("adversarial-adoption", f"closeout target branch fixture failed: {closeout_errors}"))
+            elif closeout_target_branch_payload.get("result") != "pass":
+                failures.append(Failure("adversarial-adoption", "closeout must pass when the merge commit is contained in the PR base branch"))
+            if seen_target_branches != ["release/main"]:
+                failures.append(Failure("adversarial-adoption", "closeout must check merge commit containment against the PR base branch, including slash branches"))
+
+            seen_target_branches.clear()
+            loom_flow_module.github_pr_payload = lambda *_args, **_kwargs: (
+                {
+                    "state": "MERGED",
+                    "mergeCommit": {"oid": "abc123"},
+                },
+                [],
+            )
+            closeout_missing_base_payload, closeout_errors = loom_flow_module.closeout_payload(
+                target_root=baseline,
+                phase_number=None,
+                fr_number=None,
+                issue_number=1,
+                pr_number=2,
+                project_number=None,
+                branch_name=None,
+                owner="owner",
+                repo_name="repo",
+                skip_gate=True,
+            )
+            if closeout_errors:
+                failures.append(Failure("adversarial-adoption", f"closeout missing baseRefName fixture failed: {closeout_errors}"))
+            else:
+                missing_inputs = closeout_missing_base_payload.get("missing_inputs")
+                if closeout_missing_base_payload.get("result") != "block" or "pr baseRefName is missing" not in missing_inputs:
+                    failures.append(Failure("adversarial-adoption", "closeout must block when PR baseRefName is missing instead of falling back to main"))
+            if seen_target_branches:
+                failures.append(Failure("adversarial-adoption", "closeout must not check origin/main when PR baseRefName is missing"))
+        finally:
+            loom_flow_module.github_pr_payload = original_pr_payload
+            loom_flow_module.github_issue_payload = original_issue_payload
+            loom_flow_module.reconciliation_audit_payload = original_reconciliation_audit
+            loom_flow_module.contains_merged_commit = original_contains
+
         rollover_target = base / "active-rollover"
         shutil.copytree(baseline, rollover_target)
         payload, error = load_command_json(

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1040,6 +1040,21 @@ def read_text_file(path_str: str) -> tuple[str | None, list[str]]:
     return text, []
 
 
+def read_repo_relative_text_file(root: Path, path_str: str, *, label: str) -> tuple[str | None, list[str]]:
+    path, errors = resolve_repo_relative_path(root, path_str, label=label)
+    if errors:
+        return None, errors
+    if path is None:
+        return None, [f"{label} is unavailable"]
+    if not path.exists() or not path.is_file():
+        return None, [f"{label} points to a missing file: {path_str}"]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, [f"failed to read {path_str}: {exc.strerror or exc}"]
+    return text, []
+
+
 def write_json_file(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -5322,8 +5337,24 @@ def reconciliation_audit_payload(
                 if isinstance(oid, str) and oid:
                     merge_commit_sha = oid
                     base_ref = pr_payload.get("baseRefName")
-                    target_branch = base_ref if isinstance(base_ref, str) and base_ref else "main"
-                    merge_commit_in_main = contains_merged_commit(target_root, merge_commit_sha, target_branch)
+                    if isinstance(base_ref, str) and base_ref:
+                        merge_commit_in_main = contains_merged_commit(target_root, merge_commit_sha, base_ref)
+                    else:
+                        findings.append(
+                            make_reconciliation_finding(
+                                kind="merge_signal_drift",
+                                severity="block",
+                                subject=f"PR #{pr_number} merge signal",
+                                evidence={
+                                    "pr_state": pr_payload.get("state"),
+                                    "merge_commit": merge_commit_sha,
+                                    "baseRefName": base_ref,
+                                },
+                                recommended_action="re-read the PR base branch before closeout or reconciliation.",
+                                category="binding_failure",
+                                fallback_to="manual-reconciliation",
+                            )
+                        )
             if pr_payload.get("state") == "MERGED" and (not merge_commit_sha or not merge_commit_in_main):
                 findings.append(
                     make_reconciliation_finding(
@@ -6036,10 +6067,12 @@ def closeout_payload(
             if pr_payload.get("state") != "MERGED":
                 missing_inputs.append("pr is not merged")
             if merge_commit_sha:
-                run_git(target_root, ["fetch", "origin", "main"])
-                contains = run_git(target_root, ["merge-base", "--is-ancestor", merge_commit_sha, "origin/main"])
-                if contains is None or contains.returncode != 0:
-                    missing_inputs.append("origin/main does not contain the merged PR commit")
+                base_ref = pr_payload.get("baseRefName")
+                if isinstance(base_ref, str) and base_ref:
+                    if not contains_merged_commit(target_root, merge_commit_sha, base_ref):
+                        missing_inputs.append(f"origin/{base_ref} does not contain the merged PR commit")
+                else:
+                    missing_inputs.append("pr baseRefName is missing")
 
     project_payload: dict[str, Any] | None = None
     if project_number is not None:
@@ -6303,6 +6336,34 @@ def handle_reconciliation(args: argparse.Namespace) -> int:
                 summary="reconciliation is blocked because the Loom runtime state is inconsistent.",
             )
         )
+    if args.comment and args.comment_file:
+        return emit(
+            {
+                "command": "reconciliation",
+                "operation": args.operation,
+                "result": "block",
+                "summary": "reconciliation sync accepts either --comment or --comment-file, not both.",
+                "missing_inputs": ["choose one comment source"],
+                "fallback_to": "manual-reconciliation",
+                "runtime_state": runtime_state,
+            }
+        )
+
+    comment_body = args.comment
+    if args.comment_file:
+        comment_body, comment_errors = read_repo_relative_text_file(target_root, args.comment_file, label="reconciliation comment file")
+        if comment_errors:
+            return emit(
+                {
+                    "command": "reconciliation",
+                    "operation": args.operation,
+                    "result": "block",
+                    "summary": "reconciliation sync could not read the requested comment file.",
+                    "missing_inputs": comment_errors,
+                    "fallback_to": "manual-reconciliation",
+                    "runtime_state": runtime_state,
+                }
+            )
     owner = args.owner
     repo_name = args.repo_name
     if not owner or not repo_name:
@@ -6321,35 +6382,6 @@ def handle_reconciliation(args: argparse.Namespace) -> int:
                 "runtime_state": runtime_state,
             }
         )
-
-    if args.comment and args.comment_file:
-        return emit(
-            {
-                "command": "reconciliation",
-                "operation": args.operation,
-                "result": "block",
-                "summary": "reconciliation sync accepts either --comment or --comment-file, not both.",
-                "missing_inputs": ["choose one comment source"],
-                "fallback_to": "manual-reconciliation",
-                "runtime_state": runtime_state,
-            }
-        )
-
-    comment_body = args.comment
-    if args.comment_file:
-        comment_body, comment_errors = read_text_file(args.comment_file)
-        if comment_errors:
-            return emit(
-                {
-                    "command": "reconciliation",
-                    "operation": args.operation,
-                    "result": "block",
-                    "summary": "reconciliation sync could not read the requested comment file.",
-                    "missing_inputs": comment_errors,
-                    "fallback_to": "manual-reconciliation",
-                    "runtime_state": runtime_state,
-                }
-            )
 
     payload, errors = reconciliation_audit_payload(
         target_root=target_root,


### PR DESCRIPTION
## Summary
- closeout 使用 PR base branch 校验 merge commit，不再默认 origin/main
- reconciliation sync 的 --comment-file 改为 target root 内 repo-relative locator
- adversarial fixture 覆盖 comment-file path escape、slash base branch 与缺失 baseRefName

## Validation
- python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py
- python3 tools/loom_check.py .
- make loom-check
- npm --prefix packages/loom-installer test
- node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main

Closes #394