### PR TITLE
chore(installer): recover installer release truth

### DIFF
--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.64",
+      "version": "0.1.65",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Recover the installer release truth for Phase #496 by bumping `@mc-and-his-agents/loom-installer` from `0.1.64` to `0.1.65`. The previous `0.1.64` package version exists on `main` but was never published to npm or GitHub releases because the earlier release workflow failed before the host adapter check landed.

This branch intentionally changes only the installer package metadata so the normal PR + release workflow can publish the next version instead of manually backfilling the failed release.

Refs: #496 #501 #503 #517 #521 #522

## Validation

- `npm --prefix packages/loom-installer ci`
- `npm --prefix packages/loom-installer run check:release`
- `npm --prefix packages/loom-installer test`
- `cd packages/loom-installer && npm pack --dry-run`
- `git diff --check`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`