### PR TITLE
test(distribution): add unified distribution verification gates

### DIFF
--- a/.github/workflows/node-installer-pr.yml
+++ b/.github/workflows/node-installer-pr.yml
@@ -5,9 +5,16 @@ on:
     paths:
       - 'packages/loom-installer/**'
       - 'plugins/loom/.codex-plugin/**'
+      - 'src/skills/**'
       - 'skills/**'
+      - 'tools/skills_surface.py'
+      - 'tools/host_adapter_check.py'
+      - 'tools/version_surface_check.py'
       - 'README.md'
+      - 'README.zh-CN.md'
+      - 'docs/adoption/**'
       - 'skills/README.md'
+      - 'skills/README.zh-CN.md'
       - 'skills/distribution-and-adapter-contract.md'
       - 'skills/shared/scripts/loom_check.py'
       - 'plugins/loom/.codex-plugin/plugin.json'
@@ -47,6 +54,15 @@ jobs:
 
       - name: Check doc sync
         run: npm --prefix packages/loom-installer run check:docs
+
+      - name: Check generated skills surface
+        run: npm --prefix packages/loom-installer run check:distribution
+
+      - name: Check host adapter matrix
+        run: npm --prefix packages/loom-installer run check:hosts
+
+      - name: Check version surfaces
+        run: npm --prefix packages/loom-installer run check:versions
 
       - name: Check payload drift
         run: npm --prefix packages/loom-installer run check:payload

--- a/.github/workflows/node-installer-release.yml
+++ b/.github/workflows/node-installer-release.yml
@@ -8,9 +8,16 @@ on:
     paths:
       - 'packages/loom-installer/**'
       - 'plugins/loom/.codex-plugin/**'
+      - 'src/skills/**'
       - 'skills/**'
+      - 'tools/skills_surface.py'
+      - 'tools/host_adapter_check.py'
+      - 'tools/version_surface_check.py'
       - 'README.md'
+      - 'README.zh-CN.md'
+      - 'docs/adoption/**'
       - 'skills/README.md'
+      - 'skills/README.zh-CN.md'
       - 'skills/distribution-and-adapter-contract.md'
       - 'skills/shared/scripts/loom_check.py'
       - '.github/workflows/node-installer-release.yml'
@@ -53,6 +60,15 @@ jobs:
       - name: Check doc sync
         run: npm --prefix packages/loom-installer run check:docs
 
+      - name: Check generated skills surface
+        run: npm --prefix packages/loom-installer run check:distribution
+
+      - name: Check host adapter matrix
+        run: npm --prefix packages/loom-installer run check:hosts
+
+      - name: Check version surfaces
+        run: npm --prefix packages/loom-installer run check:versions
+
       - name: Check payload drift
         run: npm --prefix packages/loom-installer run check:payload
 
@@ -82,7 +98,7 @@ jobs:
 
           CHANGED_FILES=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}")
           FILTERED_CHANGED=$CHANGED_FILES
-          if printf '%s\n' "$FILTERED_CHANGED" | grep -E '^(packages/loom-installer/src/|packages/loom-installer/scripts/build-payload\.mjs|packages/loom-installer/package.json|plugins/loom/\.codex-plugin/|skills/)' >/dev/null; then
+          if printf '%s\n' "$FILTERED_CHANGED" | grep -E '^(packages/loom-installer/src/|packages/loom-installer/scripts/build-payload\.mjs|packages/loom-installer/package.json|plugins/loom/\.codex-plugin/|src/skills/|skills/)' >/dev/null; then
             echo "behavior_changed=true" >> "$GITHUB_OUTPUT"
           else
             echo "behavior_changed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Refs #496, #502, #518, #519, #521.

Scope:
- Adds src/skills, adapter docs, version docs, and verification scripts to the node installer PR/release gate path filters.
- Runs generated skills surface, host adapter matrix, and version surface checks in both PR and release gates.
- Treats src/skills changes as installer behavior for release-state detection.

Validation:
- npm --prefix packages/loom-installer run check:release
- make check
- git diff --check

This PR intentionally only changes workflow verification wiring. The source truth, generated skills surface, host adapter matrix, version metadata, and installer result changes are already on main through #523, #524, #525, #526, and #527.