### PR TITLE
feat(gates): 定义 repo-local gate starter

### DIFF
--- a/.loom/bin/governance_surface.py
+++ b/.loom/bin/governance_surface.py
@@ -50,6 +50,53 @@ WORKSPACE_PROFILE_CONTRACTS = {
         "recommended_action": "declare the repo-specific workspace locator and keep host lifecycle ownership external",
     },
 }
+GATE_STARTER_ALIASES = {
+    "verify": {
+        "surface": "verification",
+        "entrypoint": ".loom/bin/loom_init.py",
+        "command": "python3 .loom/bin/loom_init.py verify --target .",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Run the repo-local Loom bootstrap verification entry.",
+    },
+    "status": {
+        "surface": "status",
+        "entrypoint": ".loom/bin/loom_status.py",
+        "command": "python3 .loom/bin/loom_status.py --target . --item <current-item>",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Read the repo-local Loom status surface.",
+    },
+    "merge-ready": {
+        "surface": "merge_ready",
+        "entrypoint": ".loom/bin/loom_flow.py",
+        "command": "python3 .loom/bin/loom_flow.py flow merge-ready --target . --item <current-item>",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Run Loom's local merge-ready orchestration without taking over host merge controls.",
+    },
+    "closeout-check": {
+        "surface": "closeout",
+        "entrypoint": ".loom/bin/loom_flow.py",
+        "command": "python3 .loom/bin/loom_flow.py closeout check --target .",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Check closeout readiness against local Loom carriers and readable host inputs.",
+    },
+    "reconciliation-audit": {
+        "surface": "reconciliation",
+        "entrypoint": ".loom/bin/loom_flow.py",
+        "command": "python3 .loom/bin/loom_flow.py reconciliation audit --target .",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Audit closeout drift without mutating host state.",
+    },
+}
 REPO_INTERFACE_V1_SCHEMA = "loom-repo-interface/v1"
 REPO_INTERFACE_V2_SCHEMA = "loom-repo-interface/v2"
 REPO_INTERFACE_SCHEMAS = {REPO_INTERFACE_V1_SCHEMA, REPO_INTERFACE_V2_SCHEMA}
@@ -1130,6 +1177,40 @@ def detect_workspace_profile(root: Path, *, host_binding: dict[str, Any]) -> dic
     }
 
 
+def detect_gate_starter(root: Path) -> dict[str, Any]:
+    active = active_entry_points(root)
+    item_id = active.get("current_item_id", "INIT-0001")
+    aliases: dict[str, dict[str, Any]] = {}
+    missing_entrypoints: list[str] = []
+    for alias, contract in GATE_STARTER_ALIASES.items():
+        row = dict(contract)
+        command = str(row["command"]).replace("<current-item>", item_id)
+        row["command"] = command
+        entrypoint = root / str(row["entrypoint"])
+        row["runtime_present"] = entrypoint.exists()
+        if not entrypoint.exists() and str(row["entrypoint"]) not in missing_entrypoints:
+            missing_entrypoints.append(str(row["entrypoint"]))
+        aliases[alias] = row
+    runtime_status = "present" if not missing_entrypoints else "missing"
+    return {
+        "schema_version": "loom-gate-starter/v1",
+        "aliases": aliases,
+        "runtime_status": runtime_status,
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "host_enforcement_status": "not_host_enforced",
+        "result": "pass",
+        "missing_inputs": [],
+        "missing_entrypoints": missing_entrypoints,
+        "recommended_action": (
+            "run the repo-local aliases as advisory Loom checks, then configure host-required checks separately"
+            if not missing_entrypoints
+            else "install or refresh repo-local Loom runtime entries before using gate starter aliases"
+        ),
+    }
+
+
 def bootstrap_host_binding_branch(root: Path) -> str:
     init_result = root / ".loom/bootstrap/init-result.json"
     try:
