### PR TITLE
docs(distribution): freeze unified install contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Loom exposes one root entry and eight scenario skills:
 | `loom-merge-ready` | Validates merge readiness. |
 | `loom-retire` | Cleans up and exits without discarding user changes. |
 
-The editable skills source lives under [src/skills/](./src/skills/). The generated and checked-in install surface lives under [skills/](./skills/). Each `skills/<skill-id>` directory is a self-contained single-skill package with `loom-package.json` and `.loom-runtime/`. The canonical Codex plugin manifest lives under [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/).
+The editable skills source lives under `src/skills/`. The generated and checked-in install surface lives under [skills/](./skills/). Each `skills/<skill-id>` directory is a self-contained single-skill package with `loom-package.json` and `.loom-runtime/`. The canonical Codex plugin manifest lives under [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/).
 
 ## Advanced / Compatibility
 
@@ -117,7 +117,7 @@ An individually installed skill only exposes that skill to the host. If you need
 - Architecture docs: [docs/architecture/](./docs/architecture/)
 - Adoption contracts: [docs/adoption/](./docs/adoption/)
 - Unified install experience: [docs/adoption/unified-install-experience.md](./docs/adoption/unified-install-experience.md)
-- Host adapter matrix: [docs/adoption/host-adapter-matrix.md](./docs/adoption/host-adapter-matrix.md)
+- Host adapter matrix: `docs/adoption/host-adapter-matrix.md`
 - Version authority map: [docs/adoption/version-authority-map.md](./docs/adoption/version-authority-map.md)
 - Evidence ledger: [docs/evidence/](./docs/evidence/)
 - Distribution contract: [skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It gives coding agents a behavior-first execution path across adopt, resume, spe
 
 ## How It Works
 
-Loom remains a plugin / SKILLS / CLI product. The plugin exposes install, discovery, and invocation; `SKILLS` expose scenario operations; the CLI and fixtures provide machine checks; docs remain the repository truth for methodology, harness, adoption, templates, and evidence.
+Loom remains a full-repo / plugin / SKILLS / CLI product. The default install model is full repository install plus native or host skill discovery. `SKILLS` expose scenario operations; host adapters expose install and bootstrap wiring; the CLI and fixtures provide machine checks; docs remain the repository truth for methodology, harness, adoption, templates, and evidence.
 
 Agents start from `loom-init`, then route into the right scenario skill based on the task and repository state.
 
@@ -42,9 +42,9 @@ done
 
 Restart Codex after installation so native skill discovery reloads the Loom skills.
 
-### npm Installer
+### Adapter Installer
 
-If you want to attach the Loom plugin surface to a target repository through the installer:
+The npm installer is not the Codex default path. Use it when you need an adapter-managed plugin install, single-skill helper flow, or installer verification output:
 
 ```bash
 npx @mc-and-his-agents/loom-installer add plugin --host codex
@@ -64,7 +64,7 @@ Requirements:
 - Node `>=20`
 - Python `>=3.10`, recommended `3.11+`
 
-The installer is responsible for install, discovery, and verification. Loom execution still runs on the Python runtime bundled with the skills library.
+The installer reports the distribution layer and version context it touched. Loom execution still runs on the Python runtime bundled with the generated skills surface.
 
 ## Basic Workflow
 
@@ -95,7 +95,7 @@ Loom exposes one root entry and eight scenario skills:
 | `loom-merge-ready` | Validates merge readiness. |
 | `loom-retire` | Cleans up and exits without discarding user changes. |
 
-The canonical skills library lives under [skills/](./skills/). The canonical Codex plugin manifest lives under [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/). Generated plugin payloads and single-skill payloads are not committed. Release tooling builds them dynamically from those sources.
+The editable skills source lives under [src/skills/](./src/skills/). The generated and checked-in install surface lives under [skills/](./skills/). Each `skills/<skill-id>` directory is a self-contained single-skill package with `loom-package.json` and `.loom-runtime/`. The canonical Codex plugin manifest lives under [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/).
 
 ## Advanced / Compatibility
 
@@ -106,7 +106,7 @@ npx @mc-and-his-agents/loom-installer add skill loom-retire --host codex
 npx @mc-and-his-agents/loom-installer add skill loom-retire --host claude
 ```
 
-An individually installed skill only exposes that skill to the host. If you need `loom-init` routing and the full scenario surface, install the full Loom plugin or the complete skills library.
+An individually installed skill only exposes that skill to the host. If you need `loom-init` routing and the full scenario surface, install the full repository and complete generated skills surface.
 
 ## Maintainer Docs
 
@@ -116,6 +116,9 @@ An individually installed skill only exposes that skill to the host. If you need
 - Methodology docs: [docs/methodology/](./docs/methodology/)
 - Architecture docs: [docs/architecture/](./docs/architecture/)
 - Adoption contracts: [docs/adoption/](./docs/adoption/)
+- Unified install experience: [docs/adoption/unified-install-experience.md](./docs/adoption/unified-install-experience.md)
+- Host adapter matrix: [docs/adoption/host-adapter-matrix.md](./docs/adoption/host-adapter-matrix.md)
+- Version authority map: [docs/adoption/version-authority-map.md](./docs/adoption/version-authority-map.md)
 - Evidence ledger: [docs/evidence/](./docs/evidence/)
 - Distribution contract: [skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@ Loom 是一个 agent-first project operating layer。
 
 ## 工作方式
 
-Loom 保持 plugin / SKILLS / CLI 的产品形态。Plugin 承接安装、发现和调用；`SKILLS` 暴露场景操作；CLI 与 fixtures 提供机器校验；docs 继续作为 methodology、harness、adoption、templates 和 evidence 的仓库真相。
+Loom 保持 full repo / plugin / SKILLS / CLI 的产品形态。默认安装模型是完整仓库安装加宿主原生或宿主适配的 skill discovery；`SKILLS` 暴露场景操作；宿主 adapter 承接安装和 bootstrap wiring；CLI 与 fixtures 提供机器校验；docs 继续作为 methodology、harness、adoption、templates 和 evidence 的仓库真相。
 
 智能体从 `loom-init` 起步，再根据当前任务和仓库状态路由到合适的 scenario skill。
 
@@ -42,9 +42,9 @@ done
 
 安装后请重启 Codex，让原生 skills discovery 重新加载 Loom skills。
 
-### npm Installer
+### Adapter Installer
 
-如果你希望通过 installer 把 plugin 接到目标仓库，可以使用：
+npm installer 不是 Codex 默认路径。需要 adapter 托管的 plugin 安装、single-skill helper 或 installer verification output 时再使用：
 
 ```bash
 npx @mc-and-his-agents/loom-installer add plugin --host codex
@@ -64,7 +64,7 @@ npx loom-installer add plugin --host claude
 - Node `>=20`
 - Python `>=3.10`，推荐 `3.11+`
 
-Installer 负责安装、发现和校验；Loom 的实际执行仍然运行在 skills library 随附的 Python runtime 上。
+Installer 会报告它触达的 distribution layer 和 version context；Loom 的实际执行仍然运行在生成 skills surface 随附的 Python runtime 上。
 
 ## 基本工作流
 
@@ -95,7 +95,7 @@ Loom 当前暴露一个 root entry 和八个 scenario skills：
 | `loom-merge-ready` | 验证 merge readiness。 |
 | `loom-retire` | 在不丢弃用户改动的前提下清理并退场。 |
 
-Canonical skills library 位于 [skills/](./skills/)。Canonical Codex plugin manifest 位于 [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/)；生成出来的 plugin 和 single-skill payload 不再提交到仓库，release tooling 会从这些真相源动态构建它们。
+可编辑 skills 源码真相位于 [src/skills/](./src/skills/)。生成且提交的安装表面位于 [skills/](./skills/)。每个 `skills/<skill-id>` 都是带 `loom-package.json` 和 `.loom-runtime/` 的自包含 single-skill package。Canonical Codex plugin manifest 位于 [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/)。
 
 ## 高级 / 兼容
 
@@ -106,7 +106,7 @@ npx @mc-and-his-agents/loom-installer add skill loom-retire --host codex
 npx @mc-and-his-agents/loom-installer add skill loom-retire --host claude
 ```
 
-单独安装的 skill 只会向宿主暴露该 skill 本身。如果你需要 `loom-init` 路由能力和完整 scenario surface，请安装完整 Loom plugin 或整包 skills library。
+单独安装的 skill 只会向宿主暴露该 skill 本身。如果你需要 `loom-init` 路由能力和完整 scenario surface，请安装完整仓库和完整生成 skills surface。
 
 ## 维护者文档
 
@@ -116,6 +116,9 @@ npx @mc-and-his-agents/loom-installer add skill loom-retire --host claude
 - 方法论文档：[docs/methodology/](./docs/methodology/)
 - 架构说明：[docs/architecture/](./docs/architecture/)
 - 接入合同：[docs/adoption/](./docs/adoption/)
+- 统一安装体验：[docs/adoption/unified-install-experience.md](./docs/adoption/unified-install-experience.md)
+- 宿主适配矩阵：[docs/adoption/host-adapter-matrix.md](./docs/adoption/host-adapter-matrix.md)
+- 版本权威图：[docs/adoption/version-authority-map.md](./docs/adoption/version-authority-map.md)
 - 证据台账：[docs/evidence/](./docs/evidence/)
 - 分发合同：[skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,7 +95,7 @@ Loom 当前暴露一个 root entry 和八个 scenario skills：
 | `loom-merge-ready` | 验证 merge readiness。 |
 | `loom-retire` | 在不丢弃用户改动的前提下清理并退场。 |
 
-可编辑 skills 源码真相位于 [src/skills/](./src/skills/)。生成且提交的安装表面位于 [skills/](./skills/)。每个 `skills/<skill-id>` 都是带 `loom-package.json` 和 `.loom-runtime/` 的自包含 single-skill package。Canonical Codex plugin manifest 位于 [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/)。
+可编辑 skills 源码真相位于 `src/skills/`。生成且提交的安装表面位于 [skills/](./skills/)。每个 `skills/<skill-id>` 都是带 `loom-package.json` 和 `.loom-runtime/` 的自包含 single-skill package。Canonical Codex plugin manifest 位于 [plugins/loom/.codex-plugin/](./plugins/loom/.codex-plugin/)。
 
 ## 高级 / 兼容
 
@@ -117,7 +117,7 @@ npx @mc-and-his-agents/loom-installer add skill loom-retire --host claude
 - 架构说明：[docs/architecture/](./docs/architecture/)
 - 接入合同：[docs/adoption/](./docs/adoption/)
 - 统一安装体验：[docs/adoption/unified-install-experience.md](./docs/adoption/unified-install-experience.md)
-- 宿主适配矩阵：[docs/adoption/host-adapter-matrix.md](./docs/adoption/host-adapter-matrix.md)
+- 宿主适配矩阵：`docs/adoption/host-adapter-matrix.md`
 - 版本权威图：[docs/adoption/version-authority-map.md](./docs/adoption/version-authority-map.md)
 - 证据台账：[docs/evidence/](./docs/evidence/)
 - 分发合同：[skills/distribution-and-adapter-contract.md](./skills/distribution-and-adapter-contract.md)

--- a/docs/adoption/README.md
+++ b/docs/adoption/README.md
@@ -24,6 +24,10 @@
 - GitHub 默认治理实现 profile：[github-profile.md](./github-profile.md)
 - GitHub profile 升级路径：[github-profile-upgrade.md](./github-profile-upgrade.md)
 - CI required checks bootstrap：[ci-required-checks-bootstrap.md](./ci-required-checks-bootstrap.md)
+- 统一安装体验：[unified-install-experience.md](./unified-install-experience.md)
+- 宿主适配矩阵：[host-adapter-matrix.md](./host-adapter-matrix.md)
+- 单 skill 安装合同：[single-skill-contract.md](./single-skill-contract.md)
+- 版本权威图：[version-authority-map.md](./version-authority-map.md)
 
 边界约束：
 

--- a/docs/adoption/README.md
+++ b/docs/adoption/README.md
@@ -25,7 +25,7 @@
 - GitHub profile 升级路径：[github-profile-upgrade.md](./github-profile-upgrade.md)
 - CI required checks bootstrap：[ci-required-checks-bootstrap.md](./ci-required-checks-bootstrap.md)
 - 统一安装体验：[unified-install-experience.md](./unified-install-experience.md)
-- 宿主适配矩阵：[host-adapter-matrix.md](./host-adapter-matrix.md)
+- 宿主适配矩阵：`host-adapter-matrix.md`
 - 单 skill 安装合同：[single-skill-contract.md](./single-skill-contract.md)
 - 版本权威图：[version-authority-map.md](./version-authority-map.md)
 

--- a/docs/adoption/codex-install.md
+++ b/docs/adoption/codex-install.md
@@ -1,6 +1,6 @@
 # Installing Loom for Codex
 
-Enable Loom skills in Codex via native skill discovery. Clone the repository and symlink each public Loom skill directory.
+Enable Loom skills in Codex via native skill discovery. Clone the repository and symlink each generated public Loom skill package.
 
 ## Prerequisites
 
@@ -26,11 +26,14 @@ Enable Loom skills in Codex via native skill discovery. Clone the repository and
 
 3. Restart Codex.
 
+Codex should start from `loom-init` after discovery reloads. The npm installer is not the Codex default path; it remains available for adapter-specific and single-skill helper flows.
+
 ## Verify
 
 ```bash
 ls -la ~/.agents/skills/loom-init
 ls ~/.agents/skills/loom-init/SKILL.md
+ls ~/.agents/skills/loom-init/loom-package.json
 ```
 
 ## Update
@@ -40,6 +43,12 @@ cd ~/.codex/loom && git pull
 ```
 
 The skills update through the symlink.
+
+Run this from a Loom checkout when validating the generated install surface:
+
+```bash
+make skills-check
+```
 
 ## Uninstall
 

--- a/docs/adoption/single-skill-contract.md
+++ b/docs/adoption/single-skill-contract.md
@@ -1,0 +1,81 @@
+# Single-Skill Contract
+
+This contract applies to every generated `skills/<skill-id>` directory.
+
+`src/skills/<skill-id>` is the editable source truth. Root `skills/<skill-id>` is the checked-in generated package consumed by host-native discovery and generic single-skill installers.
+
+## Package Shape
+
+Each generated package must contain:
+
+- `SKILL.md`
+- `contract.json`
+- `loom-package.json`
+- `scripts/<skill-id>.py`
+- `references/` when the skill has local references
+- `agents/` when the skill has adapter metadata
+- `.loom-runtime/`
+
+The package must be installable by copying the single `skills/<skill-id>` directory into a host skill directory.
+
+The copied directory must be sufficient on its own. A valid single-skill package must not require the Loom repository root, `src/skills/`, `skills/shared/`, or sibling generated skill directories at runtime.
+
+## Runtime Root
+
+The package runtime root is `.loom-runtime/`. Launchers must set `LOOM_INSTALLED_SKILLS_ROOT` to that package-internal runtime root before entering shared runtime code.
+
+Generated top-level package files must not require sibling paths such as `../shared`, `../registry.json`, or another generated skill directory.
+
+## Metadata
+
+`loom-package.json` is the machine-readable package contract. It must include:
+
+- `schema_version`
+- `package_type`
+- `package_id`
+- `repo_version`
+- `source_repository`
+- `source_revision`
+- `skill_package_version`
+- `skill_contract_version`
+- `registry_version`
+- `runtime_core_version`
+- `runtime_root`
+- `launcher`
+- `root_entry`
+- `plugin_surface_version`
+- `host_adapter_version`
+- `full_repo_install_surface`
+- `fail_closed_on`
+
+For generated single-skill packages, `package_type` must be `single-skill`, `runtime_root` must be `.loom-runtime`, and `full_repo_install_surface` must be `false`.
+
+## Behavior Boundary
+
+A single-skill install exposes only the named skill. It does not expose the full Loom scenario surface and must not claim that `loom-init` routing is available unless the installed package is `loom-init`.
+
+Even when the installed package is `loom-init`, the host has installed only the `loom-init` package. That package may route conceptually, but the host must not claim the rest of the Loom scenario skills are installed unless the full generated `skills/` surface is also available through full repo install.
+
+## Fail-Closed Rules
+
+The package must fail closed when:
+
+- required files are missing
+- launcher is missing or not executable
+- `.loom-runtime/` is missing
+- `.loom-runtime/registry.json`, `install-layout.json`, or `upgrade-contract.json` is missing
+- top-level package files reference paths outside the package
+- runtime-state cannot report `installed-runtime`
+- version metadata is unreadable or inconsistent with `contract.json`
+
+## Verification
+
+Run:
+
+```bash
+make skills-check
+```
+
+This checks generated drift, package completeness, package-external references, launcher runtime-state, and generic skill-installer compatibility shape.
+
+The version authority for `loom-package.json` fields is defined in [version-authority-map.md](./version-authority-map.md).

--- a/docs/adoption/unified-install-experience.md
+++ b/docs/adoption/unified-install-experience.md
@@ -1,0 +1,87 @@
+# Unified Install Experience
+
+This document is the user-facing distribution target for Loom Phase #496.
+
+## Default Model
+
+Loom defaults to a Superpowers-style install model:
+
+- clone the full Loom repository
+- let each host discover the generated root `skills/` surface through its native mechanism
+- start from `loom-init`
+- keep host-specific wiring in adapter surfaces
+
+The default path is not `@mc-and-his-agents/loom-installer` for Codex. The installer remains an adapter helper, single-skill helper, and verifier.
+
+Install path status:
+
+- Default: full repository install plus native or host skill discovery.
+- Advanced: install one generated `skills/<skill-id>` package as a single skill.
+- Adapter-managed: use `@mc-and-his-agents/loom-installer` or a host plugin when the host needs orchestration.
+- Deprecated: historical docs that present generated installer payloads or plugin-only setup as the source truth.
+- Unsupported: presenting a single-skill install as the full Loom scenario surface.
+
+## Source And Generated Surfaces
+
+- `src/skills/` is the only editable source truth for Loom skills.
+- `skills/` is a checked-in generated install surface.
+- `skills/<skill-id>` is directly consumable by host-native skill discovery.
+- `skills/<skill-id>` is also a self-contained single-skill package.
+- `skills/<skill-id>/loom-package.json` is the machine-readable package metadata location.
+- `skills/<skill-id>/.loom-runtime/` is the package-internal runtime closure.
+
+Do not hand-edit generated `skills/` content. Rebuild it with:
+
+```bash
+python3 tools/skills_surface.py generate
+```
+
+Verify it with:
+
+```bash
+make skills-check
+```
+
+## Full Repo Install
+
+Full repo install is the default user journey. It exposes the complete Loom scenario surface:
+
+- root entry: `loom-init`
+- scenario skills: `loom-adopt`, `loom-resume`, `loom-pre-review`, `loom-spec-review`, `loom-review`, `loom-merge-ready`, `loom-handoff`, `loom-retire`
+- package-internal runtime for each skill
+- shared host semantics documented in `host-adapter-matrix.md`
+
+Users should not need to understand `src/skills/`, `.loom-runtime/`, or adapter implementation details before starting.
+
+Full repo install does not mean every host uses the same filesystem path. It means each host exposes the same generated `skills/` surface, preserves `loom-init` as the default entry, and keeps host-specific discovery, bootstrap, tool mapping, and verification in adapter-owned surfaces.
+
+## Single-Skill Install
+
+Single-skill install is a supported advanced path. It installs exactly one `skills/<skill-id>` directory and exposes only that named skill.
+
+Single-skill install must:
+
+- be discoverable by the host
+- include `SKILL.md`, `contract.json`, `loom-package.json`, launcher, and `.loom-runtime/`
+- fail closed when runtime or metadata is missing
+- expose machine-readable version context
+
+Single-skill install must not claim that the full Loom scenario surface is installed.
+
+Single-skill install remains valid for targeted use, compatibility with generic skill installers, and hosts that intentionally expose only one Loom capability. It is not a replacement for full repo install.
+
+## User Semantics
+
+Across Codex, Claude Code, OpenCode, Gemini, and Cursor, the user-facing experience should remain consistent:
+
+- install entry is clear
+- `loom-init` is the default starting point for full repo installs
+- scene skills are discoverable
+- bootstrap or session-start guidance points to Loom entry semantics
+- tool mapping remains adapter-owned and mostly invisible
+- upgrades expose version context
+- failures are visible and fail closed
+
+## Version Context
+
+Loom does not use one global version line for every surface. User-facing install and upgrade docs must link to [version-authority-map.md](./version-authority-map.md) when describing repository versions, GitHub releases, installer versions, plugin surface versions, host adapter versions, generated single-skill package versions, skills registry and contract versions, runtime/core versions, or external runtime schemas.

--- a/docs/adoption/version-authority-map.md
+++ b/docs/adoption/version-authority-map.md
@@ -1,0 +1,55 @@
+# Version Authority Map
+
+Loom does not use one global version number for every distribution surface. Versions are not globally synchronized.
+
+The installer package version, plugin surface version, host adapter version, skill package version, contract version, and schema version are separate authority lines.
+
+## Authority Lines
+
+| Surface | Authority | Synchronization rule |
+| --- | --- | --- |
+| Repository release candidate | `VERSION` | Declares the repo candidate line. It may be ahead of the latest published GitHub release. |
+| Published repository release | GitHub `v*` tag and release | Represents published root repo release truth. |
+| Installer package version | `packages/loom-installer/package.json` | Independent npm package line. Published with `loom-installer-v<version>` tags. |
+| Plugin surface version | host plugin manifest, currently `plugins/loom/.codex-plugin/plugin.json` | Version of the plugin adapter surface, not the Loom repo version. |
+| Host adapter version | plugin metadata `x-loom.host_adapter_version` or adapter manifest | Version of host wiring semantics. |
+| Generated skill package version | `skills/<skill-id>/loom-package.json` `skill_package_version` | Version of the generated single-skill package surface. |
+| Skill contract version | `skills/<skill-id>/contract.json` `contract_version` | Version of the named skill behavioral contract. |
+| Skills registry version | `skills/registry.json` `registry_version` | Version of the full generated skills registry. |
+| Runtime core version | `skills/<skill-id>/loom-package.json` `runtime_core_version` | Version of the package-internal runtime closure. |
+| External runtime schema version | external runtime locator `schema_version` | Protocol/schema version for adopted repos consuming external runtime. |
+
+## Machine-Readable Metadata
+
+Each generated single-skill package exposes version context in:
+
+```text
+skills/<skill-id>/loom-package.json
+```
+
+The plugin surface exposes adapter version context in:
+
+```text
+plugins/loom/.codex-plugin/plugin.json
+```
+
+The installer payload exposes aggregate version context in:
+
+```text
+packages/loom-installer/payload/manifest.json
+```
+
+## Upgrade Rule
+
+Upgrades compare the version surface relevant to the installed layer:
+
+- full repo install compares repository revision plus generated `skills/` metadata
+- plugin install compares plugin surface and host adapter versions
+- single-skill install compares `skill_package_version`, `skill_contract_version`, `runtime_core_version`, and `source_revision`
+- installer upgrade compares npm package version
+
+No check may infer that `VERSION`, plugin version, installer version, contract version, and schema version must be equal.
+
+## Failure Rule
+
+If version metadata is missing, unreadable, or inconsistent with the installed layer, the host or installer must report a fail-closed state instead of a partial success.

--- a/packages/loom-installer/README.md
+++ b/packages/loom-installer/README.md
@@ -2,9 +2,9 @@
 
 Language: English | [中文版本](./README.zh-CN.md)
 
-Loom npm / npx installer.
+Loom npm / npx adapter helper and verifier.
 
-The primary install mode is the complete Loom plugin surface. Single-skill install remains available for compatibility and advanced use.
+The default Loom install model is full repository install plus native or host skill discovery. This package remains available for adapter-managed plugin installs, single-skill helper flows, and verification output.
 
 ## Commands
 
@@ -41,9 +41,11 @@ Options:
 
 ## Payload Model
 
-The published package includes a generated payload. The payload is generated from the canonical `plugins/loom/.codex-plugin/` manifest and `skills/` sources during build, pack, and publish.
+The published package includes a generated payload. The payload is generated from the canonical `plugins/loom/.codex-plugin/` manifest and the checked-in generated `skills/` install surface during build, pack, and publish.
 
-Generated payload directories are not committed to git. The build step recreates them deterministically, and `check:payload` verifies rebuild stability.
+Generated payload directories are not committed to git. The build step recreates them deterministically, and `check:payload` verifies rebuild stability. The root `skills/` surface itself is committed and verified with `check:distribution`.
+
+Installer JSON output reports `distribution_layer`, `version_context`, and `failed_layer` so callers can distinguish host adapter plugin installs from generated single-skill installs.
 
 ## Release Notes
 

--- a/packages/loom-installer/README.zh-CN.md
+++ b/packages/loom-installer/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 语言：中文 | [English version](./README.md)
 
-Loom 的 npm / npx installer。
+Loom 的 npm / npx adapter helper 和 verifier。
 
-主安装模式是完整 Loom plugin surface。单 skill 安装仍然保留，用于兼容和高级场景。
+Loom 默认安装模型是完整仓库安装加宿主原生或宿主适配的 skill discovery。这个 package 保留给 adapter 托管的 plugin 安装、single-skill helper 和 verification output。
 
 ## Commands
 
@@ -41,9 +41,11 @@ Options：
 
 ## Payload Model
 
-发布包会包含生成出来的 payload。该 payload 会在 build、pack 和 publish 阶段，从 canonical `plugins/loom/.codex-plugin/` manifest 与 `skills/` 源动态生成。
+发布包会包含生成出来的 payload。该 payload 会在 build、pack 和 publish 阶段，从 canonical `plugins/loom/.codex-plugin/` manifest 与已提交的生成 `skills/` install surface 动态生成。
 
-生成出来的 payload 目录不会提交到 git。Build 步骤会以确定性方式重建它们，`check:payload` 会校验重建稳定性。
+生成出来的 payload 目录不会提交到 git。Build 步骤会以确定性方式重建它们，`check:payload` 会校验重建稳定性。根 `skills/` surface 本身会提交，并通过 `check:distribution` 校验。
+
+Installer JSON output 会报告 `distribution_layer`、`version_context` 和 `failed_layer`，让调用方区分 host adapter plugin install 与 generated single-skill install。
 
 ## Release Notes
 

--- a/packages/loom-installer/scripts/check-doc-sync.mjs
+++ b/packages/loom-installer/scripts/check-doc-sync.mjs
@@ -12,7 +12,9 @@ const requiredNeedles = [
     needles: [
       'agent-first project operating layer',
       'Fetch and follow instructions from https://raw.githubusercontent.com/MC-and-his-Agents/Loom/refs/heads/main/docs/adoption/codex-install.md',
-      'npx @mc-and-his-agents/loom-installer add plugin --host codex',
+      'The npm installer is not the Codex default path',
+      'src/skills/',
+      'docs/adoption/unified-install-experience.md',
       'Advanced / Compatibility',
       '[中文版本](./README.zh-CN.md)',
     ],
@@ -22,7 +24,9 @@ const requiredNeedles = [
     needles: [
       'agent-first project operating layer',
       'Fetch and follow instructions from https://raw.githubusercontent.com/MC-and-his-Agents/Loom/refs/heads/main/docs/adoption/codex-install.md',
-      'npx @mc-and-his-agents/loom-installer add plugin --host codex',
+      'npm installer 不是 Codex 默认路径',
+      'src/skills/',
+      'docs/adoption/unified-install-experience.md',
       '高级 / 兼容',
       '[English version](./README.md)',
     ],
@@ -32,13 +36,16 @@ const requiredNeedles = [
     needles: [
       'git clone https://github.com/MC-and-his-Agents/Loom.git ~/.codex/loom',
       'ln -sfn "$skill" "$HOME/.agents/skills/$(basename "$skill")"',
+      'loom-package.json',
       'Restart Codex',
     ],
   },
   {
     path: 'skills/README.md',
     needles: [
-      'canonical skills library',
+      'generated, checked-in Loom skills install surface',
+      'src/skills/',
+      'loom-package.json',
       'unique root entry',
       'Advanced / Compatibility',
       'npx @mc-and-his-agents/loom-installer add skill <skill-id>',
@@ -48,7 +55,9 @@ const requiredNeedles = [
   {
     path: 'skills/README.zh-CN.md',
     needles: [
-      'canonical skills library',
+      '生成且提交的 skills install surface',
+      'src/skills/',
+      'loom-package.json',
       '唯一的 root entry',
       'Advanced / Compatibility',
       'npx @mc-and-his-agents/loom-installer add skill <skill-id>',
@@ -59,7 +68,9 @@ const requiredNeedles = [
     path: 'skills/distribution-and-adapter-contract.md',
     needles: [
       '@mc-and-his-agents/loom-installer',
-      'upstream `plugins/loom/.codex-plugin/` manifest + canonical `skills/`',
+      'upstream `plugins/loom/.codex-plugin/` manifest + generated root `skills/`',
+      'distribution_layer',
+      'version_context',
       'repo-scoped `<target>/.agents/skills/<skill-id>/`',
       'main 分支是真相源',
       'publish 成功后再创建 `loom-installer-v<version>` git tag 与同名前缀的 GitHub Release',
@@ -73,7 +84,9 @@ const requiredNeedles = [
       'Python `>=3.10`, recommended `3.11+`',
       'add plugin',
       'add skill <skill-id>',
-      'payload is generated from the canonical `plugins/loom/.codex-plugin/` manifest and `skills/` sources',
+      'The default Loom install model is full repository install plus native or host skill discovery.',
+      'payload is generated from the canonical `plugins/loom/.codex-plugin/` manifest and the checked-in generated `skills/` install surface',
+      'distribution_layer',
       '[中文版本](./README.zh-CN.md)',
     ],
   },
@@ -85,9 +98,23 @@ const requiredNeedles = [
       'Python `>=3.10`，推荐 `3.11+`',
       'add plugin',
       'add skill <skill-id>',
-      'canonical `plugins/loom/.codex-plugin/` manifest 与 `skills/` 源',
+      'Loom 默认安装模型是完整仓库安装加宿主原生或宿主适配的 skill discovery',
+      'canonical `plugins/loom/.codex-plugin/` manifest 与已提交的生成 `skills/` install surface',
+      'distribution_layer',
       '[English version](./README.md)',
     ],
+  },
+  {
+    path: 'docs/adoption/unified-install-experience.md',
+    needles: ['full repository install', 'src/skills/', 'skills/<skill-id>', 'loom-init', 'single-skill'],
+  },
+  {
+    path: 'docs/adoption/single-skill-contract.md',
+    needles: ['loom-package.json', '.loom-runtime/', 'fail closed', 'make skills-check'],
+  },
+  {
+    path: 'docs/adoption/version-authority-map.md',
+    needles: ['Versions are not globally synchronized', 'installer package version', 'plugin surface version', 'skill_package_version'],
   },
 ];
 

--- a/packages/loom-installer/scripts/check-version-bump.mjs
+++ b/packages/loom-installer/scripts/check-version-bump.mjs
@@ -21,7 +21,11 @@ const behaviorPaths = [
   'packages/loom-installer/scripts/build-payload.mjs',
 ];
 
-const ignoredBehaviorPaths = [];
+const ignoredBehaviorPaths = [
+  'skills/README.md',
+  'skills/README.zh-CN.md',
+  'skills/distribution-and-adapter-contract.md',
+];
 
 function git(args) {
   return execFileSync('git', args, {

--- a/skills/README.md
+++ b/skills/README.md
@@ -2,9 +2,9 @@
 
 Language: English | [中文版本](./README.zh-CN.md)
 
-`skills/` is the canonical skills library for Loom.
+`skills/` is the generated, checked-in Loom skills install surface. The editable source truth lives in `src/skills/`.
 
-When Loom is installed through Codex native skill discovery, a host plugin, or the npm installer, this directory is the user-facing execution surface. Methodology and architecture documents stay behind this layer; users should enter through skills instead of internal governance docs.
+When Loom is installed through Codex native skill discovery, a host plugin, or the npm installer, this directory is the user-facing execution surface. Each `skills/<skill-id>` directory is also a self-contained single-skill package. Methodology and architecture documents stay behind this layer; users should enter through skills instead of internal governance docs.
 
 By default, start from `loom-init`. It is the unique root entry for Loom and is responsible for two things:
 
@@ -71,6 +71,8 @@ npx @mc-and-his-agents/loom-installer add plugin --host codex
 npx @mc-and-his-agents/loom-installer add plugin --host claude
 ```
 
+The npm installer is an adapter/helper path, not the Codex default.
+
 ## Advanced / Compatibility
 
 Single-skill installation is supported for advanced compatibility, not as the default user journey:
@@ -82,6 +84,8 @@ npx @mc-and-his-agents/loom-installer add skill <skill-id> --host claude
 
 A single installed skill only exposes that named skill to the host. It does not expose the full `loom-init` routing surface unless `loom-init` itself is installed, and it should not be presented as the complete Loom experience.
 
+Every generated single-skill package contains `loom-package.json`, a package-internal `.loom-runtime/`, and a launcher that resolves runtime from inside the package.
+
 ## Internal Contracts
 
 These files are part of the runtime contract and should remain stable:
@@ -92,3 +96,10 @@ These files are part of the runtime contract and should remain stable:
 - [distribution-and-adapter-contract.md](./distribution-and-adapter-contract.md)
 
 Shared runtime scripts, assets, and references live under [shared/](./shared/). They are consumed by scenario skills and by release tooling when generating plugin or single-skill payloads.
+
+Generated surface checks:
+
+```bash
+python3 tools/skills_surface.py generate
+make skills-check
+```

--- a/skills/README.zh-CN.md
+++ b/skills/README.zh-CN.md
@@ -2,9 +2,9 @@
 
 语言：中文 | [English version](./README.md)
 
-`skills/` 是 Loom 的 canonical skills library。
+`skills/` 是 Loom 生成且提交的 skills install surface。可编辑源码真相位于 `src/skills/`。
 
-当 Loom 通过 Codex 原生 skill discovery、宿主 plugin 或 npm installer 安装时，这个目录就是面向用户的执行表面。方法论和架构文档位于这层之后，用户通常应该从 skills 进入，而不是先读内部治理文档。
+当 Loom 通过 Codex 原生 skill discovery、宿主 plugin 或 npm installer 安装时，这个目录就是面向用户的执行表面。每个 `skills/<skill-id>` 也都是自包含 single-skill package。方法论和架构文档位于这层之后，用户通常应该从 skills 进入，而不是先读内部治理文档。
 
 默认从 `loom-init` 开始。它是 Loom 唯一的 root entry，负责两件事：
 
@@ -71,6 +71,8 @@ npx @mc-and-his-agents/loom-installer add plugin --host codex
 npx @mc-and-his-agents/loom-installer add plugin --host claude
 ```
 
+npm installer 是 adapter/helper 路径，不是 Codex 默认路径。
+
 ## Advanced / Compatibility
 
 单 skill 安装保留为高级兼容路径，但不再是默认用户路径：
@@ -82,6 +84,8 @@ npx @mc-and-his-agents/loom-installer add skill <skill-id> --host claude
 
 单独安装的 skill 只会向宿主暴露该 skill 本身。除非安装的就是 `loom-init`，否则它不会暴露完整的 `loom-init` 路由面，也不应被表述成完整的 Loom 体验。
 
+每个生成 single-skill package 都包含 `loom-package.json`、包内 `.loom-runtime/`，以及从包内解析 runtime 的 launcher。
+
 ## Internal Contracts
 
 以下文件属于 runtime contract，应保持稳定：
@@ -92,3 +96,10 @@ npx @mc-and-his-agents/loom-installer add skill <skill-id> --host claude
 - [distribution-and-adapter-contract.md](./distribution-and-adapter-contract.md)
 
 共享 runtime scripts、assets 和 references 位于 [shared/](./shared/)。它们会被 scenario skills 和 release tooling 一起消费，用来生成 plugin 或 single-skill payload。
+
+生成表面检查：
+
+```bash
+python3 tools/skills_surface.py generate
+make skills-check
+```

--- a/skills/distribution-and-adapter-contract.md
+++ b/skills/distribution-and-adapter-contract.md
@@ -2,7 +2,7 @@
 
 ## 定位
 
-本文定义 Loom `v0.4.0` 在 `skills/` 层的最小分发与适配合同。
+本文定义 Loom Phase #496 之后在 `skills/` 层的最小分发与适配合同。
 
 它回答的不是某个宿主如何实现交互，而是 Loom 对外发布时，以下四层 repo-local 交付面在 `skills` 维度上如何成立：
 
@@ -14,7 +14,11 @@
 本文默认前提：
 
 - `SKILLS` 是入口层，不是事实真相源
-- 治理规则、执行机制、模板约束在安装态由 `skills/shared/references/` 暴露稳定读面；repo-local 源码真相维护在 `docs/methodology/` 与 `docs/adoption/`
+- `src/skills/` 是可编辑 skills 源真相
+- 根 `skills/` 是由 `src/skills/` 生成、提交到仓库、供宿主直接发现的安装表面
+- 治理规则、执行机制、模板约束在安装态由 full-repo `skills/shared/references/` 或 single-skill package-local `.loom-runtime/` 暴露稳定读面；repo-local 源码真相维护在 `docs/methodology/` 与 `docs/adoption/`
+- 默认分发模型是完整仓库安装加宿主原生或 adapter skill discovery
+- Codex、Claude Code、OpenCode、Gemini、Cursor 的一致体验定义见 `docs/adoption/host-adapter-matrix.md`
 - 宿主可以不同，但 Loom 对入口层的最小能力边界应保持稳定
 - 当前版本判断是 `major but still pre-1`
 
@@ -23,7 +27,7 @@
 Loom 当前把 `skills` 公开面分成三层：
 
 - 用户首层公开面
-  - 根 `README.md` 的三条 repo-local 路径与安装 / 快速开始
+  - 根 `README.md` 的完整仓库安装、宿主发现与快速开始
   - `skills/README.md` 的入口层总览
   - `skills/loom-init/SKILL.md` 的 root entry 首屏
 - 单 skill 正式交付面
@@ -48,7 +52,7 @@ Loom 当前把 `skills` 公开面分成三层：
 
 ### 1. `repo-local plugin`
 
-- 默认安装对象
+- adapter-managed 安装对象，不是 Codex 默认安装对象
 - 负责把 `loom-init` 与其余 scenario skills 暴露给宿主
 - 对用户承诺完整 Loom 的入口面，而不是单个 skill 的局部能力
 
@@ -63,7 +67,7 @@ Loom 当前把 `skills` 公开面分成三层：
 
 - 用户执行面
 - 回答“当前该进入哪个动作”
-- 保持 `loom-init` 的唯一 root entry 身份与 7 个 scenario skills 的稳定分工
+- 保持 `loom-init` 的唯一 root entry 身份与 8 个 scenario skills 的稳定分工
 
 ### 4. `single-skill standard-skill packages`
 
@@ -80,7 +84,7 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 
 - `loom-init` 作为唯一 root entry 的入口身份
 - 显式进入某个 scenario skill，或在未显式指定时由 `loom-init` 做场景路由
-- 7 个 scenario skills 的稳定分工
+- 8 个 scenario skills 的稳定分工
 
 ### 单 skill package 公开面
 
@@ -104,7 +108,7 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 
 ## 三、分发对象
 
-`skills/` 的分发对象，是可被宿主装配和调用的入口合同，而不是一整套宿主产品体验。
+根 `skills/` 的分发对象，是可被宿主装配和调用的生成后入口合同，而不是可编辑源真相，也不是一整套宿主产品体验。
 
 对 Loom 而言，`skills/` 至少承担以下发布面：
 
@@ -121,9 +125,17 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 - 运行态识别面
   - 允许宿主区分 `repo-local-demo`、`installed-runtime`、`upgrade-rehearsal`，并在当前入口不可运行时暴露 fail-closed 原因
 - shared runtime / resources
-  - 允许宿主直接安装 skill-local `scripts/` 与 `shared/scripts/assets/references`，而不是把 repo-local `tools/` 当成入口成功
+  - 允许宿主直接安装 skill-local `scripts/` 与 package-local `.loom-runtime/`，而不是把 repo-local `tools/` 当成入口成功
 
 因此，`skills/` 的“发布”不等于发布一批提示词文件；它发布的是可被宿主发现、安装、升级和调用的入口合同集合。
+
+生成关系固定如下：
+
+- `src/skills/` 承接可编辑 source truth
+- 根 `skills/` 承接已提交 generated install surface
+- `skills/<skill-id>` 同时承接 host discovery package 与 self-contained single-skill package
+- `skills/<skill-id>/.loom-runtime/` 承接该 package 的最小运行闭包
+- `skills/<skill-id>/loom-package.json` 承接 package 级机器可读版本与边界 metadata
 
 ## 四、`bootstrap/root contract` 与深知识库的关系
 
@@ -133,7 +145,7 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 
 - 识别当前任务或仓库是否需要进入 Loom 运行模型
 - 判断应装配哪些入口能力与首批落点
-- 把后续工作导向 `skills/shared/references/` 中稳定暴露的治理 / 执行 / 模板 / 采用读面，以及具体 skill 引用
+- 把后续工作导向 full-repo `skills/shared/references/` 或 package-local `.loom-runtime/` 中稳定暴露的治理 / 执行 / 模板 / 采用读面，以及具体 skill 引用
 - 暴露稳定的最小输入合同与输出合同
 
 深知识库的职责应保留在被引用的规范、规则、模板与参考材料中。两者关系如下：
@@ -143,7 +155,7 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 - `bootstrap/root contract` 可以编排与引用，但不应内联复制大段规则真相
 - 当深知识发生升级时，应优先更新被引用落点，而不是让多个 skill 各自复制一份解释
 
-如果某项知识必须长期维护、需要跨 skill 共享、或会影响治理与执行真相，它不应沉积在 root skill 本体中，而应进入 repo-local 内核区域并镜像到安装态所需的 `skills/shared/references/`。
+如果某项知识必须长期维护、需要跨 skill 共享、或会影响治理与执行真相，它不应沉积在 root skill 本体中，而应进入 repo-local 内核区域并镜像到安装态所需的 `src/skills/shared/references/`，再生成到根 `skills/` 和 package-local `.loom-runtime/`。
 
 ## 五、单 skill package 的最小合同
 
@@ -152,6 +164,7 @@ Loom 当前对 `skills` 的稳定公开接口分成三组。
 - package 能稳定声明它交付的是哪个标准 skill
 - package 能暴露该 skill 的最小输入、输出与引用关系
 - package 能定位其 launcher / shim、skill-local `scripts/` 与所需私有 runtime / resources
+- package 必须包含 `loom-package.json` 与 package-local `.loom-runtime/`
 - package 能明确说明它不承诺整包 Loom 默认能力
 - package 若缺失所需 shared runtime / resources、合同漂移或运行态冲突，必须 fail-closed
 
@@ -194,7 +207,7 @@ Loom 对宿主只要求最小合同，不要求统一实现形态。
 - 宿主能够安装一个或多个 Loom 入口对象
 - 安装物能够声明自身标识、类型与版本
 - 安装物能够定位其 root 入口或单 skill 入口与被引用资源
-- 安装物能够在 `skills/` 安装根内部定位 skill-local `scripts/` 与 `shared/scripts/assets/references`
+- 安装物能够在 `skills/` 安装根内部定位 skill-local `scripts/` 与 package-local `.loom-runtime/`
 - 宿主能够把 installed runtime、repo-local demo 与 upgrade rehearsal 区分为稳定可读状态
 - 若 shared runtime / resources 缺失、合同漂移或运行态冲突，宿主必须 fail-closed，而不是继续报告“可运行”
 
@@ -214,12 +227,15 @@ Loom 对宿主只要求最小合同，不要求统一实现形态。
 
 Loom 当前仓库内以机读工件承接这组最小合同：
 
+- `VERSION`
 - `skills/registry.json`
 - `skills/install-layout.json`
 - `skills/route-matrix.md`
 - `skills/loom-init/contract.json`
 - `skills/<scenario>/contract.json`
+- `skills/<skill-id>/loom-package.json`
 - `skills/upgrade-contract.json`
+- `docs/adoption/version-authority-map.md`
 
 Loom 在此层不规定包管理器、注册中心、目录布局或分发协议；这些属于宿主实现，而不是 Loom 内核。
 
@@ -245,8 +261,9 @@ Loom 当前为宿主适配固定承认一个 Node installer：
 
 Node installer 的职责边界：
 
-- 负责安装、发现与验证
-- 不替代 `skills/shared/scripts/*` 与各场景 skill 的 Python runtime
+- 负责 adapter-managed 安装、single-skill 安装与验证
+- 不作为 Codex 默认安装入口
+- 不替代 `src/skills/shared/scripts/*`、package-local `.loom-runtime/` 与各场景 skill 的 Python runtime
 - 不把单 skill 安装伪装成完整 Loom 安装
 - 对安装失败维持 fail-closed
 - main 分支是真相源
@@ -256,8 +273,8 @@ Node installer 的职责边界：
 
 Node installer 当前打包的正式安装源：
 
-- plugin payload：发布时由 `plugins/loom/.codex-plugin/` manifest 与 `skills/` 生成
-- single-skill payload：发布时由 canonical `skills/` 临时生成
+- plugin payload：发布时由 `plugins/loom/.codex-plugin/` manifest 与生成后的根 `skills/` 表面构建
+- single-skill payload：发布时由生成后的根 `skills/<skill-id>` package 构建
 
 Node installer 的最小 preflight 必须覆盖：
 
@@ -271,15 +288,19 @@ Node installer 的最小 verify 输出必须覆盖：
 
 - `mode`
 - `host`
+- `distribution_layer`
 - `installed_paths`
+- `version_context`
 - `verification`
 - `warnings`
+- `failed_layer`
 - `fail_closed_reason`
 
 当前宿主映射固定如下：
 
 - Codex plugin
-  - upstream `plugins/loom/.codex-plugin/` manifest + canonical `skills/`
+  - adapter-managed path, not Codex default
+  - upstream `plugins/loom/.codex-plugin/` manifest + generated root `skills/`
   - `.agents/plugins/marketplace.json`
 - Codex single-skill
   - repo-scoped `<target>/.agents/skills/<skill-id>/`
@@ -290,6 +311,9 @@ Node installer 的最小 verify 输出必须覆盖：
   - `claude plugin install loom@loom-local`
 - Claude single-skill
   - `<target>/.claude/skills/<skill-id>/`
+- OpenCode / Gemini / Cursor
+  - full repo install plus host adapter discovery as documented in `docs/adoption/host-adapter-matrix.md`
+  - static verification is required until an executable host CLI is available in the local gate environment
 
 这些路径与命令属于 adapter surface，不反向提升为 Loom 内核规则。
 


### PR DESCRIPTION
Refs #496, #497, #504, #505.

Scope:
- Freeze the default full-repo + native/host skill discovery install model.
- Define default vs advanced install path boundaries.
- Update adoption docs and README entry points for the unified install direction.

Validation:
- npm --prefix packages/loom-installer run check:docs
- git diff --check

Status: draft until dependent Phase #496 branches and issue binding chain are aligned.