### PR TITLE
feat(harness): 定义 workspace profile 启动合同

### DIFF
--- a/.loom/bin/governance_surface.py
+++ b/.loom/bin/governance_surface.py
@@ -33,6 +33,23 @@ PLANNED_LOCATORS = {
 REPO_INTERFACE_SURFACES = ("review", "merge_ready", "closeout")
 REPO_INTERFACE_AVAILABILITY = {"absent", "companion_docs_only", "incomplete", "present"}
 REPO_INTERFACE_MANIFEST_SCHEMA = "loom-repo-companion-manifest/v1"
+WORKSPACE_PROFILE_CONTRACTS = {
+    "single-workspace": {
+        "summary": "Use the repository root as the Loom execution workspace.",
+        "host_worktree_required": False,
+        "recommended_action": "keep workspace_entry as `.` unless isolation becomes necessary",
+    },
+    "per-item-worktree": {
+        "summary": "Use one isolated workspace per Work Item, usually backed by host git worktree.",
+        "host_worktree_required": True,
+        "recommended_action": "ensure workspace, branch, Work Item, and PR bindings stay aligned",
+    },
+    "attach-existing": {
+        "summary": "Attach Loom to an existing repo-defined workspace without taking over host lifecycle actions.",
+        "host_worktree_required": False,
+        "recommended_action": "declare the repo-specific workspace locator and keep host lifecycle ownership external",
+    },
+}
 REPO_INTERFACE_V1_SCHEMA = "loom-repo-interface/v1"
 REPO_INTERFACE_V2_SCHEMA = "loom-repo-interface/v2"
 REPO_INTERFACE_SCHEMAS = {REPO_INTERFACE_V1_SCHEMA, REPO_INTERFACE_V2_SCHEMA}
@@ -1047,6 +1064,72 @@ def active_entry_points(root: Path) -> dict[str, str]:
     return active
 
 
+def work_item_workspace_entry(root: Path) -> str:
+    active = active_entry_points(root)
+    locator = active.get("work_item")
+    if not locator:
+        return ""
+    resolved_locator, work_item_path = resolve_locator(root, locator)
+    if resolved_locator is None or work_item_path is None:
+        return ""
+    try:
+        text = work_item_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    match = re.search(r"^- Workspace Entry:\s*(.+?)\s*$", text, flags=re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def select_workspace_profile(workspace_entry: str, item_id: str) -> tuple[str, str]:
+    if not workspace_entry:
+        return "unknown", "workspace_entry is not readable"
+    normalized = workspace_entry.strip().replace("\\", "/")
+    if normalized == ".":
+        return "single-workspace", "workspace_entry points at the repository root"
+    if normalized.startswith(".worktrees/") or (item_id and item_id in normalized):
+        return "per-item-worktree", "workspace_entry is item-scoped or under `.worktrees/`"
+    return "attach-existing", "workspace_entry points at an existing repo-defined workspace"
+
+
+def detect_workspace_profile(root: Path, *, host_binding: dict[str, Any]) -> dict[str, Any]:
+    active = active_entry_points(root)
+    item_id = active.get("current_item_id", "")
+    workspace_entry = work_item_workspace_entry(root)
+    selected, reason = select_workspace_profile(workspace_entry, item_id)
+    locator, workspace_path = resolve_locator(root, workspace_entry)
+    missing_inputs: list[str] = []
+    if not workspace_entry:
+        missing_inputs.append("missing_workspace_entry")
+    elif locator is None or workspace_path is None:
+        missing_inputs.append("workspace_escape")
+    elif not workspace_path.exists():
+        missing_inputs.append("workspace_missing")
+    required_objects = host_binding.get("required_objects") if isinstance(host_binding, dict) else None
+    worktree = required_objects.get("worktree") if isinstance(required_objects, dict) else None
+    worktree_status = worktree.get("status") if isinstance(worktree, dict) else "unknown"
+    return {
+        "schema_version": "loom-workspace-profile/v1",
+        "selected": selected,
+        "selection_reason": reason,
+        "profiles": WORKSPACE_PROFILE_CONTRACTS,
+        "workspace_entry": workspace_entry or "unknown",
+        "workspace_path": locator or "unknown",
+        "workspace_exists": bool(workspace_path and workspace_path.exists()),
+        "host_worktree": {
+            "ownership": "host",
+            "status": worktree_status,
+            "locator": worktree.get("locator", "unknown") if isinstance(worktree, dict) else "unknown",
+        },
+        "result": "pass" if not missing_inputs else "block",
+        "missing_inputs": missing_inputs,
+        "recommended_action": (
+            WORKSPACE_PROFILE_CONTRACTS[selected]["recommended_action"]
+            if selected in WORKSPACE_PROFILE_CONTRACTS
+            else "restore the Work Item workspace_entry before running workspace profile checks"
+        ),
+    }
+
+
 def bootstrap_host_binding_branch(root: Path) -> str:
     init_result = root / ".loom/bootstrap/init-result.json"
     try:
@@ -1369,6 +1452,7 @@ def governance_control_plane(
     repo_interface: dict[str, Any],
     repo_interop: dict[str, Any],
     host_binding: dict[str, Any],
+    workspace_profile: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "schema_version": GOVERNANCE_CONTROL_VERSION,
@@ -1377,6 +1461,7 @@ def governance_control_plane(
             "illegal_entry_fallbacks": WORK_ITEM_ENFORCEMENT_FALLBACKS,
             "result": "pass" if carrier_summary.get("work_item", {}).get("status") == "present" else "block",
         },
+        "workspace_profile": workspace_profile,
         "host_binding": host_binding,
         "taxonomy": GATE_FAILURE_TAXONOMY,
         "gate_chain": GATE_CHAIN,
@@ -1414,12 +1499,14 @@ def build_governance_surface(
         repo_interface=repo_interface,
         repo_interop=repo_interop,
     )
+    workspace_profile = detect_workspace_profile(root, host_binding=host_binding)
     control_plane = governance_control_plane(
         carrier_summary=carrier_summary,
         github_control_plane=github_control_plane,
         repo_interface=repo_interface,
         repo_interop=repo_interop,
         host_binding=host_binding,
+        workspace_profile=workspace_profile,
     )
 
     missing_inputs: list[str] = []
@@ -1455,6 +1542,7 @@ def build_governance_surface(
         "github_control_plane": github_control_plane,
         "repo_interface": repo_interface,
         "repo_interop": repo_interop,
+        "workspace_profile": workspace_profile,
         "governance_control_plane": control_plane,
         "summary": summary,
         "missing_inputs": list(dict.fromkeys(missing_inputs)),

--- a/.loom/bin/loom_check.py
+++ b/.loom/bin/loom_check.py
@@ -76,6 +76,7 @@ CORE_DOCS = (
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
+    "docs/methodology/harness/workspace-profile.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/host-action-contract.md",
     "docs/methodology/harness/host-lifecycle-boundary.md",
@@ -185,6 +186,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
+    "docs/methodology/harness/workspace-profile.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/recovery-model.md",
     "docs/methodology/harness/status-surface.md",
@@ -736,12 +738,47 @@ def require_governance_surface(
         context=f"{context} governance_surface.repo_interop",
         payload=governance_surface.get("repo_interop"),
     )
+    require_workspace_profile_payload(
+        failures,
+        category=category,
+        context=f"{context} governance_surface.workspace_profile",
+        payload=governance_surface.get("workspace_profile"),
+    )
     require_governance_control_plane(
         failures,
         category=category,
         context=f"{context} governance_surface.governance_control_plane",
         payload=governance_surface.get("governance_control_plane"),
     )
+
+
+def require_workspace_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != "loom-workspace-profile/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-workspace-profile/v1`"))
+    if payload.get("selected") not in {"single-workspace", "per-item-worktree", "attach-existing", "unknown"}:
+        failures.append(Failure(category, f"{context} selected profile must stay within the stable set"))
+    if payload.get("result") not in {"pass", "block"}:
+        failures.append(Failure(category, f"{context} result must be pass/block"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+    for field in ("workspace_entry", "workspace_path", "recommended_action"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not value:
+            failures.append(Failure(category, f"{context}.{field} must be a non-empty string"))
+    host_worktree = payload.get("host_worktree")
+    if not isinstance(host_worktree, dict):
+        failures.append(Failure(category, f"{context}.host_worktree must be an object"))
+    elif host_worktree.get("ownership") != "host":
+        failures.append(Failure(category, f"{context}.host_worktree ownership must stay `host`"))
 
 
 def require_governance_control_plane(
@@ -782,6 +819,13 @@ def require_governance_control_plane(
             failures.append(Failure(category, f"{context}.host_binding.required_objects must expose the stable host binding object set"))
         elif required_objects.get("work_item", {}).get("authority") != "loom fact chain":
             failures.append(Failure(category, f"{context}.host_binding work_item authority must remain Loom fact chain"))
+
+    require_workspace_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.workspace_profile",
+        payload=payload.get("workspace_profile"),
+    )
 
     taxonomy = payload.get("taxonomy")
     expected_taxonomy = {

--- a/.loom/bin/loom_flow.py
+++ b/.loom/bin/loom_flow.py
@@ -3832,6 +3832,7 @@ def purity_report_from_context(context: dict[str, Any], fact_chain_errors: list[
 
 def base_workspace_payload(context: dict[str, Any], operation: str) -> dict[str, Any]:
     purity = purity_report_from_context(context)
+    workspace_profile = workspace_profile_from_context(context)
     return {
         "command": "workspace",
         "operation": operation,
@@ -3845,6 +3846,7 @@ def base_workspace_payload(context: dict[str, Any], operation: str) -> dict[str,
             "entry": context["workspace_entry"],
             "path": relative_to_root(context["workspace_path"], context["target_root"]),
             "exists": context["workspace_path"].exists(),
+            "profile": workspace_profile,
         },
         "recovery": {
             "path": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
@@ -3859,6 +3861,39 @@ def base_workspace_payload(context: dict[str, Any], operation: str) -> dict[str,
         "purity": purity,
         "missing_inputs": [],
         "fallback_to": None,
+    }
+
+
+def select_workspace_profile_name(workspace_entry: str, item_id: str) -> tuple[str, str]:
+    normalized = workspace_entry.strip().replace("\\", "/")
+    if normalized == ".":
+        return "single-workspace", "workspace_entry points at the repository root"
+    if normalized.startswith(".worktrees/") or (item_id and item_id in normalized):
+        return "per-item-worktree", "workspace_entry is item-scoped or under `.worktrees/`"
+    return "attach-existing", "workspace_entry points at an existing repo-defined workspace"
+
+
+def workspace_profile_from_context(context: dict[str, Any]) -> dict[str, Any]:
+    selected, reason = select_workspace_profile_name(context["workspace_entry"], context["item_id"])
+    return {
+        "schema_version": "loom-workspace-profile/v1",
+        "selected": selected,
+        "selection_reason": reason,
+        "workspace_entry": context["workspace_entry"],
+        "workspace_path": relative_to_root(context["workspace_path"], context["target_root"]),
+        "workspace_exists": context["workspace_path"].exists(),
+        "host_worktree": {
+            "ownership": "host",
+            "cwd_within_repo": current_cwd_relative(context["target_root"]) or "outside_target_repo",
+            "status": "host_managed",
+        },
+        "recommended_action": (
+            "keep workspace_entry as `.` unless isolation becomes necessary"
+            if selected == "single-workspace"
+            else "ensure workspace, branch, Work Item, and PR bindings stay aligned"
+            if selected == "per-item-worktree"
+            else "keep repo-specific workspace locator declared and host lifecycle ownership external"
+        ),
     }
 
 
@@ -5023,6 +5058,7 @@ def handle_host_binding(args: argparse.Namespace) -> int:
 def host_lifecycle_payload(context: dict[str, Any]) -> dict[str, Any]:
     branch = git_branch(context["target_root"])
     purity = purity_report_from_context(context)
+    workspace_profile = workspace_profile_from_context(context)
     worktree_root = current_cwd_relative(context["target_root"])
     branch_status = "report_only" if branch else "host_managed_without_local_branch"
     pr_status = "report_only"
@@ -5053,6 +5089,7 @@ def host_lifecycle_payload(context: dict[str, Any]) -> dict[str, Any]:
                 "ownership": "loom",
                 "entry": context["workspace_entry"],
                 "path": relative_to_root(context["workspace_path"], context["target_root"]),
+                "profile": workspace_profile,
                 "lifecycle_entry": "python3 .loom/bin/loom_flow.py workspace create|locate|cleanup|retire",
             },
             "branch": {
@@ -5096,6 +5133,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
     next_level = maturity.get("next")
     target_level = next_level if isinstance(next_level, str) else current if isinstance(current, str) else None
     gate_rollout = maturity.get("gate_rollout")
+    workspace_profile = control_plane.get("workspace_profile") if isinstance(control_plane, dict) else None
     missing_by_level = maturity.get("missing_by_level")
     missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs: list[Any] = []
@@ -5127,6 +5165,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
         "recommended_action": "run governance-profile upgrade --dry-run" if result == "block" else None,
         "fallback_to": None if result == "pass" else "adoption",
         "maturity": maturity,
+        "workspace_profile": workspace_profile,
         "gate_rollout": gate_rollout,
         "governance_control_plane": control_plane,
         "adoption_decisions": decisions,
@@ -5201,6 +5240,7 @@ def governance_profile_upgrade_payload(
         }
     base = governance_profile_payload(target_root, "upgrade-plan")
     maturity = base.get("maturity") if isinstance(base.get("maturity"), dict) else {}
+    workspace_profile = base.get("workspace_profile")
     actions = governance_upgrade_actions(target_root, target_level, maturity if isinstance(maturity, dict) else {})
     blockers: list[str] = []
     written_files: list[str] = []
@@ -5237,6 +5277,7 @@ def governance_profile_upgrade_payload(
         "actions": actions,
         "written_files": written_files,
         "maturity": maturity,
+        "workspace_profile": workspace_profile,
         "gate_rollout": maturity.get("gate_rollout") if isinstance(maturity, dict) else None,
         "adoption_decisions": decisions,
         "guided_adoption_plan": guided_plan,

--- a/.loom/bin/loom_status.py
+++ b/.loom/bin/loom_status.py
@@ -409,6 +409,7 @@ def main(argv: list[str]) -> int:
     review = implementation_review_status_payload(context)
     merge_ready = checkpoint_payload("merge", context)
     governance_surface = build_governance_surface(target_root)
+    workspace_profile = governance_surface.get("workspace_profile")
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
             "review": review,
             "merge_ready": merge_ready,
             "closeout": closeout,
+            "workspace_profile": workspace_profile,
             "governance_status": control_status,
             "governance_surface": governance_surface,
             "github": github_status,

--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -122,19 +122,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "86fcf5773a9d202b43778fa1e646ee7d2ac2070cab93ce2023520880ccbf0e8c"
+      "sha256": "ef6757f6aa1e2e1615858ab755b00aae49f711b9f8c47f80bc3bd4539cd38a33"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "caddfce59885b7f7afbc2bd91f325fb73fe7450934f42addaee15cc857b1e447"
+      "sha256": "5f15aa05f534809bac6f83997da51c96a1d324a4ee99ea62611bfb08ae393016"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "78572efeeafe7dbb82e75fd86ad80a5fdc8447ef85ba5e26eb72c0bd448ccfe0"
+      "sha256": "e5d76b6958b6129b1ba92843e2515ce0d90b293bb586f544e4ffa6e766c4e362"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -152,7 +152,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "efd1e2f54ff23130c22d6a1e7adc3620930add76b098e430c97568130695d3f8"
+      "sha256": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
     },
     {
       "path": "AGENTS.md",

--- a/.loom/bootstrap/manifest.json
+++ b/.loom/bootstrap/manifest.json
@@ -47,19 +47,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "86fcf5773a9d202b43778fa1e646ee7d2ac2070cab93ce2023520880ccbf0e8c"
+      "sha256": "ef6757f6aa1e2e1615858ab755b00aae49f711b9f8c47f80bc3bd4539cd38a33"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "caddfce59885b7f7afbc2bd91f325fb73fe7450934f42addaee15cc857b1e447"
+      "sha256": "5f15aa05f534809bac6f83997da51c96a1d324a4ee99ea62611bfb08ae393016"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "78572efeeafe7dbb82e75fd86ad80a5fdc8447ef85ba5e26eb72c0bd448ccfe0"
+      "sha256": "e5d76b6958b6129b1ba92843e2515ce0d90b293bb586f544e4ffa6e766c4e362"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "efd1e2f54ff23130c22d6a1e7adc3620930add76b098e430c97568130695d3f8"
+      "sha256": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
     },
     {
       "path": "AGENTS.md",

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -10,6 +10,6 @@
   ],
   "source_sha256": {
     ".github/workflows/loom-check.yml": "94497e146bf2ff0d8652c56bdde95fe9743f76dcfd666f8a3d04b22a8d32d787",
-    "skills/shared/scripts/loom_check.py": "efd1e2f54ff23130c22d6a1e7adc3620930add76b098e430c97568130695d3f8"
+    "skills/shared/scripts/loom_check.py": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
   }
 }

--- a/.loom/shadow/merge-ready-repo.json
+++ b/.loom/shadow/merge-ready-repo.json
@@ -10,6 +10,6 @@
   ],
   "source_sha256": {
     ".github/workflows/loom-check.yml": "94497e146bf2ff0d8652c56bdde95fe9743f76dcfd666f8a3d04b22a8d32d787",
-    "skills/shared/scripts/loom_check.py": "efd1e2f54ff23130c22d6a1e7adc3620930add76b098e430c97568130695d3f8"
+    "skills/shared/scripts/loom_check.py": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
   }
 }

--- a/docs/methodology/harness/README.md
+++ b/docs/methodology/harness/README.md
@@ -29,6 +29,8 @@
   - 定义 `admission` / `build` checkpoint 的输入、输出、失败语义与回退去向
 - [workspace-model.md](./workspace-model.md)
   - 定义执行现场的隔离、定位与 clean state 要求
+- [workspace-profile.md](./workspace-profile.md)
+  - 定义 `single-workspace`、`per-item-worktree`、`attach-existing` 三类默认现场装配 profile
 - `workspace-lifecycle.md`
   - 定义 `create`、`locate`、`cleanup`、`retire` 与 `purity-check` 的生命周期合同
 - [host-action-contract.md](./host-action-contract.md)

--- a/docs/methodology/harness/workspace-model.md
+++ b/docs/methodology/harness/workspace-model.md
@@ -54,3 +54,4 @@ Loom 当前不固化：
 
 branch、PR 与 git worktree 的宿主边界见 [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)。
 `active issue` 绑定消费见 [host-issue-binding.md](./host-issue-binding.md)。
+默认 workspace profile 见 [workspace-profile.md](./workspace-profile.md)。

--- a/docs/methodology/harness/workspace-profile.md
+++ b/docs/methodology/harness/workspace-profile.md
@@ -1,0 +1,89 @@
+# Workspace Profile
+
+本文件定义 Loom 新仓库与既有仓库默认可消费的 workspace profile。
+
+它回答一件事：执行现场如何被装配、定位和校验，而不把 Git
+`worktree` 的底层生命周期改写成 Loom-owned 能力。
+
+## 1. 稳定 profiles
+
+Loom 当前固定三种默认 profile：
+
+- `single-workspace`
+  - 使用仓库根目录作为执行现场。
+  - 适合新仓库、单事项推进或尚未需要隔离 worktree 的轻量接入。
+- `per-item-worktree`
+  - 每个正式 `Work Item` 使用独立工作现场，通常可由宿主
+    `git worktree` 承接。
+  - 适合多事项并行、长任务恢复或需要强纯度隔离的仓库。
+- `attach-existing`
+  - 读取并校验既有仓库或 repo companion 声明的工作现场。
+  - 适合成熟既有仓库的 recognize-and-attach 路径。
+
+## 2. Profile 选择语义
+
+profile 选择是派生读面，不是第二份 authored 真相。
+
+最小默认推断：
+
+- `workspace_entry` 为 `.` 时，选择 `single-workspace`
+- `workspace_entry` 指向 `.worktrees/` 或包含当前 item id 时，选择
+  `per-item-worktree`
+- 其他可解析 repo-relative 现场默认视为 `attach-existing`
+
+仓库后续可以在 profile 合同中显式声明更强策略；但显式声明也只能改变
+Loom 如何校验现场，不改变 Git / GitHub / host adapter 的底层 ownership。
+
+## 3. 每个 profile 必须暴露的事实
+
+统一状态面至少应能读出：
+
+- selected profile
+- `workspace_entry`
+- resolved workspace path
+- workspace 是否存在
+- purity check 结果
+- host worktree binding 是否可观察
+- 下一步修复建议
+
+这些字段只能从 `Work Item`、fact-chain、workspace locate、purity check 与
+host lifecycle 派生，不能反向覆盖 `Work Item` 或宿主对象。
+
+## 4. 失败语义
+
+- `missing_workspace_entry`
+  - `Work Item` 缺少 workspace entry。
+- `workspace_missing`
+  - 声明的 workspace path 不存在。
+- `workspace_escape`
+  - 声明路径逃逸目标仓库。
+- `workspace_dirty`
+  - 当前现场存在未分流改动。
+- `workspace_binding_drift`
+  - workspace / branch / PR / host worktree 与当前事项绑定不一致。
+
+以上失败可以阻断 resume、review 或 merge-ready；但不得被解释为 Git
+worktree 生命周期命令失败。
+
+## 5. Ownership 边界
+
+Loom 拥有：
+
+- workspace profile 语义
+- workspace locate / purity / retire 的编排合同
+- 当前事项与执行现场的绑定校验
+- 派生状态面与修复建议
+
+宿主平台仍拥有：
+
+- `git worktree add/remove/list` 的底层实现
+- branch create / rename / retire
+- PR create / update / merge / close
+- ruleset、required checks 与 merge policy 的强制执行
+
+## 6. 非目标
+
+- 不要求所有仓库都使用 Git worktree。
+- 不把 `workspace` 命名成 `git worktree` 的别名。
+- 不新增替代 Git 的 worktree manager。
+- 不用 profile 状态反向覆盖 authored work item truth。

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.57",
+      "version": "0.1.58",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -40,6 +40,7 @@
     "shared/references/harness/runtime-state.md",
     "shared/references/harness/work-item-contract.md",
     "shared/references/harness/workspace-model.md",
+    "shared/references/harness/workspace-profile.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/execution-context.md",

--- a/skills/shared/references/harness/workspace-profile.md
+++ b/skills/shared/references/harness/workspace-profile.md
@@ -1,0 +1,19 @@
+# Workspace Profile
+
+Canonical source: `docs/methodology/harness/workspace-profile.md`.
+
+Installed skills consume this summary to keep the runtime package aware of the
+workspace profile surface without creating a second rule definition.
+
+Stable installed-surface facts:
+
+- Supported profile ids are `single-workspace`, `per-item-worktree`, and
+  `attach-existing`.
+- Profile status is a derived read surface from `Work Item`, fact-chain,
+  workspace locate, purity check, and host lifecycle.
+- `workspace` remains Loom-owned execution semantics.
+- `git worktree`, branch, PR, ruleset, checks, and merge policy remain
+  host-owned lifecycle and enforcement surfaces.
+
+Implementations must update the canonical methodology file first, then keep this
+installed summary aligned.

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -33,6 +33,23 @@ PLANNED_LOCATORS = {
 REPO_INTERFACE_SURFACES = ("review", "merge_ready", "closeout")
 REPO_INTERFACE_AVAILABILITY = {"absent", "companion_docs_only", "incomplete", "present"}
 REPO_INTERFACE_MANIFEST_SCHEMA = "loom-repo-companion-manifest/v1"
+WORKSPACE_PROFILE_CONTRACTS = {
+    "single-workspace": {
+        "summary": "Use the repository root as the Loom execution workspace.",
+        "host_worktree_required": False,
+        "recommended_action": "keep workspace_entry as `.` unless isolation becomes necessary",
+    },
+    "per-item-worktree": {
+        "summary": "Use one isolated workspace per Work Item, usually backed by host git worktree.",
+        "host_worktree_required": True,
+        "recommended_action": "ensure workspace, branch, Work Item, and PR bindings stay aligned",
+    },
+    "attach-existing": {
+        "summary": "Attach Loom to an existing repo-defined workspace without taking over host lifecycle actions.",
+        "host_worktree_required": False,
+        "recommended_action": "declare the repo-specific workspace locator and keep host lifecycle ownership external",
+    },
+}
 REPO_INTERFACE_V1_SCHEMA = "loom-repo-interface/v1"
 REPO_INTERFACE_V2_SCHEMA = "loom-repo-interface/v2"
 REPO_INTERFACE_SCHEMAS = {REPO_INTERFACE_V1_SCHEMA, REPO_INTERFACE_V2_SCHEMA}
@@ -1047,6 +1064,72 @@ def active_entry_points(root: Path) -> dict[str, str]:
     return active
 
 
+def work_item_workspace_entry(root: Path) -> str:
+    active = active_entry_points(root)
+    locator = active.get("work_item")
+    if not locator:
+        return ""
+    resolved_locator, work_item_path = resolve_locator(root, locator)
+    if resolved_locator is None or work_item_path is None:
+        return ""
+    try:
+        text = work_item_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    match = re.search(r"^- Workspace Entry:\s*(.+?)\s*$", text, flags=re.MULTILINE)
+    return match.group(1).strip() if match else ""
+
+
+def select_workspace_profile(workspace_entry: str, item_id: str) -> tuple[str, str]:
+    if not workspace_entry:
+        return "unknown", "workspace_entry is not readable"
+    normalized = workspace_entry.strip().replace("\\", "/")
+    if normalized == ".":
+        return "single-workspace", "workspace_entry points at the repository root"
+    if normalized.startswith(".worktrees/") or (item_id and item_id in normalized):
+        return "per-item-worktree", "workspace_entry is item-scoped or under `.worktrees/`"
+    return "attach-existing", "workspace_entry points at an existing repo-defined workspace"
+
+
+def detect_workspace_profile(root: Path, *, host_binding: dict[str, Any]) -> dict[str, Any]:
+    active = active_entry_points(root)
+    item_id = active.get("current_item_id", "")
+    workspace_entry = work_item_workspace_entry(root)
+    selected, reason = select_workspace_profile(workspace_entry, item_id)
+    locator, workspace_path = resolve_locator(root, workspace_entry)
+    missing_inputs: list[str] = []
+    if not workspace_entry:
+        missing_inputs.append("missing_workspace_entry")
+    elif locator is None or workspace_path is None:
+        missing_inputs.append("workspace_escape")
+    elif not workspace_path.exists():
+        missing_inputs.append("workspace_missing")
+    required_objects = host_binding.get("required_objects") if isinstance(host_binding, dict) else None
+    worktree = required_objects.get("worktree") if isinstance(required_objects, dict) else None
+    worktree_status = worktree.get("status") if isinstance(worktree, dict) else "unknown"
+    return {
+        "schema_version": "loom-workspace-profile/v1",
+        "selected": selected,
+        "selection_reason": reason,
+        "profiles": WORKSPACE_PROFILE_CONTRACTS,
+        "workspace_entry": workspace_entry or "unknown",
+        "workspace_path": locator or "unknown",
+        "workspace_exists": bool(workspace_path and workspace_path.exists()),
+        "host_worktree": {
+            "ownership": "host",
+            "status": worktree_status,
+            "locator": worktree.get("locator", "unknown") if isinstance(worktree, dict) else "unknown",
+        },
+        "result": "pass" if not missing_inputs else "block",
+        "missing_inputs": missing_inputs,
+        "recommended_action": (
+            WORKSPACE_PROFILE_CONTRACTS[selected]["recommended_action"]
+            if selected in WORKSPACE_PROFILE_CONTRACTS
+            else "restore the Work Item workspace_entry before running workspace profile checks"
+        ),
+    }
+
+
 def bootstrap_host_binding_branch(root: Path) -> str:
     init_result = root / ".loom/bootstrap/init-result.json"
     try:
@@ -1369,6 +1452,7 @@ def governance_control_plane(
     repo_interface: dict[str, Any],
     repo_interop: dict[str, Any],
     host_binding: dict[str, Any],
+    workspace_profile: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "schema_version": GOVERNANCE_CONTROL_VERSION,
@@ -1377,6 +1461,7 @@ def governance_control_plane(
             "illegal_entry_fallbacks": WORK_ITEM_ENFORCEMENT_FALLBACKS,
             "result": "pass" if carrier_summary.get("work_item", {}).get("status") == "present" else "block",
         },
+        "workspace_profile": workspace_profile,
         "host_binding": host_binding,
         "taxonomy": GATE_FAILURE_TAXONOMY,
         "gate_chain": GATE_CHAIN,
@@ -1414,12 +1499,14 @@ def build_governance_surface(
         repo_interface=repo_interface,
         repo_interop=repo_interop,
     )
+    workspace_profile = detect_workspace_profile(root, host_binding=host_binding)
     control_plane = governance_control_plane(
         carrier_summary=carrier_summary,
         github_control_plane=github_control_plane,
         repo_interface=repo_interface,
         repo_interop=repo_interop,
         host_binding=host_binding,
+        workspace_profile=workspace_profile,
     )
 
     missing_inputs: list[str] = []
@@ -1455,6 +1542,7 @@ def build_governance_surface(
         "github_control_plane": github_control_plane,
         "repo_interface": repo_interface,
         "repo_interop": repo_interop,
+        "workspace_profile": workspace_profile,
         "governance_control_plane": control_plane,
         "summary": summary,
         "missing_inputs": list(dict.fromkeys(missing_inputs)),

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -76,6 +76,7 @@ CORE_DOCS = (
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
+    "docs/methodology/harness/workspace-profile.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/host-action-contract.md",
     "docs/methodology/harness/host-lifecycle-boundary.md",
@@ -185,6 +186,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
+    "docs/methodology/harness/workspace-profile.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/recovery-model.md",
     "docs/methodology/harness/status-surface.md",
@@ -736,12 +738,47 @@ def require_governance_surface(
         context=f"{context} governance_surface.repo_interop",
         payload=governance_surface.get("repo_interop"),
     )
+    require_workspace_profile_payload(
+        failures,
+        category=category,
+        context=f"{context} governance_surface.workspace_profile",
+        payload=governance_surface.get("workspace_profile"),
+    )
     require_governance_control_plane(
         failures,
         category=category,
         context=f"{context} governance_surface.governance_control_plane",
         payload=governance_surface.get("governance_control_plane"),
     )
+
+
+def require_workspace_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != "loom-workspace-profile/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-workspace-profile/v1`"))
+    if payload.get("selected") not in {"single-workspace", "per-item-worktree", "attach-existing", "unknown"}:
+        failures.append(Failure(category, f"{context} selected profile must stay within the stable set"))
+    if payload.get("result") not in {"pass", "block"}:
+        failures.append(Failure(category, f"{context} result must be pass/block"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+    for field in ("workspace_entry", "workspace_path", "recommended_action"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not value:
+            failures.append(Failure(category, f"{context}.{field} must be a non-empty string"))
+    host_worktree = payload.get("host_worktree")
+    if not isinstance(host_worktree, dict):
+        failures.append(Failure(category, f"{context}.host_worktree must be an object"))
+    elif host_worktree.get("ownership") != "host":
+        failures.append(Failure(category, f"{context}.host_worktree ownership must stay `host`"))
 
 
 def require_governance_control_plane(
@@ -782,6 +819,13 @@ def require_governance_control_plane(
             failures.append(Failure(category, f"{context}.host_binding.required_objects must expose the stable host binding object set"))
         elif required_objects.get("work_item", {}).get("authority") != "loom fact chain":
             failures.append(Failure(category, f"{context}.host_binding work_item authority must remain Loom fact chain"))
+
+    require_workspace_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.workspace_profile",
+        payload=payload.get("workspace_profile"),
+    )
 
     taxonomy = payload.get("taxonomy")
     expected_taxonomy = {

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -3832,6 +3832,7 @@ def purity_report_from_context(context: dict[str, Any], fact_chain_errors: list[
 
 def base_workspace_payload(context: dict[str, Any], operation: str) -> dict[str, Any]:
     purity = purity_report_from_context(context)
+    workspace_profile = workspace_profile_from_context(context)
     return {
         "command": "workspace",
         "operation": operation,
@@ -3845,6 +3846,7 @@ def base_workspace_payload(context: dict[str, Any], operation: str) -> dict[str,
             "entry": context["workspace_entry"],
             "path": relative_to_root(context["workspace_path"], context["target_root"]),
             "exists": context["workspace_path"].exists(),
+            "profile": workspace_profile,
         },
         "recovery": {
             "path": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
@@ -3859,6 +3861,39 @@ def base_workspace_payload(context: dict[str, Any], operation: str) -> dict[str,
         "purity": purity,
         "missing_inputs": [],
         "fallback_to": None,
+    }
+
+
+def select_workspace_profile_name(workspace_entry: str, item_id: str) -> tuple[str, str]:
+    normalized = workspace_entry.strip().replace("\\", "/")
+    if normalized == ".":
+        return "single-workspace", "workspace_entry points at the repository root"
+    if normalized.startswith(".worktrees/") or (item_id and item_id in normalized):
+        return "per-item-worktree", "workspace_entry is item-scoped or under `.worktrees/`"
+    return "attach-existing", "workspace_entry points at an existing repo-defined workspace"
+
+
+def workspace_profile_from_context(context: dict[str, Any]) -> dict[str, Any]:
+    selected, reason = select_workspace_profile_name(context["workspace_entry"], context["item_id"])
+    return {
+        "schema_version": "loom-workspace-profile/v1",
+        "selected": selected,
+        "selection_reason": reason,
+        "workspace_entry": context["workspace_entry"],
+        "workspace_path": relative_to_root(context["workspace_path"], context["target_root"]),
+        "workspace_exists": context["workspace_path"].exists(),
+        "host_worktree": {
+            "ownership": "host",
+            "cwd_within_repo": current_cwd_relative(context["target_root"]) or "outside_target_repo",
+            "status": "host_managed",
+        },
+        "recommended_action": (
+            "keep workspace_entry as `.` unless isolation becomes necessary"
+            if selected == "single-workspace"
+            else "ensure workspace, branch, Work Item, and PR bindings stay aligned"
+            if selected == "per-item-worktree"
+            else "keep repo-specific workspace locator declared and host lifecycle ownership external"
+        ),
     }
 
 
@@ -5023,6 +5058,7 @@ def handle_host_binding(args: argparse.Namespace) -> int:
 def host_lifecycle_payload(context: dict[str, Any]) -> dict[str, Any]:
     branch = git_branch(context["target_root"])
     purity = purity_report_from_context(context)
+    workspace_profile = workspace_profile_from_context(context)
     worktree_root = current_cwd_relative(context["target_root"])
     branch_status = "report_only" if branch else "host_managed_without_local_branch"
     pr_status = "report_only"
@@ -5053,6 +5089,7 @@ def host_lifecycle_payload(context: dict[str, Any]) -> dict[str, Any]:
                 "ownership": "loom",
                 "entry": context["workspace_entry"],
                 "path": relative_to_root(context["workspace_path"], context["target_root"]),
+                "profile": workspace_profile,
                 "lifecycle_entry": "python3 .loom/bin/loom_flow.py workspace create|locate|cleanup|retire",
             },
             "branch": {
@@ -5096,6 +5133,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
     next_level = maturity.get("next")
     target_level = next_level if isinstance(next_level, str) else current if isinstance(current, str) else None
     gate_rollout = maturity.get("gate_rollout")
+    workspace_profile = control_plane.get("workspace_profile") if isinstance(control_plane, dict) else None
     missing_by_level = maturity.get("missing_by_level")
     missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs: list[Any] = []
@@ -5127,6 +5165,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
         "recommended_action": "run governance-profile upgrade --dry-run" if result == "block" else None,
         "fallback_to": None if result == "pass" else "adoption",
         "maturity": maturity,
+        "workspace_profile": workspace_profile,
         "gate_rollout": gate_rollout,
         "governance_control_plane": control_plane,
         "adoption_decisions": decisions,
@@ -5201,6 +5240,7 @@ def governance_profile_upgrade_payload(
         }
     base = governance_profile_payload(target_root, "upgrade-plan")
     maturity = base.get("maturity") if isinstance(base.get("maturity"), dict) else {}
+    workspace_profile = base.get("workspace_profile")
     actions = governance_upgrade_actions(target_root, target_level, maturity if isinstance(maturity, dict) else {})
     blockers: list[str] = []
     written_files: list[str] = []
@@ -5237,6 +5277,7 @@ def governance_profile_upgrade_payload(
         "actions": actions,
         "written_files": written_files,
         "maturity": maturity,
+        "workspace_profile": workspace_profile,
         "gate_rollout": maturity.get("gate_rollout") if isinstance(maturity, dict) else None,
         "adoption_decisions": decisions,
         "guided_adoption_plan": guided_plan,

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -409,6 +409,7 @@ def main(argv: list[str]) -> int:
     review = implementation_review_status_payload(context)
     merge_ready = checkpoint_payload("merge", context)
     governance_surface = build_governance_surface(target_root)
+    workspace_profile = governance_surface.get("workspace_profile")
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
             "review": review,
             "merge_ready": merge_ready,
             "closeout": closeout,
+            "workspace_profile": workspace_profile,
             "governance_status": control_status,
             "governance_surface": governance_surface,
             "github": github_status,


### PR DESCRIPTION
## 摘要

本 PR 收口 #479 的 PR 1：workspace profile 默认启动合同。

Closes #480
Closes #484
Closes #485

## 变更

- 新增 `docs/methodology/harness/workspace-profile.md` 作为 canonical 合同，固定 `single-workspace`、`per-item-worktree`、`attach-existing` 的语义、输入/输出、失败分类与 ownership 边界。
- 在 governance surface、`governance-profile status|upgrade-plan|upgrade --dry-run`、workspace/host-lifecycle/status 读面暴露 `workspace_profile`。
- 明确 `host_worktree.ownership = host`，Loom 只治理 workspace 语义、绑定和检查，不接管 `git worktree` 生命周期动作。
- 同步 repo self-governance carrier：`.loom/bin/*`、bootstrap manifest hash、merge-ready shadow hash。

## 边界确认

- 未新增 GitHub 远端读取。
- 未新增统一 `loom` 可执行文件。
- 未提交 `.agents/`、`.codex/`、`.claude/`、payload、cache 或 `__pycache__` 安装态。
- `skills/shared/references/harness/workspace-profile.md` 只作为安装摘要与 canonical doc 引用，不建立第二套定义。

## 验证

- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `make loom-check`
- `python3 tools/loom_flow.py governance-profile status --target . | python3 -m json.tool`
- `python3 tools/loom_status.py --target . --item INIT-0001 | python3 -m json.tool`
- `git diff --check`
- `cmp -s skills/shared/scripts/governance_surface.py .loom/bin/governance_surface.py && cmp -s skills/shared/scripts/loom_flow.py .loom/bin/loom_flow.py && cmp -s skills/shared/scripts/loom_status.py .loom/bin/loom_status.py && cmp -s skills/shared/scripts/loom_check.py .loom/bin/loom_check.py`

说明：`make loom-check` 会按现有 CI 路径先重建 `examples/new-project` demo runtime，再执行 `python3 tools/loom_check.py`。校验生成的 demo 本机路径变更未进入本 PR。