@@ -1453,6 +1534,7 @@ def governance_control_plane(
     repo_interop: dict[str, Any],
     host_binding: dict[str, Any],
     workspace_profile: dict[str, Any],
+    gate_starter: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "schema_version": GOVERNANCE_CONTROL_VERSION,
@@ -1462,6 +1544,7 @@ def governance_control_plane(
             "result": "pass" if carrier_summary.get("work_item", {}).get("status") == "present" else "block",
         },
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "host_binding": host_binding,
         "taxonomy": GATE_FAILURE_TAXONOMY,
         "gate_chain": GATE_CHAIN,
@@ -1500,6 +1583,7 @@ def build_governance_surface(
         repo_interop=repo_interop,
     )
     workspace_profile = detect_workspace_profile(root, host_binding=host_binding)
+    gate_starter = detect_gate_starter(root)
     control_plane = governance_control_plane(
         carrier_summary=carrier_summary,
         github_control_plane=github_control_plane,
@@ -1507,6 +1591,7 @@ def build_governance_surface(
         repo_interop=repo_interop,
         host_binding=host_binding,
         workspace_profile=workspace_profile,
+        gate_starter=gate_starter,
     )
 
     missing_inputs: list[str] = []
@@ -1543,6 +1628,7 @@ def build_governance_surface(
         "repo_interface": repo_interface,
         "repo_interop": repo_interop,
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "governance_control_plane": control_plane,
         "summary": summary,
         "missing_inputs": list(dict.fromkeys(missing_inputs)),

--- a/.loom/bin/loom_check.py
+++ b/.loom/bin/loom_check.py
@@ -77,6 +77,7 @@ CORE_DOCS = (
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
     "docs/methodology/harness/workspace-profile.md",
+    "docs/methodology/harness/repo-local-gate-starter.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/host-action-contract.md",
     "docs/methodology/harness/host-lifecycle-boundary.md",
@@ -187,6 +188,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
     "docs/methodology/harness/workspace-profile.md",
+    "docs/methodology/harness/repo-local-gate-starter.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/recovery-model.md",
     "docs/methodology/harness/status-surface.md",
@@ -744,6 +746,12 @@ def require_governance_surface(
         context=f"{context} governance_surface.workspace_profile",
         payload=governance_surface.get("workspace_profile"),
     )
+    require_gate_starter_payload(
+        failures,
+        category=category,
+        context=f"{context} governance_surface.gate_starter",
+        payload=governance_surface.get("gate_starter"),
+    )
     require_governance_control_plane(
         failures,
         category=category,
@@ -779,6 +787,52 @@ def require_workspace_profile_payload(
         failures.append(Failure(category, f"{context}.host_worktree must be an object"))
     elif host_worktree.get("ownership") != "host":
         failures.append(Failure(category, f"{context}.host_worktree ownership must stay `host`"))
+
+
+def require_gate_starter_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != "loom-gate-starter/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-gate-starter/v1`"))
+    if payload.get("authority") != "local":
+        failures.append(Failure(category, f"{context} authority must stay `local`"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} enforcement must stay `advisory`"))
+    if payload.get("host_enforcement") is not False:
+        failures.append(Failure(category, f"{context} host_enforcement must stay false"))
+    if payload.get("host_enforcement_status") != "not_host_enforced":
+        failures.append(Failure(category, f"{context} host_enforcement_status must stay `not_host_enforced`"))
+    if payload.get("result") != "pass":
+        failures.append(Failure(category, f"{context} result must stay pass because aliases are local starter definitions"))
+    aliases = payload.get("aliases")
+    required_aliases = {"verify", "status", "merge-ready", "closeout-check", "reconciliation-audit"}
+    if not isinstance(aliases, dict):
+        failures.append(Failure(category, f"{context}.aliases must be an object"))
+        return
+    missing_aliases = sorted(required_aliases - set(aliases.keys()))
+    if missing_aliases:
+        failures.append(Failure(category, f"{context}.aliases is missing {', '.join(missing_aliases)}"))
+    for alias, row in aliases.items():
+        if not isinstance(row, dict):
+            failures.append(Failure(category, f"{context}.aliases.{alias} must be an object"))
+            continue
+        if row.get("authority") != "local":
+            failures.append(Failure(category, f"{context}.aliases.{alias}.authority must stay `local`"))
+        if row.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"{context}.aliases.{alias}.enforcement must stay `advisory`"))
+        if row.get("host_enforcement") is not False:
+            failures.append(Failure(category, f"{context}.aliases.{alias}.host_enforcement must stay false"))
+        for field in ("surface", "entrypoint", "command", "summary"):
+            value = row.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.aliases.{alias}.{field} must be a non-empty string"))
 
 
 def require_governance_control_plane(
@@ -825,6 +879,12 @@ def require_governance_control_plane(
         category=category,
         context=f"{context}.workspace_profile",
         payload=payload.get("workspace_profile"),
+    )
+    require_gate_starter_payload(
+        failures,
+        category=category,
+        context=f"{context}.gate_starter",
+        payload=payload.get("gate_starter"),
     )
 
     taxonomy = payload.get("taxonomy")
@@ -2501,6 +2561,19 @@ def check_demo_assets(root: Path) -> list[Failure]:
         run = init_result.get("run")
         if not isinstance(run, dict) or run.get("scenario_key") != "new":
             failures.append(Failure("demo-assets", "demo init-result must keep `scenario_key` as `new`"))
+        governance_surface = init_result.get("governance_surface")
+        if not isinstance(governance_surface, dict):
+            failures.append(Failure("demo-assets", "demo init-result must include governance_surface"))
+        else:
+            require_gate_starter_payload(
+                failures,
+                category="demo-assets",
+                context="demo init-result governance_surface.gate_starter",
+                payload=governance_surface.get("gate_starter"),
+            )
+            gate_starter = governance_surface.get("gate_starter")
+            if isinstance(gate_starter, dict) and gate_starter.get("host_enforcement") is not False:
+                failures.append(Failure("demo-assets", "demo gate starter must not claim host enforcement"))
     return failures
 
 

--- a/.loom/bin/loom_flow.py
+++ b/.loom/bin/loom_flow.py
@@ -5134,6 +5134,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
     target_level = next_level if isinstance(next_level, str) else current if isinstance(current, str) else None
     gate_rollout = maturity.get("gate_rollout")
     workspace_profile = control_plane.get("workspace_profile") if isinstance(control_plane, dict) else None
+    gate_starter = control_plane.get("gate_starter") if isinstance(control_plane, dict) else None
     missing_by_level = maturity.get("missing_by_level")
     missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs: list[Any] = []
@@ -5166,6 +5167,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
         "fallback_to": None if result == "pass" else "adoption",
         "maturity": maturity,
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "gate_rollout": gate_rollout,
         "governance_control_plane": control_plane,
         "adoption_decisions": decisions,
@@ -5241,6 +5243,7 @@ def governance_profile_upgrade_payload(
     base = governance_profile_payload(target_root, "upgrade-plan")
     maturity = base.get("maturity") if isinstance(base.get("maturity"), dict) else {}
     workspace_profile = base.get("workspace_profile")
+    gate_starter = base.get("gate_starter")
     actions = governance_upgrade_actions(target_root, target_level, maturity if isinstance(maturity, dict) else {})
     blockers: list[str] = []
     written_files: list[str] = []
@@ -5278,6 +5281,7 @@ def governance_profile_upgrade_payload(
         "written_files": written_files,
         "maturity": maturity,
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "gate_rollout": maturity.get("gate_rollout") if isinstance(maturity, dict) else None,
         "adoption_decisions": decisions,
         "guided_adoption_plan": guided_plan,

--- a/.loom/bin/loom_status.py
+++ b/.loom/bin/loom_status.py
@@ -410,6 +410,7 @@ def main(argv: list[str]) -> int:
     merge_ready = checkpoint_payload("merge", context)
     governance_surface = build_governance_surface(target_root)
     workspace_profile = governance_surface.get("workspace_profile")
+    gate_starter = governance_surface.get("gate_starter")
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
             "merge_ready": merge_ready,
             "closeout": closeout,
             "workspace_profile": workspace_profile,
+            "gate_starter": gate_starter,
             "governance_status": control_status,
             "governance_surface": governance_surface,
             "github": github_status,

--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -122,19 +122,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "ef6757f6aa1e2e1615858ab755b00aae49f711b9f8c47f80bc3bd4539cd38a33"
+      "sha256": "0a0dab521978135609f9e5dde97aaa28d5f034c9d77f5e21a90cf9ecce62c64b"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "5f15aa05f534809bac6f83997da51c96a1d324a4ee99ea62611bfb08ae393016"
+      "sha256": "0549a076540fdd83c0c0260df79146b008f091002d614a7a512dc265c6a822f0"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "e5d76b6958b6129b1ba92843e2515ce0d90b293bb586f544e4ffa6e766c4e362"
+      "sha256": "e7c71c2ecf39e9340771142d9c6e3b207f3528f8c620e55bd58f70e2595e73ef"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -152,7 +152,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
+      "sha256": "4f406d137c1c5b80531ece54e17544984286951663133efc8943e2f11afcf04e"
     },
     {
       "path": "AGENTS.md",

--- a/.loom/bootstrap/manifest.json
+++ b/.loom/bootstrap/manifest.json
@@ -47,19 +47,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "ef6757f6aa1e2e1615858ab755b00aae49f711b9f8c47f80bc3bd4539cd38a33"
+      "sha256": "0a0dab521978135609f9e5dde97aaa28d5f034c9d77f5e21a90cf9ecce62c64b"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "5f15aa05f534809bac6f83997da51c96a1d324a4ee99ea62611bfb08ae393016"
+      "sha256": "0549a076540fdd83c0c0260df79146b008f091002d614a7a512dc265c6a822f0"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "e5d76b6958b6129b1ba92843e2515ce0d90b293bb586f544e4ffa6e766c4e362"
+      "sha256": "e7c71c2ecf39e9340771142d9c6e3b207f3528f8c620e55bd58f70e2595e73ef"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
+      "sha256": "4f406d137c1c5b80531ece54e17544984286951663133efc8943e2f11afcf04e"
     },
     {
       "path": "AGENTS.md",

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -10,6 +10,6 @@
   ],
   "source_sha256": {
     ".github/workflows/loom-check.yml": "94497e146bf2ff0d8652c56bdde95fe9743f76dcfd666f8a3d04b22a8d32d787",
-    "skills/shared/scripts/loom_check.py": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
+    "skills/shared/scripts/loom_check.py": "4f406d137c1c5b80531ece54e17544984286951663133efc8943e2f11afcf04e"
   }
 }

--- a/.loom/shadow/merge-ready-repo.json
+++ b/.loom/shadow/merge-ready-repo.json
@@ -10,6 +10,6 @@
   ],
   "source_sha256": {
     ".github/workflows/loom-check.yml": "94497e146bf2ff0d8652c56bdde95fe9743f76dcfd666f8a3d04b22a8d32d787",
-    "skills/shared/scripts/loom_check.py": "271a4d11844e45f8e343138107c315bde22edc697b22547907d6a9316457e2d5"
+    "skills/shared/scripts/loom_check.py": "4f406d137c1c5b80531ece54e17544984286951663133efc8943e2f11afcf04e"
   }
 }

--- a/docs/methodology/harness/README.md
+++ b/docs/methodology/harness/README.md
@@ -31,6 +31,8 @@
   - 定义执行现场的隔离、定位与 clean state 要求
 - [workspace-profile.md](./workspace-profile.md)
   - 定义 `single-workspace`、`per-item-worktree`、`attach-existing` 三类默认现场装配 profile
+- [repo-local-gate-starter.md](./repo-local-gate-starter.md)
+  - 定义新仓库可用的本地 gate starter aliases，并明确它们不是宿主强制门禁
 - `workspace-lifecycle.md`
   - 定义 `create`、`locate`、`cleanup`、`retire` 与 `purity-check` 的生命周期合同
 - [host-action-contract.md](./host-action-contract.md)

--- a/docs/methodology/harness/repo-local-gate-starter.md
+++ b/docs/methodology/harness/repo-local-gate-starter.md
@@ -1,0 +1,49 @@
+# Repo-Local Gate Starter
+
+Loom 可以提供 repo-local gate starter aliases，让新仓库在没有宿主控制面之前也能启动一致的本地检查入口。
+
+这些 aliases 是 Loom source/runtime 的可执行启动器，不是 GitHub、CI、branch protection 或 merge queue 的替代物。
+
+## Stable Aliases
+
+| Alias | Runtime entry | Purpose |
+| --- | --- | --- |
+| `verify` | `python3 .loom/bin/loom_init.py verify --target .` | 读取 bootstrap 与事实链是否完整。 |
+| `status` | `python3 .loom/bin/loom_status.py --target . --item <current-item>` | 汇总当前 Work Item、review、merge checkpoint 与 host 读面。 |
+| `merge-ready` | `python3 .loom/bin/loom_flow.py flow merge-ready --target . --item <current-item>` | 编排本地 merge-ready 检查。 |
+| `closeout-check` | `python3 .loom/bin/loom_flow.py closeout check --target .` | 检查 closeout 是否能消费本地 carrier 与可读 host 输入。 |
+| `reconciliation-audit` | `python3 .loom/bin/loom_flow.py reconciliation audit --target .` | 审计 issue / PR / project / branch drift，不写宿主状态。 |
+
+## Machine Contract
+
+`governance_surface.gate_starter` 与 `governance_control_plane.gate_starter` 必须使用：
+
+- `schema_version: loom-gate-starter/v1`
+- `authority: local`
+- `enforcement: advisory`
+- `host_enforcement: false`
+- `host_enforcement_status: not_host_enforced`
+
+每个 alias 必须声明：
+
+- `surface`
+- `entrypoint`
+- `command`
+- `authority`
+- `enforcement`
+- `host_enforcement`
+- `summary`
+
+## Failure Semantics
+
+本地 alias 的存在只能证明 Loom starter 已定义或 repo-local runtime 可读。
+
+它不能证明：
+
+- GitHub Actions workflow 已安装。
+- required checks 已配置为 blocking。
+- branch protection 或 ruleset 已强制。
+- PR merge path 已受控。
+- merge queue、squash policy 或 host merge button 已由 Loom 接管。
+
+若 repo-local runtime 尚未安装，`missing_entrypoints` 可以列出缺失入口；但 alias 合同本身仍保持 advisory。升级到 `strong` 必须由 host enforcement 读面单独证明。

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.58",
+      "version": "0.1.59",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -41,6 +41,7 @@
     "shared/references/harness/work-item-contract.md",
     "shared/references/harness/workspace-model.md",
     "shared/references/harness/workspace-profile.md",
+    "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/execution-context.md",

--- a/skills/shared/references/harness/repo-local-gate-starter.md
+++ b/skills/shared/references/harness/repo-local-gate-starter.md
@@ -1,0 +1,10 @@
+# Repo-Local Gate Starter
+
+Canonical contract: `docs/methodology/harness/repo-local-gate-starter.md`.
+
+Installed summary:
+
+- Loom exposes local starter aliases for `verify`, `status`, `merge-ready`, `closeout-check`, and `reconciliation-audit`.
+- These aliases point at existing `.loom/bin/loom_*` runtime entries.
+- They are always `authority: local`, `enforcement: advisory`, and `host_enforcement: false`.
+- Host-enforced controls must be proven separately by GitHub/CI/ruleset reads.

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -50,6 +50,53 @@ WORKSPACE_PROFILE_CONTRACTS = {
         "recommended_action": "declare the repo-specific workspace locator and keep host lifecycle ownership external",
     },
 }
+GATE_STARTER_ALIASES = {
+    "verify": {
+        "surface": "verification",
+        "entrypoint": ".loom/bin/loom_init.py",
+        "command": "python3 .loom/bin/loom_init.py verify --target .",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Run the repo-local Loom bootstrap verification entry.",
+    },
+    "status": {
+        "surface": "status",
+        "entrypoint": ".loom/bin/loom_status.py",
+        "command": "python3 .loom/bin/loom_status.py --target . --item <current-item>",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Read the repo-local Loom status surface.",
+    },
+    "merge-ready": {
+        "surface": "merge_ready",
+        "entrypoint": ".loom/bin/loom_flow.py",
+        "command": "python3 .loom/bin/loom_flow.py flow merge-ready --target . --item <current-item>",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Run Loom's local merge-ready orchestration without taking over host merge controls.",
+    },
+    "closeout-check": {
+        "surface": "closeout",
+        "entrypoint": ".loom/bin/loom_flow.py",
+        "command": "python3 .loom/bin/loom_flow.py closeout check --target .",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Check closeout readiness against local Loom carriers and readable host inputs.",
+    },
+    "reconciliation-audit": {
+        "surface": "reconciliation",
+        "entrypoint": ".loom/bin/loom_flow.py",
+        "command": "python3 .loom/bin/loom_flow.py reconciliation audit --target .",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "summary": "Audit closeout drift without mutating host state.",
+    },
+}
 REPO_INTERFACE_V1_SCHEMA = "loom-repo-interface/v1"
 REPO_INTERFACE_V2_SCHEMA = "loom-repo-interface/v2"
 REPO_INTERFACE_SCHEMAS = {REPO_INTERFACE_V1_SCHEMA, REPO_INTERFACE_V2_SCHEMA}
@@ -1130,6 +1177,40 @@ def detect_workspace_profile(root: Path, *, host_binding: dict[str, Any]) -> dic
     }
 
 
