### PR TITLE
fix: 将 review shadow evidence 视为 carrier-only

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "92e83310b827ce99e3ab1c60216d07e65c2dc1b74511c1dd06297b226a00f94c"
+      "sha256": "1d48bec787cdb4a056cd98c0f40b54fadc70711299691c343dcf4db60672246b"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "afdb899f25a4647fd80ae840b8381fc2bdc9c9f3018ddebd985a2e8bd2284a5f"
+      "sha256": "451270ab050bc0b1522ae08d2c151dd704d711a41c5de5ba237d626b6d60ec1d"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-402-bootstrapped-route-without-registry",
+            "locator": "issue-404-review-shadow-carrier-only",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "92e83310b827ce99e3ab1c60216d07e65c2dc1b74511c1dd06297b226a00f94c"
+      "sha256": "1d48bec787cdb4a056cd98c0f40b54fadc70711299691c343dcf4db60672246b"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "afdb899f25a4647fd80ae840b8381fc2bdc9c9f3018ddebd985a2e8bd2284a5f"
+      "sha256": "451270ab050bc0b1522ae08d2c151dd704d711a41c5de5ba237d626b6d60ec1d"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -7193,7 +7193,20 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                     "source_sha256": {review_path: sha256_file(review_shadow_target / review_path)},
                 },
             )
-            run_command(root, ["git", "add", "-f", review_path, ".loom/shadow/review-loom.json"], cwd=review_shadow_target, timeout_seconds=30)
+            write_json(
+                review_shadow_target / ".loom/shadow/review-repo.json",
+                {
+                    "decision": "allow",
+                    "source_files": ["native/status/review.json"],
+                    "source_sha256": {"native/status/review.json": sha256_file(review_shadow_target / "native/status/review.json")},
+                },
+            )
+            run_command(
+                root,
+                ["git", "add", "-f", review_path, ".loom/shadow/review-loom.json", ".loom/shadow/review-repo.json"],
+                cwd=review_shadow_target,
+                timeout_seconds=30,
+            )
             run_command(root, ["git", "commit", "-m", "refresh review carrier evidence"], cwd=review_shadow_target, timeout_seconds=30)
             carrier_context = {
                 "target_root": review_shadow_target,

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1507,6 +1507,12 @@ def allowed_post_review_carrier_paths(context: dict[str, Any], *review_paths: st
         str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
     }
     allowed.update(shadow_evidence_paths_for_sources(context["target_root"], set(review_paths)))
+    review_shadow_root = context["target_root"] / ".loom/shadow"
+    if review_shadow_root.exists():
+        allowed.update(
+            evidence_path.relative_to(context["target_root"]).as_posix()
+            for evidence_path in sorted(review_shadow_root.glob("review-*.json"))
+        )
     return allowed
 
 


### PR DESCRIPTION
## Summary
- Treat `.loom/shadow/review-*.json` as post-review carrier metadata.
- Preserve existing source-bound shadow evidence allowance.
- Extend the adversarial adoption fixture so review artifact refresh plus review loom/repo shadow evidence remains `carrier-only`.
- Bump installer package to `0.1.48` and refresh example bootstrap hashes.

## Validation
- `python3 tools/loom_init.py bootstrap --target examples/new-project --write --force --verify --install-pr-template`
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `npm --prefix packages/loom-installer run check:release`
- `node packages/loom-installer/scripts/check-version-bump.mjs`

Closes #404