### PR TITLE
fix: 支持 detached worktree host binding fallback

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -125,7 +125,7 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "02e6f66afcfad5b117ea9a801c7153466f24c6d5721da1546f286aa046c548f1"
+      "sha256": "543e10c205be62f5be78704fe9bf27e808fc07ffe035382e3d4dd78ffa8c80cc"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-394-closeout-reconciliation-boundaries",
+            "locator": "issue-396-detached-worktree-host-binding",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -47,7 +47,7 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "02e6f66afcfad5b117ea9a801c7153466f24c6d5721da1546f286aa046c548f1"
+      "sha256": "543e10c205be62f5be78704fe9bf27e808fc07ffe035382e3d4dd78ffa8c80cc"
     },
     {
       "path": ".loom/bin/loom_flow.py",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.43",
+      "version": "0.1.44",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -1004,6 +1004,35 @@ def active_entry_points(root: Path) -> dict[str, str]:
     return active
 
 
+def bootstrap_host_binding_branch(root: Path) -> str:
+    init_result = root / ".loom/bootstrap/init-result.json"
+    try:
+        payload = json.loads(init_result.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(payload, dict):
+        return ""
+    governance_surface = payload.get("governance_surface")
+    if not isinstance(governance_surface, dict):
+        return ""
+    control_plane = governance_surface.get("governance_control_plane")
+    if not isinstance(control_plane, dict):
+        return ""
+    host_binding = control_plane.get("host_binding")
+    if not isinstance(host_binding, dict):
+        return ""
+    required_objects = host_binding.get("required_objects")
+    if not isinstance(required_objects, dict):
+        return ""
+    branch = required_objects.get("branch")
+    if not isinstance(branch, dict):
+        return ""
+    locator = branch.get("locator")
+    if isinstance(locator, str) and locator.strip() and locator != "unknown":
+        return locator.strip()
+    return ""
+
+
 def detect_carrier_summary(root: Path, *, repository_mode: str, planning_mode: bool) -> dict[str, dict[str, str]]:
     active = active_entry_points(root)
     active_item_id = active.get("current_item_id") or "INIT-0001"
@@ -1140,6 +1169,11 @@ def detect_host_binding_surface(
 ) -> dict[str, Any]:
     branch_result = run_process(["git", "branch", "--show-current"], root)
     branch = branch_result.stdout.strip() if branch_result.returncode == 0 else ""
+    branch_authority = "git"
+    if not branch:
+        branch = bootstrap_host_binding_branch(root)
+        if branch:
+            branch_authority = "bootstrap host binding"
     worktree_result = run_process(["git", "rev-parse", "--show-toplevel"], root)
     worktree = worktree_result.stdout.strip() if worktree_result.returncode == 0 else ""
     default_branch = github_control_plane.get("default_branch")
@@ -1152,7 +1186,7 @@ def detect_host_binding_surface(
         "branch": {
             "status": "present" if branch else "missing",
             "locator": branch or "unknown",
-            "authority": "git",
+            "authority": branch_authority,
         },
         "worktree": {
             "status": "present" if worktree else "missing",


### PR DESCRIPTION
## Summary
- Make `governance-profile status` recover the host branch binding from `.loom/bootstrap/init-result.json` when a detached PR worktree has no current git branch.
- Keep normal git branch detection as the primary authority.
- Refresh the bootstrapped example runtime hash.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`

Closes #396.