+def detect_gate_starter(root: Path) -> dict[str, Any]:
+    active = active_entry_points(root)
+    item_id = active.get("current_item_id", "INIT-0001")
+    aliases: dict[str, dict[str, Any]] = {}
+    missing_entrypoints: list[str] = []
+    for alias, contract in GATE_STARTER_ALIASES.items():
+        row = dict(contract)
+        command = str(row["command"]).replace("<current-item>", item_id)
+        row["command"] = command
+        entrypoint = root / str(row["entrypoint"])
+        row["runtime_present"] = entrypoint.exists()
+        if not entrypoint.exists() and str(row["entrypoint"]) not in missing_entrypoints:
+            missing_entrypoints.append(str(row["entrypoint"]))
+        aliases[alias] = row
+    runtime_status = "present" if not missing_entrypoints else "missing"
+    return {
+        "schema_version": "loom-gate-starter/v1",
+        "aliases": aliases,
+        "runtime_status": runtime_status,
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": False,
+        "host_enforcement_status": "not_host_enforced",
+        "result": "pass",
+        "missing_inputs": [],
+        "missing_entrypoints": missing_entrypoints,
+        "recommended_action": (
+            "run the repo-local aliases as advisory Loom checks, then configure host-required checks separately"
+            if not missing_entrypoints
+            else "install or refresh repo-local Loom runtime entries before using gate starter aliases"
+        ),
+    }
+
+
 def bootstrap_host_binding_branch(root: Path) -> str:
     init_result = root / ".loom/bootstrap/init-result.json"
     try:
