### PR TITLE
fix: 允许 bootstrapped route 不依赖 registry

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -113,7 +113,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "059440a394dd4e92356addeab830f536497e0180d85e0be053e56442594410af"
+      "sha256": "5d6bca788639db8d58548ebf2b0603e4286262d8847003babf817639b5308424"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "52f7999482666670935b42e8477f5ceff2ba3da75470ed9c22260bee29c097e9"
+      "sha256": "afdb899f25a4647fd80ae840b8381fc2bdc9c9f3018ddebd985a2e8bd2284a5f"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-400-review-schema-enforcement",
+            "locator": "issue-402-bootstrapped-route-without-registry",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -35,7 +35,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "059440a394dd4e92356addeab830f536497e0180d85e0be053e56442594410af"
+      "sha256": "5d6bca788639db8d58548ebf2b0603e4286262d8847003babf817639b5308424"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "52f7999482666670935b42e8477f5ceff2ba3da75470ed9c22260bee29c097e9"
+      "sha256": "afdb899f25a4647fd80ae840b8381fc2bdc9c9f3018ddebd985a2e8bd2284a5f"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -4039,6 +4039,34 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 allowed_results={"pass"},
             )
 
+        payload, error = load_command_json(
+            root,
+            ["python3", ".loom/bin/loom_init.py", "route", "--target", ".", "--task", "inspect adoption carrier"],
+            cwd=bootstrap_target,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`bootstrapped loom-init route` failed: {error}"))
+        else:
+            require_route_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`bootstrapped loom-init route`",
+                payload=payload,
+                expected_skill="loom-adopt",
+                expected_mode="implicit",
+                allowed_results={"pass"},
+            )
+            runtime_state = payload.get("runtime_state")
+            if not isinstance(runtime_state, dict) or runtime_state.get("carrier") != "bootstrapped-target-runtime":
+                failures.append(Failure("daily-execution-cli", "`bootstrapped loom-init route` must use the bootstrapped target runtime carrier"))
+            registry_check = (
+                runtime_state.get("checks", {}).get("registry_contract")
+                if isinstance(runtime_state, dict) and isinstance(runtime_state.get("checks"), dict)
+                else None
+            )
+            if not isinstance(registry_check, dict) or registry_check.get("status") != "not_applicable":
+                failures.append(Failure("daily-execution-cli", "`bootstrapped loom-init route` must not require skills/registry.json"))
+
         broken_bootstrap = tmp_root / "broken-bootstrapped-target"
         shutil.copytree(example_target, broken_bootstrap)
         manifest_path = broken_bootstrap / ".loom" / "bootstrap" / "manifest.json"

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -1955,23 +1955,29 @@ def route(args: argparse.Namespace) -> int:
 
     registry_skill_ids, registry_error = load_registry_skill_ids()
     if registry_error:
-        print(
-            json.dumps(
-                route_payload(
-                    result="block",
-                    selected_skill="loom-init",
-                    mode="fallback",
-                    matched_signals=[],
-                    summary=f"cannot route because {registry_error}",
-                    missing_inputs=["a valid installed registry"],
-                    fallback_to="loom-init",
-                    runtime_state=runtime_state,
-                ),
-                ensure_ascii=False,
-                indent=2,
+        if runtime_state.get("carrier") == "bootstrapped-target-runtime":
+            registry_skill_ids = tuple(sorted({"loom-init", *SKILL_SIGNAL_RULES.keys()}))
+        else:
+            print(
+                json.dumps(
+                    route_payload(
+                        result="block",
+                        selected_skill="loom-init",
+                        mode="fallback",
+                        matched_signals=[],
+                        summary=f"cannot route because {registry_error}",
+                        missing_inputs=["a valid installed registry"],
+                        fallback_to="loom-init",
+                        runtime_state=runtime_state,
+                    ),
+                    ensure_ascii=False,
+                    indent=2,
+                )
             )
-        )
-        return 1
+            return 1
+
+    if registry_error and runtime_state.get("carrier") == "bootstrapped-target-runtime":
+        registry_error = None
 
     known_skills = set(registry_skill_ids or ())
     governance_surface: dict[str, object] | None = None


### PR DESCRIPTION
## Summary
- Allow bootstrapped target runtime `loom_init.py route` to run without `.loom/skills/registry.json`.
- Keep installed/runtime registry validation unchanged for non-bootstrapped carriers.
- Add a `loom_check` regression covering bootstrapped route selection for adoption carrier inspection.
- Bump installer package to `0.1.47` and refresh the example bootstrap manifest hashes.

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `npm --prefix packages/loom-installer run check:release`
- `node packages/loom-installer/scripts/check-version-bump.mjs`

Closes #402