### PR TITLE
docs(adapters): define host adapter matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: loom-check check skills-check version-surface-check loom-demo-new-project loom-self-plugin-check
+.PHONY: loom-check check skills-check host-adapter-check version-surface-check loom-demo-new-project loom-self-plugin-check
 
 loom-check: loom-self-plugin-check loom-demo-new-project
 	python3 tools/loom_check.py
@@ -6,10 +6,13 @@ loom-check: loom-self-plugin-check loom-demo-new-project
 skills-check:
 	python3 tools/skills_surface.py check
 
+host-adapter-check:
+	python3 tools/host_adapter_check.py
+
 version-surface-check:
 	python3 tools/version_surface_check.py
 
-check: skills-check version-surface-check loom-check
+check: skills-check host-adapter-check version-surface-check loom-check
 
 loom-demo-new-project:
 	python3 tools/loom_init.py bootstrap --target examples/new-project --write --force --verify --install-pr-template

--- a/docs/adoption/host-adapter-matrix.md
+++ b/docs/adoption/host-adapter-matrix.md
@@ -1,0 +1,63 @@
+# Host Adapter Matrix
+
+This matrix defines consistent Loom semantics across supported hosts. Implementations may differ, but user-visible meaning must not.
+
+| Host | Support status | Default install path | Discovery surface | Bootstrap/session-start surface | Tool mapping surface | Upgrade surface | Verification surface |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Codex | primary | clone full repo, link `skills/loom-*` into native skill discovery | `~/.agents/skills/<skill-id>` or host-native equivalent | restart Codex, start from `loom-init` | Codex tools remain host-owned; Loom skills describe required actions | `git pull` on clone, then restart discovery | `make skills-check`; `ls ~/.agents/skills/loom-init/SKILL.md` |
+| Claude Code | adapter | full repo plus Claude plugin or project skills registration | `.claude/skills/<skill-id>` or marketplace plugin | plugin/session guidance must point to `loom-init` | Claude tools remain adapter-owned | refresh repo clone or reinstall adapter package | installer verify plus static plugin/skills checks |
+| OpenCode | adapter contract | full repo plus OpenCode plugin/path injection | configured skills path pointing at generated `skills/` | plugin injects startup guidance for `loom-init` | plugin maps OpenCode tools to Loom host-action expectations | refresh clone and reload plugin | static adapter check until OpenCode CLI is available |
+| Gemini | adapter contract | full repo plus extension/context import | extension/context references generated `skills/` | context import names `loom-init` as root entry | Gemini tool use is documented as adapter mapping | refresh clone and reload extension/context | static adapter check until Gemini extension CLI is available |
+| Cursor | adapter contract | full repo plus Cursor plugin/hooks | plugin manifest points at generated `skills/` | hooks surface `loom-init` startup guidance | Cursor tool mapping is adapter-owned | refresh clone and reload plugin/hooks | static adapter check until Cursor plugin CLI is available |
+
+Each supported host has exactly one default path: full repository install plus that host's native or adapter discovery of the generated root `skills/` surface. Single-skill install is always advanced. Installer-driven plugin installation is adapter-managed and must not be described as the Codex default path.
+
+## Required Fields
+
+Each host adapter must define:
+
+- `host`
+- `support_status`
+- `default_install_path`
+- `advanced_single_skill_path`
+- `install_surface`
+- `discovery_surface`
+- `bootstrap_or_session_start_surface`
+- `default_entry`
+- `invocation_surface`
+- `tool_mapping_surface`
+- `override_or_shadowing_surface`
+- `upgrade_surface`
+- `verification_surface`
+- `fail_closed_conditions`
+- `version_metadata_location`
+
+## Single-Skill Boundary
+
+Every host may install `skills/<skill-id>` as an advanced path. The host must present it as a single named skill, not as a complete Loom installation.
+
+The package source is the checked-in generated root directory. The editable source remains `src/skills/<skill-id>`, but host adapters and generic skill installers consume `skills/<skill-id>` because it contains `loom-package.json` and `.loom-runtime/`.
+
+## Version Metadata
+
+Adapters must surface machine-readable version context instead of implying one global Loom version. The minimum version metadata locations are:
+
+- full repository install: `VERSION` and the git revision of the clone
+- generated skill surface: `skills/registry.json` and `skills/upgrade-contract.json`
+- single-skill package: `skills/<skill-id>/loom-package.json`
+- plugin surface: the host plugin manifest, such as `plugins/loom/.codex-plugin/plugin.json`
+- installer: `packages/loom-installer/package.json`
+
+The authority rules for these surfaces live in [version-authority-map.md](./version-authority-map.md).
+
+## Fail-Closed Conditions
+
+Adapters must fail closed and report failure instead of partial success when:
+
+- `SKILL.md` is missing
+- `contract.json` or `loom-package.json` is missing
+- `.loom-runtime/` is missing
+- the launcher cannot report `installed-runtime`
+- host discovery cannot observe the installed skill
+- version metadata cannot be read
+- a conflicting user override shadows Loom without explicit operator intent