@@ -1453,6 +1534,7 @@ def governance_control_plane(
     repo_interop: dict[str, Any],
     host_binding: dict[str, Any],
     workspace_profile: dict[str, Any],
+    gate_starter: dict[str, Any],
 ) -> dict[str, Any]:
     return {
         "schema_version": GOVERNANCE_CONTROL_VERSION,
@@ -1462,6 +1544,7 @@ def governance_control_plane(
             "result": "pass" if carrier_summary.get("work_item", {}).get("status") == "present" else "block",
         },
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "host_binding": host_binding,
         "taxonomy": GATE_FAILURE_TAXONOMY,
         "gate_chain": GATE_CHAIN,
@@ -1500,6 +1583,7 @@ def build_governance_surface(
         repo_interop=repo_interop,
     )
     workspace_profile = detect_workspace_profile(root, host_binding=host_binding)
+    gate_starter = detect_gate_starter(root)
     control_plane = governance_control_plane(
         carrier_summary=carrier_summary,
         github_control_plane=github_control_plane,
@@ -1507,6 +1591,7 @@ def build_governance_surface(
         repo_interop=repo_interop,
         host_binding=host_binding,
         workspace_profile=workspace_profile,
+        gate_starter=gate_starter,
     )
 
     missing_inputs: list[str] = []
@@ -1543,6 +1628,7 @@ def build_governance_surface(
         "repo_interface": repo_interface,
         "repo_interop": repo_interop,
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "governance_control_plane": control_plane,
         "summary": summary,
         "missing_inputs": list(dict.fromkeys(missing_inputs)),

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -77,6 +77,7 @@ CORE_DOCS = (
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
     "docs/methodology/harness/workspace-profile.md",
+    "docs/methodology/harness/repo-local-gate-starter.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/host-action-contract.md",
     "docs/methodology/harness/host-lifecycle-boundary.md",
@@ -187,6 +188,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/checkpoint-model.md",
     "docs/methodology/harness/workspace-model.md",
     "docs/methodology/harness/workspace-profile.md",
+    "docs/methodology/harness/repo-local-gate-starter.md",
     "docs/methodology/harness/workspace-lifecycle.md",
     "docs/methodology/harness/recovery-model.md",
     "docs/methodology/harness/status-surface.md",
@@ -744,6 +746,12 @@ def require_governance_surface(
         context=f"{context} governance_surface.workspace_profile",
         payload=governance_surface.get("workspace_profile"),
     )
+    require_gate_starter_payload(
+        failures,
+        category=category,
+        context=f"{context} governance_surface.gate_starter",
+        payload=governance_surface.get("gate_starter"),
+    )
     require_governance_control_plane(
         failures,
         category=category,
@@ -779,6 +787,52 @@ def require_workspace_profile_payload(
         failures.append(Failure(category, f"{context}.host_worktree must be an object"))
     elif host_worktree.get("ownership") != "host":
         failures.append(Failure(category, f"{context}.host_worktree ownership must stay `host`"))
+
+
+def require_gate_starter_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != "loom-gate-starter/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-gate-starter/v1`"))
+    if payload.get("authority") != "local":
+        failures.append(Failure(category, f"{context} authority must stay `local`"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} enforcement must stay `advisory`"))
+    if payload.get("host_enforcement") is not False:
+        failures.append(Failure(category, f"{context} host_enforcement must stay false"))
+    if payload.get("host_enforcement_status") != "not_host_enforced":
+        failures.append(Failure(category, f"{context} host_enforcement_status must stay `not_host_enforced`"))
+    if payload.get("result") != "pass":
+        failures.append(Failure(category, f"{context} result must stay pass because aliases are local starter definitions"))
+    aliases = payload.get("aliases")
+    required_aliases = {"verify", "status", "merge-ready", "closeout-check", "reconciliation-audit"}
+    if not isinstance(aliases, dict):
+        failures.append(Failure(category, f"{context}.aliases must be an object"))
+        return
+    missing_aliases = sorted(required_aliases - set(aliases.keys()))
+    if missing_aliases:
+        failures.append(Failure(category, f"{context}.aliases is missing {', '.join(missing_aliases)}"))
+    for alias, row in aliases.items():
+        if not isinstance(row, dict):
+            failures.append(Failure(category, f"{context}.aliases.{alias} must be an object"))
+            continue
+        if row.get("authority") != "local":
+            failures.append(Failure(category, f"{context}.aliases.{alias}.authority must stay `local`"))
+        if row.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"{context}.aliases.{alias}.enforcement must stay `advisory`"))
+        if row.get("host_enforcement") is not False:
+            failures.append(Failure(category, f"{context}.aliases.{alias}.host_enforcement must stay false"))
+        for field in ("surface", "entrypoint", "command", "summary"):
+            value = row.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.aliases.{alias}.{field} must be a non-empty string"))
 
 
 def require_governance_control_plane(
@@ -825,6 +879,12 @@ def require_governance_control_plane(
         category=category,
         context=f"{context}.workspace_profile",
         payload=payload.get("workspace_profile"),
+    )
+    require_gate_starter_payload(
+        failures,
+        category=category,
+        context=f"{context}.gate_starter",
+        payload=payload.get("gate_starter"),
     )
 
     taxonomy = payload.get("taxonomy")
@@ -2501,6 +2561,19 @@ def check_demo_assets(root: Path) -> list[Failure]:
         run = init_result.get("run")
         if not isinstance(run, dict) or run.get("scenario_key") != "new":
             failures.append(Failure("demo-assets", "demo init-result must keep `scenario_key` as `new`"))
+        governance_surface = init_result.get("governance_surface")
+        if not isinstance(governance_surface, dict):
+            failures.append(Failure("demo-assets", "demo init-result must include governance_surface"))
+        else:
+            require_gate_starter_payload(
+                failures,
+                category="demo-assets",
+                context="demo init-result governance_surface.gate_starter",
+                payload=governance_surface.get("gate_starter"),
+            )
+            gate_starter = governance_surface.get("gate_starter")
+            if isinstance(gate_starter, dict) and gate_starter.get("host_enforcement") is not False:
+                failures.append(Failure("demo-assets", "demo gate starter must not claim host enforcement"))
     return failures
 
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -5134,6 +5134,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
     target_level = next_level if isinstance(next_level, str) else current if isinstance(current, str) else None
     gate_rollout = maturity.get("gate_rollout")
     workspace_profile = control_plane.get("workspace_profile") if isinstance(control_plane, dict) else None
+    gate_starter = control_plane.get("gate_starter") if isinstance(control_plane, dict) else None
     missing_by_level = maturity.get("missing_by_level")
     missing_details_by_level = maturity.get("missing_details_by_level")
     missing_inputs: list[Any] = []
@@ -5166,6 +5167,7 @@ def governance_profile_payload(target_root: Path, operation: str) -> dict[str, A
         "fallback_to": None if result == "pass" else "adoption",
         "maturity": maturity,
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "gate_rollout": gate_rollout,
         "governance_control_plane": control_plane,
         "adoption_decisions": decisions,
@@ -5241,6 +5243,7 @@ def governance_profile_upgrade_payload(
     base = governance_profile_payload(target_root, "upgrade-plan")
     maturity = base.get("maturity") if isinstance(base.get("maturity"), dict) else {}
     workspace_profile = base.get("workspace_profile")
+    gate_starter = base.get("gate_starter")
     actions = governance_upgrade_actions(target_root, target_level, maturity if isinstance(maturity, dict) else {})
     blockers: list[str] = []
     written_files: list[str] = []
@@ -5278,6 +5281,7 @@ def governance_profile_upgrade_payload(
         "written_files": written_files,
         "maturity": maturity,
         "workspace_profile": workspace_profile,
+        "gate_starter": gate_starter,
         "gate_rollout": maturity.get("gate_rollout") if isinstance(maturity, dict) else None,
         "adoption_decisions": decisions,
         "guided_adoption_plan": guided_plan,

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -410,6 +410,7 @@ def main(argv: list[str]) -> int:
     merge_ready = checkpoint_payload("merge", context)
     governance_surface = build_governance_surface(target_root)
     workspace_profile = governance_surface.get("workspace_profile")
+    gate_starter = governance_surface.get("gate_starter")
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
             "merge_ready": merge_ready,
             "closeout": closeout,
             "workspace_profile": workspace_profile,
+            "gate_starter": gate_starter,
             "governance_status": control_status,
             "governance_surface": governance_surface,
             "github": github_status,


### PR DESCRIPTION
## 摘要

本 PR 收口 #479 的 PR 2：repo-local gate starter aliases。

Closes #481
Closes #486
Closes #487

Base: #492 / `feat/479-workspace-profiles`

## 变更

- 新增 `docs/methodology/harness/repo-local-gate-starter.md` 作为 canonical 合同。
- 声明默认 starter aliases：`verify`、`status`、`merge-ready`、`closeout-check`、`reconciliation-audit`。
- 在 `governance_surface` 与 `governance_control_plane` 暴露 `gate_starter` 读面。
- 在 `governance-profile status|upgrade-plan|upgrade --dry-run` 和 `loom_status` 输出中包含 gate starter 状态。
- 扩展 `loom_check`，校验 fresh demo fixture 能读出 gate starter aliases，并且 local gate 不会被解释成 host enforcement。

## 边界确认

- aliases 只指向现有 `.loom/bin/loom_*` runtime，不新增完整统一 CLI 产品。
- `gate_starter.authority = local`、`enforcement = advisory`、`host_enforcement = false`。
- local gate 存在不代表 GitHub Actions、required checks、branch protection、ruleset 或 PR merge path 已被宿主强制。

## 验证

- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py governance-profile status --target . | python3 -m json.tool`
- `python3 tools/loom_status.py --target . --item INIT-0001 | python3 -m json.tool`
- `make loom-check`
- `git diff --check`
- `cmp -s skills/shared/scripts/governance_surface.py .loom/bin/governance_surface.py && cmp -s skills/shared/scripts/loom_flow.py .loom/bin/loom_flow.py && cmp -s skills/shared/scripts/loom_status.py .loom/bin/loom_status.py && cmp -s skills/shared/scripts/loom_check.py .loom/bin/loom_check.py`

说明：`make loom-check` 会重建 `examples/new-project` demo runtime；生成的本机路径化 demo bootstrap 变更未进入本 PR。
