### PR TITLE
feat(installer): report distribution layer and version context

### DIFF
--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.63",
+      "version": "0.1.64",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -20,8 +20,11 @@
   "scripts": {
     "build": "node ./scripts/build-payload.mjs && tsc -p tsconfig.json",
     "check:docs": "node ./scripts/check-doc-sync.mjs",
+    "check:distribution": "cd ../.. && python3 tools/skills_surface.py check",
+    "check:hosts": "cd ../.. && python3 tools/host_adapter_check.py",
     "check:payload": "node ./scripts/check-payload-drift.mjs",
-    "check:release": "npm run check:docs && npm run check:payload",
+    "check:versions": "cd ../.. && python3 tools/version_surface_check.py",
+    "check:release": "npm run check:docs && npm run check:distribution && npm run check:hosts && npm run check:versions && npm run check:payload",
     "prepack": "npm run build",
     "prepublishOnly": "npm test && npm run check:release",
     "test": "npm run build && node --test dist/test/*.test.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/packages/loom-installer/scripts/build-payload.mjs
+++ b/packages/loom-installer/scripts/build-payload.mjs
@@ -12,8 +12,9 @@ const pluginManifestSource = join(repoRoot, 'plugins', 'loom', '.codex-plugin');
 const skillsSourceRoot = join(repoRoot, 'skills');
 const pluginManifestPath = join(pluginManifestSource, 'plugin.json');
 const installLayoutPath = join(skillsSourceRoot, 'install-layout.json');
-const privateRuntimeDir = '.loom-runtime';
 const payloadLockDir = join(packageRoot, '.payload-lock');
+const repoVersionPath = join(repoRoot, 'VERSION');
+const packageJsonPath = join(packageRoot, 'package.json');
 
 function sleep(milliseconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
@@ -108,57 +109,6 @@ function requiredInstallLayoutPaths() {
   return layout.required_paths;
 }
 
-function runtimeScript(skillId) {
-  return skillId === 'loom-init' || skillId === 'loom-adopt' ? 'loom_init.py' : 'loom_flow.py';
-}
-
-function writeSingleSkillWrapper(skillId, targetPath) {
-  const script = runtimeScript(skillId);
-  writeFileSync(
-    targetPath,
-    [
-      '#!/usr/bin/env python3',
-      'from __future__ import annotations',
-      '',
-      'import os',
-      'import runpy',
-      'import sys',
-      'from pathlib import Path',
-      '',
-      'SCRIPT_PATH = Path(__file__).resolve()',
-      'PACKAGE_ROOT = SCRIPT_PATH.parents[1]',
-      `RUNTIME_ROOT = PACKAGE_ROOT / "${privateRuntimeDir}"`,
-      '',
-      'os.environ.setdefault("LOOM_INSTALLED_SKILLS_ROOT", str(RUNTIME_ROOT))',
-      `os.environ.setdefault("LOOM_PACKAGE_SKILL_ID", "${skillId}")`,
-      'sys.path.insert(0, str(RUNTIME_ROOT / "shared/scripts"))',
-      `runpy.run_path(RUNTIME_ROOT / "shared/scripts/${script}", run_name="__main__")`,
-      '',
-    ].join('\n'),
-    { encoding: 'utf8', mode: 0o755 },
-  );
-}
-
-function copyTopLevelSkillSurface(skillId, targetRoot) {
-  const sourceRoot = join(skillsSourceRoot, skillId);
-  const targetSkillRoot = join(targetRoot, skillId);
-  const packageSkillRoot = targetRoot;
-  copyDirectoryFiltered(sourceRoot, packageSkillRoot);
-  rmSync(join(packageSkillRoot, 'scripts'), { recursive: true, force: true });
-  mkdirSync(join(packageSkillRoot, 'scripts'), { recursive: true });
-  const entrypoint = readJson(join(sourceRoot, 'contract.json')).entrypoint ?? {};
-  const executable = entrypoint.script ?? entrypoint.bootstrap_cli ?? entrypoint.orchestration_cli ?? entrypoint.route_cli;
-  if (!executable || typeof executable !== 'string') {
-    throw new Error(`${skillId}/contract.json must declare entrypoint.script`);
-  }
-  writeSingleSkillWrapper(skillId, join(packageSkillRoot, executable));
-  rmSync(targetSkillRoot, { recursive: true, force: true });
-}
-
-function copyFullRuntime(runtimeRoot) {
-  copyDirectoryFiltered(skillsSourceRoot, runtimeRoot);
-}
-
 function verifyRequiredPaths(rootDir, requiredPaths, label) {
   const missing = [];
   for (const requiredPath of requiredPaths) {
@@ -190,16 +140,24 @@ function buildSingleSkillPayloads(currentPayloadRoot, entries, requiredPaths) {
       throw new Error(`missing skill source: ${sourceDir}`);
     }
     const contract = readJson(join(sourceDir, 'contract.json'));
+    const packageMetadata = readJson(join(sourceDir, 'loom-package.json'));
     const packageDir = join(skillsPayloadRoot, skillId);
     mkdirSync(packageDir, { recursive: true });
-    copyTopLevelSkillSurface(skillId, packageDir);
-    const runtimeRoot = join(packageDir, privateRuntimeDir);
-    copyFullRuntime(runtimeRoot);
+    copyDirectoryFiltered(sourceDir, packageDir);
+    const runtimeRoot = join(packageDir, packageMetadata.runtime_root ?? '.loom-runtime');
     verifyRequiredPaths(runtimeRoot, requiredPaths, `single-skill runtime for ${skillId}`);
+    if (!existsSync(join(packageDir, 'SKILL.md')) || !existsSync(join(packageDir, 'loom-package.json'))) {
+      throw new Error(`single-skill package for ${skillId} is incomplete`);
+    }
     skills.push({
       id: contract.id,
       display_name: contract.display_name,
       contract_version: contract.contract_version,
+      skill_package_version: packageMetadata.skill_package_version,
+      runtime_core_version: packageMetadata.runtime_core_version,
+      package_metadata: 'loom-package.json',
+      runtime_root: packageMetadata.runtime_root,
+      launcher: packageMetadata.launcher,
       relative_path: `skills/${skillId}`,
     });
   }
@@ -254,15 +212,27 @@ function buildPayload() {
     verifyRequiredPaths(join(pluginTarget, 'skills'), requiredPaths, 'plugin payload');
     const skillRecords = buildSingleSkillPayloads(stagingRoot, publicSkillEntries(), requiredPaths);
     const pluginManifest = readJson(pluginManifestPath);
+    const packageJson = readJson(packageJsonPath);
+    const repoVersion = readFileSync(repoVersionPath, 'utf8').trim();
+    const registry = readJson(join(skillsSourceRoot, 'registry.json'));
     const files = collectFiles(stagingRoot).filter((entry) => entry.path !== 'manifest.json');
+    const hostAdapterVersion = pluginManifest['x-loom']?.host_adapter_version ?? '1.0.0';
 
     const manifest = {
       schema_version: 'loom-installer-payload/v1',
-      loom_version: pluginManifest.version,
+      loom_version: repoVersion,
       source_repository: 'https://github.com/MC-and-his-Agents/Loom',
       source_commit: gitValue(['rev-parse', 'HEAD'], 'unknown'),
       source_ref: gitValue(['rev-parse', '--abbrev-ref', 'HEAD'], 'unknown'),
       built_at: process.env.LOOM_INSTALLER_BUILD_TIMESTAMP ?? new Date().toISOString(),
+      version_context: {
+        repo_version: repoVersion,
+        installer_package_version: packageJson.version,
+        plugin_surface_version: pluginManifest.version,
+        host_adapter_version: hostAdapterVersion,
+        skills_registry_version: registry.registry_version,
+        runtime_core_version: skillRecords[0]?.runtime_core_version ?? '1.0.0',
+      },
       runtime: {
         python_minimum: '3.10',
         python_recommended: '3.11+',
@@ -270,6 +240,7 @@ function buildPayload() {
       plugin: {
         name: pluginManifest.name,
         version: pluginManifest.version,
+        host_adapter_version: hostAdapterVersion,
         relative_path: 'plugin/loom',
       },
       skills: skillRecords,

--- a/packages/loom-installer/scripts/check-doc-sync.mjs
+++ b/packages/loom-installer/scripts/check-doc-sync.mjs
@@ -77,6 +77,15 @@ const requiredNeedles = [
     ],
   },
   {
+    path: 'docs/adoption/version-authority-map.md',
+    needles: [
+      'Versions are not globally synchronized',
+      'installer package version',
+      'plugin surface version',
+      'skill_package_version',
+    ],
+  },
+  {
     path: 'packages/loom-installer/README.md',
     needles: [
       'npm install -D @mc-and-his-agents/loom-installer',

--- a/packages/loom-installer/src/claude.ts
+++ b/packages/loom-installer/src/claude.ts
@@ -136,6 +136,7 @@ export function installClaudePlugin(
   return {
     mode: 'plugin',
     host: 'claude',
+    distribution_layer: 'host-adapter-plugin',
     status: /already installed/i.test(installOutput) ? 'already-installed' : 'installed',
     installed_paths: [marketplaceRoot, marketplaceManifestPath, pluginTarget, claudePluginManifestPath],
     verification: [
@@ -144,6 +145,8 @@ export function installClaudePlugin(
       'verified `claude plugin list --json` contains loom',
     ],
     warnings: ['Claude plugin install goes through the official CLI and does not replace the Python runtime.'],
+    version_context: null,
+    failed_layer: null,
     fail_closed_reason: null,
   };
 }
@@ -181,6 +184,7 @@ export function installClaudeSkill(
   return {
     mode: 'skill',
     host: 'claude',
+    distribution_layer: 'generated-single-skill',
     status: 'installed',
     installed_paths: [targetDir],
     verification: [
@@ -188,6 +192,8 @@ export function installClaudeSkill(
       `verified discoverable SKILL.md at ${skillMarkdownPath}`,
     ],
     warnings: ['Claude single-skill install relies on project-level `.claude/skills` discovery and does not expose the full Loom plugin surface.'],
+    version_context: null,
+    failed_layer: null,
     fail_closed_reason: null,
   };
 }

--- a/packages/loom-installer/src/cli.ts
+++ b/packages/loom-installer/src/cli.ts
@@ -7,10 +7,13 @@ function errorResult(message: string): InstallResult {
   return {
     mode: 'plugin',
     host: 'codex',
+    distribution_layer: 'host-adapter-plugin',
     status: 'installed',
     installed_paths: [],
     verification: [],
     warnings: [],
+    version_context: null,
+    failed_layer: 'cli',
     fail_closed_reason: message,
   };
 }

--- a/packages/loom-installer/src/codex.ts
+++ b/packages/loom-installer/src/codex.ts
@@ -102,6 +102,7 @@ export function installCodexPlugin(
   return {
     mode: 'plugin',
     host: 'codex',
+    distribution_layer: 'host-adapter-plugin',
     status: 'installed',
     installed_paths: installedPaths,
     verification: [
@@ -109,6 +110,8 @@ export function installCodexPlugin(
       `verified marketplace entry at ${codexMarketplacePath(targetRoot)}`,
     ],
     warnings,
+    version_context: null,
+    failed_layer: null,
     fail_closed_reason: null,
   };
 }
@@ -145,6 +148,7 @@ export function installCodexSkill(
   return {
     mode: 'skill',
     host: 'codex',
+    distribution_layer: 'generated-single-skill',
     status: 'installed',
     installed_paths: [targetDir],
     verification: [
@@ -152,6 +156,8 @@ export function installCodexSkill(
       `verified repo skill discovery path at ${skillMarkdownPath}`,
     ],
     warnings: ['Codex repo-scoped single-skill install exposes only the named skill, not the full Loom plugin surface.'],
+    version_context: null,
+    failed_layer: null,
     fail_closed_reason: null,
   };
 }

--- a/packages/loom-installer/src/index.ts
+++ b/packages/loom-installer/src/index.ts
@@ -1,6 +1,6 @@
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Host, CliOptions, InstallResult, Mode, PayloadManifest, ResolvedEnv } from './types.js';
+import { Host, CliOptions, InstallResult, Mode, PayloadManifest, PayloadSkillRecord, ResolvedEnv, VersionContext } from './types.js';
 import { InstallerError, assert, dirExists, ensureTargetWritable, runCommand } from './utils.js';
 import { loadPayloadManifest, resolveSkillRecord, verifyPayload } from './payload.js';
 import { installCodexPlugin, installCodexSkill } from './codex.js';
@@ -155,8 +155,15 @@ export function ensureClaudeCliWhenNeeded(host: Host, mode: Mode, env: ResolvedE
 }
 
 export function formatResult(result: InstallResult): string {
+  const version = result.version_context;
   return [
     `${result.host} ${result.mode}: ${result.status}`,
+    `layer: ${result.distribution_layer}`,
+    ...(version
+      ? [
+          `versions: repo=${version.repo_version} installer=${version.installer_package_version} plugin=${version.plugin_surface_version} registry=${version.skills_registry_version}`,
+        ]
+      : []),
     ...result.verification.map((line) => `- ${line}`),
     ...result.warnings.map((line) => `! ${line}`),
   ].join('\n');
@@ -183,7 +190,31 @@ export function runInstaller(parsed: ParsedCommand, envSource: NodeJS.ProcessEnv
     manifest,
   });
   result.warnings.unshift(...warnings);
-  return result;
+  return withVersionContext(result, manifest, parsed.mode === 'skill' ? resolveSkillRecord(manifest, parsed.skillId ?? '') : undefined);
+}
+
+function payloadVersionContext(manifest: PayloadManifest, skill?: PayloadSkillRecord): VersionContext {
+  return {
+    ...manifest.version_context,
+    source_repository: manifest.source_repository,
+    source_commit: manifest.source_commit,
+    source_ref: manifest.source_ref,
+    ...(skill
+      ? {
+          skill_package_id: skill.id,
+          skill_package_version: skill.skill_package_version,
+          skill_contract_version: skill.contract_version,
+          runtime_core_version: skill.runtime_core_version,
+        }
+      : {}),
+  };
+}
+
+function withVersionContext(result: InstallResult, manifest: PayloadManifest, skill?: PayloadSkillRecord): InstallResult {
+  return {
+    ...result,
+    version_context: payloadVersionContext(manifest, skill),
+  };
 }
 
 function installForHost(input: {

--- a/packages/loom-installer/src/types.ts
+++ b/packages/loom-installer/src/types.ts
@@ -1,6 +1,7 @@
 export type Host = 'codex' | 'claude';
 export type Mode = 'plugin' | 'skill';
 export type InstallStatus = 'installed' | 'already-installed';
+export type DistributionLayer = 'host-adapter-plugin' | 'generated-single-skill';
 
 export interface PayloadFileRecord {
   path: string;
@@ -12,7 +13,27 @@ export interface PayloadSkillRecord {
   id: string;
   display_name: string;
   contract_version: string;
+  skill_package_version: string;
+  runtime_core_version: string;
+  package_metadata: string;
+  runtime_root: string;
+  launcher: string;
   relative_path: string;
+}
+
+export interface VersionContext {
+  repo_version: string;
+  installer_package_version: string;
+  plugin_surface_version: string;
+  host_adapter_version: string;
+  skills_registry_version: string;
+  runtime_core_version: string;
+  source_repository?: string;
+  source_commit?: string;
+  source_ref?: string;
+  skill_package_version?: string;
+  skill_contract_version?: string;
+  skill_package_id?: string;
 }
 
 export interface PayloadManifest {
@@ -22,6 +43,7 @@ export interface PayloadManifest {
   source_commit: string;
   source_ref: string;
   built_at: string;
+  version_context: VersionContext;
   runtime: {
     python_minimum: string;
     python_recommended: string;
@@ -29,6 +51,7 @@ export interface PayloadManifest {
   plugin: {
     name: string;
     version: string;
+    host_adapter_version: string;
     relative_path: string;
   };
   skills: PayloadSkillRecord[];
@@ -38,10 +61,13 @@ export interface PayloadManifest {
 export interface InstallResult {
   mode: Mode;
   host: Host;
+  distribution_layer: DistributionLayer;
   status: InstallStatus;
   installed_paths: string[];
   verification: string[];
   warnings: string[];
+  version_context: VersionContext | null;
+  failed_layer: string | null;
   fail_closed_reason: string | null;
 }
 

--- a/packages/loom-installer/test/installer.test.ts
+++ b/packages/loom-installer/test/installer.test.ts
@@ -88,10 +88,15 @@ test('payload manifest excludes python cache artifacts', () => {
 test('payload manifest tracks loom-spec-review as a public skill', () => {
   const manifest = JSON.parse(readFileSync(join(packageRoot(), 'payload', 'manifest.json'), 'utf8'));
   assert.equal(Array.isArray(manifest.skills), true);
-  assert.equal(
-    manifest.skills.some((entry: { id: string; relative_path: string }) => entry.id === 'loom-spec-review' && entry.relative_path === 'skills/loom-spec-review'),
-    true,
-  );
+  const skill = manifest.skills.find((entry: { id: string }) => entry.id === 'loom-spec-review');
+  assert.equal(skill.relative_path, 'skills/loom-spec-review');
+  assert.equal(skill.package_metadata, 'loom-package.json');
+  assert.equal(skill.runtime_root, '.loom-runtime');
+  assert.equal(typeof skill.skill_package_version, 'string');
+  assert.equal(typeof skill.runtime_core_version, 'string');
+  assert.equal(typeof manifest.version_context.repo_version, 'string');
+  assert.equal(typeof manifest.version_context.installer_package_version, 'string');
+  assert.equal(typeof manifest.version_context.plugin_surface_version, 'string');
 });
 
 test('payload bundles shared references and runtime paths required by install layout', () => {
@@ -155,6 +160,8 @@ test('codex plugin install writes marketplace entry', () => {
   const result = runInstaller(parsed, envSource, packageRoot());
   const marketplace = JSON.parse(readFileSync(join(repoRoot, '.agents', 'plugins', 'marketplace.json'), 'utf8'));
   assert.equal(result.host, 'codex');
+  assert.equal(result.distribution_layer, 'host-adapter-plugin');
+  assert.equal(result.version_context?.plugin_surface_version, '0.4.0');
   assert.equal(marketplace.plugins[0].name, 'loom');
   assert.equal(marketplace.plugins[0].source.path, './plugins/loom');
 });
@@ -246,6 +253,9 @@ test('codex skill install writes repo-scoped .agents skill', () => {
   const result = runInstaller(parsed, envSource, packageRoot());
   const skillPath = join(repoRoot, '.agents', 'skills', 'loom-review', 'SKILL.md');
   assert.equal(result.mode, 'skill');
+  assert.equal(result.distribution_layer, 'generated-single-skill');
+  assert.equal(result.version_context?.skill_package_id, 'loom-review');
+  assert.equal(typeof result.version_context?.skill_package_version, 'string');
   assert.equal(existsSync(skillPath), true);
   assert.equal(existsSync(join(envSource.CODEX_HOME!, 'config.toml')), false);
 });
@@ -400,5 +410,8 @@ test('cli emits structured json on success', () => {
   const payload = JSON.parse(output);
   assert.equal(payload.host, 'codex');
   assert.equal(payload.mode, 'plugin');
+  assert.equal(payload.distribution_layer, 'host-adapter-plugin');
+  assert.equal(payload.version_context.plugin_surface_version, '0.4.0');
+  assert.equal(payload.failed_layer, null);
   assert.equal(payload.fail_closed_reason, null);
 });


### PR DESCRIPTION
Refs #496, #501, #516, #517.

Stack base: #526 / work-item-503-version-surfaces.

Scope:
- Re-scope loom-installer away from Codex default install ownership.
- Keep the installer as host adapter, single-skill helper, payload builder, and verifier.
- Extend InstallResult JSON/text output with distribution_layer, version_context, and failed_layer while preserving compatibility.

Validation:
- npm --prefix packages/loom-installer run check:docs
- npm --prefix packages/loom-installer test
- npm --prefix packages/loom-installer run check:payload
- git diff --check

Status: draft until #526 is merged or this branch is rebased onto main after #526.