--- a/docs/adoption/host-adapter-matrix.md
+++ b/docs/adoption/host-adapter-matrix.md
@@ -48,7 +48,7 @@ Adapters must surface machine-readable version context instead of implying one g
 - plugin surface: the host plugin manifest, such as `plugins/loom/.codex-plugin/plugin.json`
 - installer: `packages/loom-installer/package.json`
 
-The authority rules for these surfaces live in [version-authority-map.md](./version-authority-map.md).
+The authority rules for these surfaces live in `version-authority-map.md`.
 
 ## Fail-Closed Conditions
 

--- a/docs/adoption/unified-install-experience.md
+++ b/docs/adoption/unified-install-experience.md
@@ -84,4 +84,4 @@ Across Codex, Claude Code, OpenCode, Gemini, and Cursor, the user-facing experie
 
 ## Version Context
 
-Loom does not use one global version line for every surface. User-facing install and upgrade docs must link to [version-authority-map.md](./version-authority-map.md) when describing repository versions, GitHub releases, installer versions, plugin surface versions, host adapter versions, generated single-skill package versions, skills registry and contract versions, runtime/core versions, or external runtime schemas.
+Loom does not use one global version line for every surface. User-facing install and upgrade docs must refer to `version-authority-map.md` when describing repository versions, GitHub releases, installer versions, plugin surface versions, host adapter versions, generated single-skill package versions, skills registry and contract versions, runtime/core versions, or external runtime schemas.

--- a/tools/host_adapter_check.py
+++ b/tools/host_adapter_check.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Static checks for Loom host adapter distribution contracts."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MATRIX = ROOT / "docs" / "adoption" / "host-adapter-matrix.md"
+UNIFIED = ROOT / "docs" / "adoption" / "unified-install-experience.md"
+
+HOSTS = ("Codex", "Claude Code", "OpenCode", "Gemini", "Cursor")
+REQUIRED_FIELDS = (
+    "default_install_path",
+    "advanced_single_skill_path",
+    "install_surface",
+    "discovery_surface",
+    "bootstrap_or_session_start_surface",
+    "default_entry",
+    "tool_mapping_surface",
+    "upgrade_surface",
+    "verification_surface",
+    "fail_closed_conditions",
+    "version_metadata_location",
+)
+
+
+def require_contains(path: Path, needles: tuple[str, ...]) -> list[str]:
+    if not path.exists():
+        return [f"missing {path.relative_to(ROOT)}"]
+    text = path.read_text(encoding="utf-8")
+    return [f"{path.relative_to(ROOT)} must mention `{needle}`" for needle in needles if needle not in text]
+
+
+def main() -> int:
+    errors: list[str] = []
+    errors.extend(require_contains(MATRIX, HOSTS))
+    errors.extend(require_contains(MATRIX, REQUIRED_FIELDS))
+    errors.extend(require_contains(MATRIX, ("loom-init", "skills/<skill-id>", "fail closed", "static adapter check")))
+    errors.extend(require_contains(UNIFIED, ("full repo", "native", "single-skill", "skills/<skill-id>", "loom-init")))
+    if errors:
+        print("host adapter check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("host adapter check: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refs #496, #500, #511, #512, #513, #514, #515, #519.

Scope:
- Define Codex, Claude Code, OpenCode, Gemini, and Cursor adapter surfaces.
- Fix install, discovery, bootstrap/session-start, tool mapping, override/shadowing, upgrade, verification, and fail-closed semantics.
- Add a static host adapter matrix check for the documented adapter contract.

Validation:
- python3 tools/host_adapter_check.py
- git diff --check

Status: draft until the Phase #496 stack and issue binding comments are complete.