### PR TITLE
fix: 将 review shadow evidence 视为 carrier-only 漂移

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "334a8df4ef8400125b6e7c311d386ac98c15f34c5be91befb9499215ee4ba0c4"
+      "sha256": "de815cf27623c6529d21ce47966f428d84d5c5f456792f2334e2391ea03831a8"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "71f0b9a7d55526b119af75b06c9787d875c27e19bbea70853ebc3df11f43eee7"
+      "sha256": "257e6bb1c2d2c6b6e31741d2183624ae1900d03dc1d2977d5bfd9837a97530ed"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-396-detached-worktree-host-binding",
+            "locator": "fix/review-shadow-carrier-only-drift",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "334a8df4ef8400125b6e7c311d386ac98c15f34c5be91befb9499215ee4ba0c4"
+      "sha256": "de815cf27623c6529d21ce47966f428d84d5c5f456792f2334e2391ea03831a8"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "71f0b9a7d55526b119af75b06c9787d875c27e19bbea70853ebc3df11f43eee7"
+      "sha256": "257e6bb1c2d2c6b6e31741d2183624ae1900d03dc1d2977d5bfd9837a97530ed"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -21,7 +21,7 @@ import governance_surface as governance_surface_module
 import loom_flow as loom_flow_module
 import runtime_state as runtime_state_module
 from governance_surface import build_governance_surface
-from loom_flow import repo_specific_requirements_payload, review_head_binding
+from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
 TOP_LEVEL_DIRS = (
@@ -7148,6 +7148,45 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
         assert_broken_shadow_evidence("partial-hash", partial_source_hash)
         assert_broken_shadow_evidence("hash-drift", drift_source_hash)
         assert_broken_shadow_evidence("undeclared", undeclared_shadow_evidence, expect_validation_warn=False)
+
+        review_shadow_target = base / "review-shadow-carrier"
+        shutil.copytree(baseline, review_shadow_target)
+        reviewed_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=review_shadow_target, timeout_seconds=30).stdout.strip()
+        review_path = ".loom/reviews/INIT-0001.json"
+        review_payload = load_json_file(review_shadow_target / review_path)
+        if isinstance(review_payload, dict):
+            review_payload["summary"] = "Carrier-only review artifact refresh."
+            write_json(review_shadow_target / review_path, review_payload)
+            write_json(
+                review_shadow_target / ".loom/shadow/review-loom.json",
+                {
+                    "decision": "allow",
+                    "source_files": [review_path],
+                    "source_sha256": {review_path: sha256_file(review_shadow_target / review_path)},
+                },
+            )
+            run_command(root, ["git", "add", "-f", review_path, ".loom/shadow/review-loom.json"], cwd=review_shadow_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "refresh review carrier evidence"], cwd=review_shadow_target, timeout_seconds=30)
+            carrier_context = {
+                "target_root": review_shadow_target,
+                "report": {
+                    "fact_chain": {
+                        "entry_points": {
+                            "recovery_entry": ".loom/progress/INIT-0001.md",
+                            "status_surface": ".loom/status/current.md",
+                        }
+                    }
+                },
+            }
+            binding_payload, binding_errors = review_head_binding(
+                review_shadow_target,
+                reviewed_head=reviewed_head,
+                allowed_paths=allowed_post_review_carrier_paths(carrier_context, review_path),
+            )
+            if binding_errors or binding_payload.get("status") != "carrier-only":
+                failures.append(Failure("adversarial-adoption", "review shadow evidence tied to a review artifact must be carrier-only after review refresh"))
+        else:
+            failures.append(Failure("adversarial-adoption", "review shadow carrier fixture could not load review artifact"))
 
         head_before_drift = run_command(root, ["git", "rev-parse", "HEAD"], cwd=baseline, timeout_seconds=30).stdout.strip()
         (baseline / "implementation-drift.txt").write_text("changed after review\n", encoding="utf-8")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1479,12 +1479,35 @@ def default_spec_review_path(item_id: str) -> str:
     return f".loom/reviews/{item_id}.spec.json"
 
 
+def shadow_evidence_paths_for_sources(target_root: Path, source_paths: set[str]) -> set[str]:
+    shadow_root = target_root / ".loom/shadow"
+    if not shadow_root.exists():
+        return set()
+
+    evidence_paths: set[str] = set()
+    for evidence_path in sorted(shadow_root.glob("*.json")):
+        relative = evidence_path.relative_to(target_root).as_posix()
+        if relative == ".loom/shadow/shadow-parity.json":
+            continue
+        payload = load_json_file(evidence_path)
+        if not isinstance(payload, dict):
+            continue
+        source_files = payload.get("source_files")
+        if not isinstance(source_files, list):
+            continue
+        if any(isinstance(source, str) and source in source_paths for source in source_files):
+            evidence_paths.add(relative)
+    return evidence_paths
+
+
 def allowed_post_review_carrier_paths(context: dict[str, Any], *review_paths: str) -> set[str]:
-    return {
+    allowed = {
         *review_paths,
         str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
         str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
     }
+    allowed.update(shadow_evidence_paths_for_sources(context["target_root"], set(review_paths)))
+    return allowed
 
 
 def formal_spec_path(context: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary

- Treat Loom-owned shadow evidence that directly sources refreshed review artifacts as post-review carrier-only drift.
- Keep implementation drift blocking.
- Add adversarial adoption fixture coverage for review artifact + shadow evidence refresh.

Closes #398.

## Validation

- `python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`