### PR TITLE
fix: 要求 spec review 消费完整规约套件

### DIFF
--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "00a5476d3e1a1b6215558d1d840e852be898cd818749c3caaa442bc657dde5eb"
+      "sha256": "f8fe63875c5abce92281c4fce0fa329c3584a25a85c131ba2d0364ac39b78997"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a2e8c10cda53568e099b6c9ce242b524d84b7a7b0bbcb8efb4163b92e9150bb4"
+      "sha256": "e48281477bbb35b887e21034570ed519a40dae718ea97e99886a66b04dbd1d50"
     },
     {
       "path": "AGENTS.md",
@@ -438,7 +438,7 @@
           },
           "branch": {
             "status": "present",
-            "locator": "issue-406-spec-review-shadow-refresh-hardening",
+            "locator": "issue-408-spec-review-complete-suite",
             "authority": "git"
           },
           "worktree": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "00a5476d3e1a1b6215558d1d840e852be898cd818749c3caaa442bc657dde5eb"
+      "sha256": "f8fe63875c5abce92281c4fce0fa329c3584a25a85c131ba2d0364ac39b78997"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a2e8c10cda53568e099b6c9ce242b524d84b7a7b0bbcb8efb4163b92e9150bb4"
+      "sha256": "e48281477bbb35b887e21034570ed519a40dae718ea97e99886a66b04dbd1d50"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.49",
+      "version": "0.1.50",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -4466,6 +4466,42 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif payload.get("result") != "pass":
                     failures.append(Failure("daily-execution-cli", "`installed spec review record allow` must pass"))
 
+                spec_plan_path = positive_target / ".loom/specs/INIT-0001/plan.md"
+                spec_plan_text = spec_plan_path.read_text(encoding="utf-8")
+                spec_plan_path.unlink()
+                try:
+                    payload, error = load_command_json(
+                        root,
+                        [
+                            "python3",
+                            str(install_root / "loom-spec-review" / "scripts" / "loom-spec-review.py"),
+                            "review",
+                            "record",
+                            "--target",
+                            str(positive_target),
+                            "--item",
+                            "INIT-0001",
+                            "--review-file",
+                            ".loom/reviews/INIT-0001.spec.json",
+                            "--decision",
+                            "allow",
+                            "--kind",
+                            "spec_review",
+                            "--summary",
+                            "Incomplete formal spec suite should not be approved.",
+                            "--reviewer",
+                            "loom-check",
+                        ],
+                    )
+                    if error:
+                        failures.append(Failure("daily-execution-cli", f"`installed incomplete spec review record` failed: {error}"))
+                    elif payload.get("result") != "block":
+                        failures.append(Failure("daily-execution-cli", "`installed incomplete spec review record` must block"))
+                    elif not any("plan.md" in str(item) for item in payload.get("missing_inputs", [])):
+                        failures.append(Failure("daily-execution-cli", "`installed incomplete spec review record` must name the missing plan.md"))
+                finally:
+                    spec_plan_path.write_text(spec_plan_text, encoding="utf-8")
+
                 payload, error = load_command_json(
                     root,
                     [

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1541,6 +1541,16 @@ def formal_spec_path(context: dict[str, Any]) -> str | None:
     return None
 
 
+def formal_spec_suite_status(context: dict[str, Any]) -> tuple[dict[str, str], list[str]]:
+    suite = spec_suite_paths(context)
+    missing = [
+        path
+        for path in (suite["spec"], suite["plan"], suite["implementation_contract"])
+        if not (context["target_root"] / path).is_file()
+    ]
+    return suite, missing
+
+
 def spec_suite_paths(context: dict[str, Any]) -> dict[str, str]:
     item_id = context["item_id"]
     candidates = [
@@ -1757,15 +1767,25 @@ def review_gate_payload(
 
 
 def spec_review_gate_payload(context: dict[str, Any]) -> dict[str, Any]:
-    spec_path = formal_spec_path(context)
-    return review_gate_payload(
+    suite, missing_suite_paths = formal_spec_suite_status(context)
+    spec_path = suite["spec"] if not missing_suite_paths else formal_spec_path(context)
+    payload = review_gate_payload(
         context,
         review_path=default_spec_review_path(context["item_id"]),
         expected_kind="spec_review",
         gate_name="spec_review",
-        required=spec_path is not None,
+        required=not missing_suite_paths,
         path_label=spec_path,
     )
+    payload["formal_spec_suite"] = suite
+    if missing_suite_paths:
+        payload["result"] = "block"
+        payload["summary"] = "spec review is blocked until the complete formal spec suite is present."
+        payload["missing_inputs"] = [
+            f"missing formal spec suite file: {path}" for path in missing_suite_paths
+        ] + list(payload.get("missing_inputs", []))
+        payload["fallback_to"] = "build"
+    return payload
 
 
 def implementation_review_status_payload(context: dict[str, Any]) -> dict[str, Any]:
@@ -6813,15 +6833,17 @@ def handle_review(args: argparse.Namespace) -> int:
             }
         )
     if args.decision == "allow" and args.kind == "spec_review":
-        spec_path = formal_spec_path(context)
-        if spec_path is None:
+        _, missing_suite_paths = formal_spec_suite_status(context)
+        if missing_suite_paths:
             return emit(
                 {
                     "command": "review",
                     "operation": "record",
                     "result": "block",
-                    "summary": "spec review cannot be recorded as `allow` without a readable formal spec path.",
-                    "missing_inputs": ["formal spec path"],
+                    "summary": "spec review cannot be recorded as `allow` without the complete formal spec suite.",
+                    "missing_inputs": [
+                        f"missing formal spec suite file: {path}" for path in missing_suite_paths
+                    ],
                     "fallback_to": "build",
                     "build_checkpoint": build_payload,
                 }


### PR DESCRIPTION
## Summary
- require `spec_review allow` to consume the complete formal spec suite, not only `spec.md`
- expose missing `plan.md` / `implementation-contract.md` as blocking missing inputs
- add an installed-runtime adversarial check proving incomplete spec suites cannot be approved

Closes #408

## Validation
- `python3 tools/loom_init.py bootstrap --target examples/new-project --write --force --verify --install-pr-template`
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py .`
- `make loom-check`
- `npm --prefix packages/loom-installer test`
- `npm --prefix packages/loom-installer run check:release`
- `node packages/loom-installer/scripts/check-version-bump.mjs`