### PR TITLE
fix: 收紧 spec-review shadow evidence 与 carrier refresh

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "1d48bec787cdb4a056cd98c0f40b54fadc70711299691c343dcf4db60672246b"
+      "sha256": "00a5476d3e1a1b6215558d1d840e852be898cd818749c3caaa442bc657dde5eb"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "451270ab050bc0b1522ae08d2c151dd704d711a41c5de5ba237d626b6d60ec1d"
+      "sha256": "a2e8c10cda53568e099b6c9ce242b524d84b7a7b0bbcb8efb4163b92e9150bb4"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-404-review-shadow-carrier-only",
+            "locator": "issue-406-spec-review-shadow-refresh-hardening",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "1d48bec787cdb4a056cd98c0f40b54fadc70711299691c343dcf4db60672246b"
+      "sha256": "00a5476d3e1a1b6215558d1d840e852be898cd818749c3caaa442bc657dde5eb"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "451270ab050bc0b1522ae08d2c151dd704d711a41c5de5ba237d626b6d60ec1d"
+      "sha256": "a2e8c10cda53568e099b6c9ce242b524d84b7a7b0bbcb8efb4163b92e9150bb4"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -7229,6 +7229,39 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
         else:
             failures.append(Failure("adversarial-adoption", "review shadow carrier fixture could not load review artifact"))
 
+        unreadable_review_shadow_target = base / "unreadable-review-shadow"
+        shutil.copytree(baseline, unreadable_review_shadow_target)
+        (unreadable_review_shadow_target / ".loom/shadow/review-repo.json").write_text("{not-json", encoding="utf-8")
+        run_command(
+            root,
+            ["git", "add", "-f", ".loom/shadow/review-repo.json"],
+            cwd=unreadable_review_shadow_target,
+            timeout_seconds=30,
+        )
+        run_command(
+            root,
+            ["git", "commit", "-m", "corrupt review shadow evidence"],
+            cwd=unreadable_review_shadow_target,
+            timeout_seconds=30,
+        )
+        unreadable_payload, unreadable_error = load_command_json(
+            root,
+            [
+                "python3",
+                str(unreadable_review_shadow_target / ".loom/bin/loom_flow.py"),
+                "checkpoint",
+                "merge",
+                "--target",
+                str(unreadable_review_shadow_target),
+                "--item",
+                "INIT-0001",
+            ],
+        )
+        if unreadable_error:
+            failures.append(Failure("adversarial-adoption", f"unreadable review shadow evidence must fail closed without crashing: {unreadable_error}"))
+        elif unreadable_payload.get("result") == "pass":
+            failures.append(Failure("adversarial-adoption", "unreadable review shadow evidence must fail closed instead of passing"))
+
         invalid_review_schema_target = base / "invalid-review-schema"
         shutil.copytree(baseline, invalid_review_schema_target)
         invalid_review_payload = load_json_file(invalid_review_schema_target / review_path)

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1489,7 +1489,10 @@ def shadow_evidence_paths_for_sources(target_root: Path, source_paths: set[str])
         relative = evidence_path.relative_to(target_root).as_posix()
         if relative == ".loom/shadow/shadow-parity.json":
             continue
-        payload = load_json_file(evidence_path)
+        try:
+            payload = load_json_file(evidence_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
         if not isinstance(payload, dict):
             continue
         source_files = payload.get("source_files")
@@ -1509,10 +1512,13 @@ def allowed_post_review_carrier_paths(context: dict[str, Any], *review_paths: st
     allowed.update(shadow_evidence_paths_for_sources(context["target_root"], set(review_paths)))
     review_shadow_root = context["target_root"] / ".loom/shadow"
     if review_shadow_root.exists():
-        allowed.update(
-            evidence_path.relative_to(context["target_root"]).as_posix()
-            for evidence_path in sorted(review_shadow_root.glob("review-*.json"))
-        )
+        for evidence_path in sorted(review_shadow_root.glob("review-*.json")):
+            try:
+                payload = load_json_file(evidence_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            if isinstance(payload, dict):
+                allowed.add(evidence_path.relative_to(context["target_root"]).as_posix())
     return allowed
 
 
@@ -2107,7 +2113,7 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
-    surface_name = "review" if operation == "review" else "spec_review"
+    surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
         target_root=target_root,
@@ -4237,6 +4243,15 @@ def carrier_refresh_payload(target_root: Path, output_relative: str, expected_it
     for action in actions:
         if action.get("status") == "block":
             missing_inputs.extend(str(message) for message in action.get("missing_inputs", []))
+    if runtime_state.get("result") != "pass":
+        refreshable_runtime_drift = {
+            f"bootstrap runtime artifact `{action.get('path')}` sha256 drifted"
+            for action in actions
+            if action.get("kind") is None and action.get("status") == "refresh-needed" and action.get("path")
+        }
+        for message in runtime_state.get("missing_inputs", []):
+            if str(message) not in refreshable_runtime_drift:
+                missing_inputs.append(f"runtime-state: {message}")
 
     review_status: dict[str, Any] = {"status": "not_checked"}
     if not context_errors:


### PR DESCRIPTION
## Summary
- Make `flow spec-review` consume the stable `review` repo-interface surface.
- Avoid crashing on unreadable shadow evidence while building review carrier-only path allowances; unreadable changed evidence now fails closed instead of passing as carrier-only.
- Make carrier refresh block on unhandled blocking runtime_state while still allowing repairable runtime hash drift.
- Extend adversarial adoption fixture coverage.
- Bump installer package to `0.1.49` and refresh example bootstrap hashes.

## Validation
- `python3 tools/loom_init.py bootstrap --target examples/new-project --write --force --verify --install-pr-template`
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `npm --prefix packages/loom-installer run check:release`
- `node packages/loom-installer/scripts/check-version-bump.mjs`

Closes #406