### PR TITLE
feat(status): 收紧事实链来源说明与漂移阻断

### DIFF
--- a/.loom/bin/fact_chain_support.py
+++ b/.loom/bin/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/.loom/bin/loom_check.py
+++ b/.loom/bin/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2025,6 +2030,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
 
 
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+
+
 def require_route_payload(
     failures: list[Failure],
     *,
@@ -2121,8 +2174,8 @@ def check_root_route_contracts(root: Path) -> list[Failure]:
     if not isinstance(routing, dict):
         failures.append(Failure(category, "`skills/loom-init/contract.json` must declare `routing`"))
     else:
-        if routing.get("reference") != "../route-matrix.md":
-            failures.append(Failure(category, "`skills/loom-init/contract.json` must reference `../route-matrix.md`"))
+        if routing.get("reference") not in {"../route-matrix.md", ".loom-runtime/route-matrix.md"}:
+            failures.append(Failure(category, "`skills/loom-init/contract.json` must reference the generated route matrix"))
         if routing.get("fallback_entry") != "loom-init":
             failures.append(Failure(category, "`skills/loom-init/contract.json` fallback entry must remain `loom-init`"))
         if routing.get("priority_order") != [
@@ -2568,7 +2621,7 @@ def check_skill_routing(root: Path) -> list[Failure]:
     with tempfile.TemporaryDirectory(prefix="loom-check-route-registry-") as tmp:
         broken_skills = Path(tmp) / "skills"
         shutil.copytree(root / "skills", broken_skills)
-        registry_path = broken_skills / "registry.json"
+        registry_path = broken_skills / "loom-init" / ".loom-runtime" / "registry.json"
         registry = load_json_file(registry_path)
         if isinstance(registry, dict):
             entries = registry.get("entries")
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"
@@ -4626,7 +4790,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         broken_install = tmp_root / "broken-install" / "skills"
         shutil.copytree(root / "skills", broken_install)
-        (broken_install / "shared" / "scripts" / "loom_flow.py").unlink()
+        (broken_install / "loom-init" / ".loom-runtime" / "shared" / "scripts" / "loom_flow.py").unlink()
         payload, error = load_command_json(
             root,
             ["python3", str(broken_install / "loom-init" / "scripts" / "loom-init.py"), "runtime-state", "--target", str(target_root)],
@@ -4638,7 +4802,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
         drift_install = tmp_root / "drift-install" / "skills"
         shutil.copytree(root / "skills", drift_install)
-        (drift_install / "install-layout.json").unlink()
+        (drift_install / "loom-init" / ".loom-runtime" / "install-layout.json").unlink()
         payload, error = load_command_json(
             root,
             ["python3", str(drift_install / "loom-init" / "scripts" / "loom-init.py"), "runtime-state", "--target", str(target_root)],
@@ -5475,7 +5639,8 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
                 broken_install = tmp_root / "broken-install" / "skills"
                 shutil.copytree(root / "skills", broken_install)
-                (broken_install / "install-layout.json").unlink()
+                (broken_install / "loom-init" / ".loom-runtime" / "install-layout.json").unlink()
+                (broken_install / "loom-pre-review" / ".loom-runtime" / "install-layout.json").unlink()
                 payload, error = load_command_json(
                     root,
                     [
@@ -5979,6 +6144,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
 
             shutil.copytree(root / "skills", broken_install)
             (broken_install / "install-layout.json").unlink()
+            (broken_install / "loom-retire" / ".loom-runtime" / "install-layout.json").unlink()
             for label, args in (
                 (
                     "installed closeout check missing install-layout",

--- a/.loom/bin/loom_flow.py
+++ b/.loom/bin/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/.loom/bin/loom_status.py
+++ b/.loom/bin/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/Users/mc/dev/Loom",
+    "target": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance",
     "scenario": "复杂既有仓库",
     "scenario_key": "complex-existing",
     "integration_mode": "companion",
@@ -16,13 +16,13 @@
   "intake": {
     "schema_version": "loom-init-intake/v1",
     "repository_type": "existing",
-    "root_boundary_docs": "clear",
+    "root_boundary_docs": "partial",
     "ci_or_basic_tests": true,
     "repository_level_validation_entry": true,
-    "primary_gap_category": "spec-path",
+    "primary_gap_category": "governance",
     "long_running_recovery_pain": true,
     "shared_contract_or_high_risk_boundary": true,
-    "purity_or_scope_signals": "clean",
+    "purity_or_scope_signals": "severe",
     "merge_review_semantic_overload": false,
     "notes": "autodetected by loom_init.py"
   },
@@ -116,7 +116,7 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "78cf0d0022a4c03933a5e46cba676e80cafa5d0802fb95191a761ec9f9417e65"
+      "sha256": "5d10e10d459269dd718b3385ee13019f564f361cad696965122745b0d329078b"
     },
     {
       "path": ".loom/bin/governance_surface.py",
@@ -128,13 +128,13 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "d67ffd22cacad33d25e1a4ef5dc90b57eb7143aae7a9a65420fcbdcb38fc701d"
+      "sha256": "216adef334fa5db5596d989155e03eb2222bc54b10b64fa2b4f19b92eddba72b"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "229ecdf3171aab0df302fd9662f5a9ce6371e7b8f194ece341909d38ce268bed"
+      "sha256": "e8814b5ef11c120a7909e48f7d3a648f5ce9baf1dde14425f02c9db072495f36"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -152,7 +152,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "e0d0178b76619a82a6d616db872a57efaea90e635bfe0883ef318e42e937232c"
+      "sha256": "09297502d6a5c54a147791dae1e1fa93d0dbee3fc772e3e1230f9726688037e8"
     },
     {
       "path": "AGENTS.md",
@@ -198,6 +198,11 @@
       "path": ".loom/specs/INIT-0001/implementation-contract.md",
       "kind": "implementation-contract",
       "source": "skills/shared/assets/templates/scaffold/implementation-contract.md"
+    },
+    {
+      "path": ".github/PULL_REQUEST_TEMPLATE.md",
+      "kind": "pr-template",
+      "source": "skills/shared/assets/github/PULL_REQUEST_TEMPLATE.md"
     }
   ],
   "initial_work_items": [
@@ -255,12 +260,12 @@
     "scene": "repo-local-demo",
     "carrier": "repo-local-wrapper",
     "entry_family": "loom-init",
-    "install_root": "/Users/mc/dev/Loom/skills",
-    "runtime_root": "/Users/mc/dev/Loom/skills/shared/scripts",
-    "registry_path": "/Users/mc/dev/Loom/skills/registry.json",
-    "layout_or_manifest_path": "/Users/mc/dev/Loom/skills/install-layout.json",
-    "source_repo_root": "/Users/mc/dev/Loom",
-    "target_root": "/Users/mc/dev/Loom",
+    "install_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills",
+    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/shared/scripts",
+    "registry_path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/registry.json",
+    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/install-layout.json",
+    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance",
+    "target_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance",
     "checks": {
       "scene_marker": {
         "status": "pass",
@@ -270,21 +275,21 @@
         "status": "pass",
         "summary": "carrier layout exposes an installed skills root and shared runtime tree.",
         "evidence": {
-          "install_root": "/Users/mc/dev/Loom/skills"
+          "install_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills"
         }
       },
       "registry_contract": {
         "status": "pass",
         "summary": "registry, upgrade contract, and skill entrypoints are consistent.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom/skills/registry.json"
+          "path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/registry.json"
         }
       },
       "shared_runtime": {
         "status": "pass",
         "summary": "shared runtime scripts are present and executable roots can be resolved.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom/skills/shared/scripts"
+          "path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/shared/scripts"
         }
       },
       "referenced_resources": {
@@ -295,36 +300,36 @@
   },
   "governance_surface": {
     "repository_mode": "complex-existing",
-    "loom_state": "partial",
+    "loom_state": "active",
     "carrier_summary": {
       "work_item": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/work-items/INIT-0001.md",
         "source": "repository scan"
       },
       "recovery": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/progress/INIT-0001.md",
         "source": "repository scan"
       },
       "review": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/reviews/INIT-0001.json",
         "source": "repository scan"
       },
       "status_surface": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/status/current.md",
         "source": "repository scan"
       },
       "spec_path": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/specs/INIT-0001/spec.md",
         "source": "repository scan"
       },
       "plan_path": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/specs/INIT-0001/plan.md",
         "source": "repository scan"
       }
     },
@@ -345,57 +350,228 @@
         "repo-local-cli",
         "loom-check"
       ],
-      "pr_reviews": "not_required"
+      "pr_reviews": "not_required",
+      "rulesets": {
+        "status": "verified",
+        "enforced": false,
+        "count": 0
+      },
+      "ci_check_presence": {
+        "schema_version": "loom-ci-check-presence/v1",
+        "workflow_exists": true,
+        "workflow_locator": ".github/workflows/loom-check.yml",
+        "stable_check_names": [
+          "py-compile",
+          "demo-bootstrap",
+          "repo-local-cli",
+          "loom-check"
+        ],
+        "check_ran": true,
+        "required_checks_configured": true,
+        "host_enforcement_status": "verified",
+        "recommended_action": "install the workflow and configure its stable check names as host-required checks"
+      },
+      "host_enforcement": {
+        "branch_protection_or_ruleset": true,
+        "required_checks": true,
+        "workflow_exists": true,
+        "check_ran": true,
+        "verification_status": "verified"
+      },
+      "api_snapshot": {
+        "schema_version": "loom-host-api-snapshot/v1",
+        "read_mode": "cached_non_merge",
+        "verification_status": "verified",
+        "fallback_status": null,
+        "cache_scope": "process",
+        "requests": [
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom",
+            "purpose": "repository default branch"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/branches/main",
+            "purpose": "branch protection"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/actions/workflows",
+            "purpose": "workflow presence"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/commits/main/check-runs",
+            "purpose": "recent check runs"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/rulesets",
+            "purpose": "branch ruleset enforcement"
+          }
+        ],
+        "errors": [],
+        "budget": {
+          "schema_version": "loom-host-api-budget/v1",
+          "default_non_merge_read_mode": "cached_non_merge",
+          "merge_gate_read_mode": "uncached_live_gate",
+          "cache_scope": "process",
+          "rest_first": true,
+          "graphql_allowed_when": "REST cannot express the required relationship",
+          "search_endpoint": "not_in_hot_path",
+          "polling": "not_in_hot_path",
+          "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
+          "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits"
+        }
+      }
     },
     "repo_interface": {
-      "availability": "absent",
+      "availability": "present",
       "manifest": {
-        "status": "missing",
+        "status": "present",
         "locator": ".loom/companion/manifest.json",
-        "source": "companion manifest"
+        "source": "repository scan"
       },
       "companion_entry": {
-        "status": "missing",
-        "locator": "unknown",
-        "source": "repo companion manifest"
+        "status": "present",
+        "locator": ".loom/companion/README.md",
+        "source": "repo companion interface.companion_entry"
       },
       "repo_specific_requirements": {
-        "status": "missing",
-        "locator": "unknown",
-        "source": "repo companion interface"
+        "status": "present",
+        "locator": ".loom/companion/repo-interface.json",
+        "source": "repo companion manifest.repo_interface"
       },
       "specialized_gates": {
-        "status": "missing",
-        "locator": "unknown",
-        "source": "repo companion interface"
+        "status": "present",
+        "locator": ".loom/companion/repo-interface.json",
+        "source": "repo companion manifest.repo_interface"
       },
-      "summary": "no repo companion interface is declared for this repository.",
+      "summary": "repo companion manifest and machine-readable repo interface are readable.",
       "missing_inputs": []
     },
     "repo_interop": {
-      "availability": "absent",
+      "availability": "present",
       "contract": {
-        "status": "missing",
+        "status": "present",
         "locator": ".loom/companion/interop.json",
         "source": "repository scan"
       },
       "host_adapters": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/companion/interop.json",
         "source": "repo interop contract"
       },
       "repo_native_carriers": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/companion/interop.json",
         "source": "repo interop contract"
       },
       "shadow_surfaces": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/companion/interop.json",
         "source": "repo interop contract"
       },
-      "summary": "no repo interop contract is declared for this repository.",
+      "summary": "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity.",
       "missing_inputs": []
+    },
+    "workspace_profile": {
+      "schema_version": "loom-workspace-profile/v1",
+      "selected": "single-workspace",
+      "selection_reason": "workspace_entry points at the repository root",
+      "profiles": {
+        "single-workspace": {
+          "summary": "Use the repository root as the Loom execution workspace.",
+          "host_worktree_required": false,
+          "recommended_action": "keep workspace_entry as `.` unless isolation becomes necessary"
+        },
+        "per-item-worktree": {
+          "summary": "Use one isolated workspace per Work Item, usually backed by host git worktree.",
+          "host_worktree_required": true,
+          "recommended_action": "ensure workspace, branch, Work Item, and PR bindings stay aligned"
+        },
+        "attach-existing": {
+          "summary": "Attach Loom to an existing repo-defined workspace without taking over host lifecycle actions.",
+          "host_worktree_required": false,
+          "recommended_action": "declare the repo-specific workspace locator and keep host lifecycle ownership external"
+        }
+      },
+      "workspace_entry": ".",
+      "workspace_path": ".",
+      "workspace_exists": true,
+      "host_worktree": {
+        "ownership": "host",
+        "status": "present",
+        "locator": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance"
+      },
+      "result": "pass",
+      "missing_inputs": [],
+      "recommended_action": "keep workspace_entry as `.` unless isolation becomes necessary"
+    },
+    "gate_starter": {
+      "schema_version": "loom-gate-starter/v1",
+      "aliases": {
+        "verify": {
+          "surface": "verification",
+          "entrypoint": ".loom/bin/loom_init.py",
+          "command": "python3 .loom/bin/loom_init.py verify --target .",
+          "authority": "local",
+          "enforcement": "advisory",
+          "host_enforcement": false,
+          "summary": "Run the repo-local Loom bootstrap verification entry.",
+          "runtime_present": true
+        },
+        "status": {
+          "surface": "status",
+          "entrypoint": ".loom/bin/loom_status.py",
+          "command": "python3 .loom/bin/loom_status.py --target . --item INIT-0001",
+          "authority": "local",
+          "enforcement": "advisory",
+          "host_enforcement": false,
+          "summary": "Read the repo-local Loom status surface.",
+          "runtime_present": true
+        },
+        "merge-ready": {
+          "surface": "merge_ready",
+          "entrypoint": ".loom/bin/loom_flow.py",
+          "command": "python3 .loom/bin/loom_flow.py flow merge-ready --target . --item INIT-0001",
+          "authority": "local",
+          "enforcement": "advisory",
+          "host_enforcement": false,
+          "summary": "Run Loom's local merge-ready orchestration without taking over host merge controls.",
+          "runtime_present": true
+        },
+        "closeout-check": {
+          "surface": "closeout",
+          "entrypoint": ".loom/bin/loom_flow.py",
+          "command": "python3 .loom/bin/loom_flow.py closeout check --target .",
+          "authority": "local",
+          "enforcement": "advisory",
+          "host_enforcement": false,
+          "summary": "Check closeout readiness against local Loom carriers and readable host inputs.",
+          "runtime_present": true
+        },
+        "reconciliation-audit": {
+          "surface": "reconciliation",
+          "entrypoint": ".loom/bin/loom_flow.py",
+          "command": "python3 .loom/bin/loom_flow.py reconciliation audit --target .",
+          "authority": "local",
+          "enforcement": "advisory",
+          "host_enforcement": false,
+          "summary": "Audit closeout drift without mutating host state.",
+          "runtime_present": true
+        }
+      },
+      "runtime_status": "present",
+      "authority": "local",
+      "enforcement": "advisory",
+      "host_enforcement": false,
+      "host_enforcement_status": "not_host_enforced",
+      "result": "pass",
+      "missing_inputs": [],
+      "missing_entrypoints": [],
+      "recommended_action": "run the repo-local aliases as advisory Loom checks, then configure host-required checks separately"
     },
     "governance_control_plane": {
       "schema_version": "loom-governance-control/v1",
@@ -408,7 +584,104 @@
           "implementation_pr": "work_item",
           "merge_commit": "closeout"
         },
-        "result": "block"
+        "result": "pass"
+      },
+      "workspace_profile": {
+        "schema_version": "loom-workspace-profile/v1",
+        "selected": "single-workspace",
+        "selection_reason": "workspace_entry points at the repository root",
+        "profiles": {
+          "single-workspace": {
+            "summary": "Use the repository root as the Loom execution workspace.",
+            "host_worktree_required": false,
+            "recommended_action": "keep workspace_entry as `.` unless isolation becomes necessary"
+          },
+          "per-item-worktree": {
+            "summary": "Use one isolated workspace per Work Item, usually backed by host git worktree.",
+            "host_worktree_required": true,
+            "recommended_action": "ensure workspace, branch, Work Item, and PR bindings stay aligned"
+          },
+          "attach-existing": {
+            "summary": "Attach Loom to an existing repo-defined workspace without taking over host lifecycle actions.",
+            "host_worktree_required": false,
+            "recommended_action": "declare the repo-specific workspace locator and keep host lifecycle ownership external"
+          }
+        },
+        "workspace_entry": ".",
+        "workspace_path": ".",
+        "workspace_exists": true,
+        "host_worktree": {
+          "ownership": "host",
+          "status": "present",
+          "locator": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance"
+        },
+        "result": "pass",
+        "missing_inputs": [],
+        "recommended_action": "keep workspace_entry as `.` unless isolation becomes necessary"
+      },
+      "gate_starter": {
+        "schema_version": "loom-gate-starter/v1",
+        "aliases": {
+          "verify": {
+            "surface": "verification",
+            "entrypoint": ".loom/bin/loom_init.py",
+            "command": "python3 .loom/bin/loom_init.py verify --target .",
+            "authority": "local",
+            "enforcement": "advisory",
+            "host_enforcement": false,
+            "summary": "Run the repo-local Loom bootstrap verification entry.",
+            "runtime_present": true
+          },
+          "status": {
+            "surface": "status",
+            "entrypoint": ".loom/bin/loom_status.py",
+            "command": "python3 .loom/bin/loom_status.py --target . --item INIT-0001",
+            "authority": "local",
+            "enforcement": "advisory",
+            "host_enforcement": false,
+            "summary": "Read the repo-local Loom status surface.",
+            "runtime_present": true
+          },
+          "merge-ready": {
+            "surface": "merge_ready",
+            "entrypoint": ".loom/bin/loom_flow.py",
+            "command": "python3 .loom/bin/loom_flow.py flow merge-ready --target . --item INIT-0001",
+            "authority": "local",
+            "enforcement": "advisory",
+            "host_enforcement": false,
+            "summary": "Run Loom's local merge-ready orchestration without taking over host merge controls.",
+            "runtime_present": true
+          },
+          "closeout-check": {
+            "surface": "closeout",
+            "entrypoint": ".loom/bin/loom_flow.py",
+            "command": "python3 .loom/bin/loom_flow.py closeout check --target .",
+            "authority": "local",
+            "enforcement": "advisory",
+            "host_enforcement": false,
+            "summary": "Check closeout readiness against local Loom carriers and readable host inputs.",
+            "runtime_present": true
+          },
+          "reconciliation-audit": {
+            "surface": "reconciliation",
+            "entrypoint": ".loom/bin/loom_flow.py",
+            "command": "python3 .loom/bin/loom_flow.py reconciliation audit --target .",
+            "authority": "local",
+            "enforcement": "advisory",
+            "host_enforcement": false,
+            "summary": "Audit closeout drift without mutating host state.",
+            "runtime_present": true
+          }
+        },
+        "runtime_status": "present",
+        "authority": "local",
+        "enforcement": "advisory",
+        "host_enforcement": false,
+        "host_enforcement_status": "not_host_enforced",
+        "result": "pass",
+        "missing_inputs": [],
+        "missing_entrypoints": [],
+        "recommended_action": "run the repo-local aliases as advisory Loom checks, then configure host-required checks separately"
       },
       "host_binding": {
         "schema_version": "loom-host-binding/v1",
@@ -424,18 +697,18 @@
             "authority": "github-profile"
           },
           "work_item": {
-            "status": "missing",
-            "locator": "unknown",
+            "status": "present",
+            "locator": ".loom/work-items/INIT-0001.md",
             "authority": "loom fact chain"
           },
           "branch": {
             "status": "present",
-            "locator": "feat/loom-self-adoption-carrier",
+            "locator": "work/536-fact-chain-provenance",
             "authority": "git"
           },
           "worktree": {
             "status": "present",
-            "locator": "/Users/mc/dev/Loom",
+            "locator": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance",
             "authority": "git"
           },
           "implementation_pr": {
@@ -449,17 +722,15 @@
             "authority": "host"
           },
           "closeout": {
-            "status": "host-managed",
+            "status": "present",
             "locator": "reconciliation audit + closeout gate",
             "authority": "loom + host"
           }
         },
         "default_branch": "main",
-        "missing_inputs": [
-          "work_item"
-        ],
-        "result": "block",
-        "summary": "host binding surface is readable, but required binding facts are missing or host-managed."
+        "missing_inputs": [],
+        "result": "pass",
+        "summary": "host binding surface can relate the active Work Item to branch, worktree, PR, merge commit, and closeout."
       },
       "taxonomy": {
         "spec_stale": "Approved spec no longer covers the implementation surface.",
@@ -538,9 +809,13 @@
       ],
       "maturity": {
         "schema_version": "loom-governance-maturity/v1",
-        "current": "unadopted",
-        "achieved": [],
-        "next": "light",
+        "current": "strong",
+        "achieved": [
+          "light",
+          "standard",
+          "strong"
+        ],
+        "next": null,
         "levels": {
           "light": {
             "requires": [
@@ -569,6 +844,10 @@
               "standard",
               "repo_interface",
               "repo_interop",
+              "host_enforced_control_plane",
+              "pr_merge_path",
+              "controlled_merge_basis",
+              "closeout_basis",
               "github_controlled_merge"
             ],
             "summary": "Host-backed binding, reconciliation, controlled merge, and closeout gates are available."
@@ -677,130 +956,51 @@
               "required": true,
               "defaulting": "host",
               "recommended_action": "enable controlled merge binding and required host gates"
+            },
+            {
+              "id": "host_enforced_control_plane",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "host",
+              "recommended_action": "verify branch protection or ruleset enforcement plus required checks before claiming strong governance"
+            },
+            {
+              "id": "pr_merge_path",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "host",
+              "recommended_action": "prove the PR merge path is host-owned and readable before strong governance"
+            },
+            {
+              "id": "controlled_merge_basis",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "host",
+              "recommended_action": "prove controlled merge depends on verified host checks instead of local aliases"
+            },
+            {
+              "id": "closeout_basis",
+              "layer": "github-profile",
+              "required": true,
+              "defaulting": "host",
+              "recommended_action": "prove closeout consumes merge commit and reconciliation basis before strong governance"
             }
           ]
         },
         "missing_by_level": {
-          "light": [
-            "work_item",
-            "recovery",
-            "status_surface",
-            "review"
-          ],
-          "standard": [
-            "light",
-            "fr_work_item_layer",
-            "spec_path",
-            "plan_path",
-            "spec_gate",
-            "basic_host_binding",
-            "closeout_reconciliation_read"
-          ],
-          "strong": [
-            "standard",
-            "repo_interface",
-            "repo_interop",
-            "github_controlled_merge"
-          ]
+          "light": [],
+          "standard": [],
+          "strong": []
         },
         "missing_details_by_level": {
-          "light": [
-            {
-              "id": "work_item",
-              "layer": "core",
-              "required": true,
-              "defaulting": "generated",
-              "recommended_action": "run loom-init or restore the Work Item carrier"
-            },
-            {
-              "id": "recovery",
-              "layer": "core",
-              "required": true,
-              "defaulting": "generated",
-              "recommended_action": "restore the recovery carrier"
-            },
-            {
-              "id": "status_surface",
-              "layer": "core",
-              "required": true,
-              "defaulting": "generated",
-              "recommended_action": "restore the status surface carrier"
-            },
-            {
-              "id": "review",
-              "layer": "core",
-              "required": true,
-              "defaulting": "generated",
-              "recommended_action": "restore the review carrier"
-            }
-          ],
-          "standard": [
-            {
-              "id": "fr_work_item_layer",
-              "layer": "github-profile",
-              "required": true,
-              "defaulting": "profile",
-              "recommended_action": "declare the FR -> Work Item split through the GitHub profile upgrade path"
-            },
-            {
-              "id": "spec_path",
-              "layer": "core",
-              "required": true,
-              "defaulting": "generated",
-              "recommended_action": "install formal spec scaffold"
-            },
-            {
-              "id": "plan_path",
-              "layer": "core",
-              "required": true,
-              "defaulting": "generated",
-              "recommended_action": "install execution plan scaffold"
-            },
-            {
-              "id": "spec_gate",
-              "layer": "core",
-              "required": true,
-              "defaulting": "generated",
-              "recommended_action": "record or restore the spec review gate"
-            },
-            {
-              "id": "basic_host_binding",
-              "layer": "github-profile",
-              "required": true,
-              "defaulting": "profile",
-              "recommended_action": "run governance-profile binding and repair missing host bindings"
-            },
-            {
-              "id": "closeout_reconciliation_read",
-              "layer": "github-profile",
-              "required": true,
-              "defaulting": "profile",
-              "recommended_action": "install repo interop so closeout can consume reconciliation"
-            }
-          ],
-          "strong": [
-            {
-              "id": "repo_interface",
-              "layer": "repo-owned-residue",
-              "required": true,
-              "defaulting": "scaffold",
-              "recommended_action": "install or repair the repo companion interface"
-            },
-            {
-              "id": "repo_interop",
-              "layer": "repo-owned-residue",
-              "required": true,
-              "defaulting": "scaffold",
-              "recommended_action": "install or repair the repo interop contract"
-            },
-            {
-              "id": "github_controlled_merge",
-              "layer": "github-profile",
-              "required": true,
-              "defaulting": "host",
-              "recommended_action": "enable controlled merge binding and required host gates"
-            }
-          ]
+          "light": [],
+          "standard": [],
+          "strong": []
+        },
+        "fresh_adoption": {
+          "repository_mode": "complex-existing",
+          "max_default_maturity": "light",
+          "applied": false
         },
         "gate_rollout": {
           "schema_version": "loom-adoption-gate-rollout/v1",
@@ -825,7 +1025,7 @@
           "blocking_preconditions": [
             {
               "id": "strong_maturity",
-              "status": "missing",
+              "status": "pass",
               "layer": "github-profile",
               "recommended_action": "upgrade the repository to strong maturity before enabling blocking gates"
             },
@@ -833,7 +1033,7 @@
               "id": "adversarial_adoption_checks",
               "status": "missing",
               "layer": "core",
-              "recommended_action": "run the Loom-owned Syvert-style adversarial adoption fixture and record the validation evidence"
+              "recommended_action": "run the Loom-owned strong-governance adversarial adoption fixture and record the validation evidence"
             },
             {
               "id": "rollback_switch",
@@ -850,54 +1050,17 @@
         }
       }
     },
-    "summary": "resume chain is only partially supported because governance carriers or GitHub control-plane signals are incomplete.",
-    "missing_inputs": [
-      "no stable Loom carriers are readable yet",
-      "host binding: work_item"
-    ]
+    "summary": "resume chain is readable and the current governance carriers can support continued execution.",
+    "missing_inputs": []
   },
   "maturity_upgrade_path": {
-    "result": "block",
-    "current": "unadopted",
-    "next": "light",
-    "missing_inputs": [
-      "work_item",
-      "recovery",
-      "status_surface",
-      "review"
-    ],
-    "missing_details": [
-      {
-        "id": "work_item",
-        "layer": "core",
-        "required": true,
-        "defaulting": "generated",
-        "recommended_action": "run loom-init or restore the Work Item carrier"
-      },
-      {
-        "id": "recovery",
-        "layer": "core",
-        "required": true,
-        "defaulting": "generated",
-        "recommended_action": "restore the recovery carrier"
-      },
-      {
-        "id": "status_surface",
-        "layer": "core",
-        "required": true,
-        "defaulting": "generated",
-        "recommended_action": "restore the status surface carrier"
-      },
-      {
-        "id": "review",
-        "layer": "core",
-        "required": true,
-        "defaulting": "generated",
-        "recommended_action": "restore the review carrier"
-      }
-    ],
-    "fallback_to": "adoption",
-    "upgrade_entry": "python3 .loom/bin/loom_flow.py governance-profile upgrade --target . --to light --dry-run",
+    "result": "pass",
+    "current": "strong",
+    "next": null,
+    "missing_inputs": [],
+    "missing_details": [],
+    "fallback_to": null,
+    "upgrade_entry": null,
     "validation_entries": [
       "python3 .loom/bin/loom_flow.py governance-profile status --target .",
       "python3 .loom/bin/loom_flow.py governance-profile upgrade-plan --target ."
@@ -925,7 +1088,7 @@
       "blocking_preconditions": [
         {
           "id": "strong_maturity",
-          "status": "missing",
+          "status": "pass",
           "layer": "github-profile",
           "recommended_action": "upgrade the repository to strong maturity before enabling blocking gates"
         },
@@ -933,7 +1096,7 @@
           "id": "adversarial_adoption_checks",
           "status": "missing",
           "layer": "core",
-          "recommended_action": "run the Loom-owned Syvert-style adversarial adoption fixture and record the validation evidence"
+          "recommended_action": "run the Loom-owned strong-governance adversarial adoption fixture and record the validation evidence"
         },
         {
           "id": "rollback_switch",

--- a/.loom/bootstrap/intake.snapshot.json
+++ b/.loom/bootstrap/intake.snapshot.json
@@ -1,13 +1,13 @@
 {
   "schema_version": "loom-init-intake/v1",
   "repository_type": "existing",
-  "root_boundary_docs": "clear",
+  "root_boundary_docs": "partial",
   "ci_or_basic_tests": true,
   "repository_level_validation_entry": true,
-  "primary_gap_category": "spec-path",
+  "primary_gap_category": "governance",
   "long_running_recovery_pain": true,
   "shared_contract_or_high_risk_boundary": true,
-  "purity_or_scope_signals": "clean",
+  "purity_or_scope_signals": "severe",
   "merge_review_semantic_overload": false,
   "notes": "autodetected by loom_init.py"
 }

--- a/.loom/bootstrap/manifest.json
+++ b/.loom/bootstrap/manifest.json
@@ -41,7 +41,7 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "78cf0d0022a4c03933a5e46cba676e80cafa5d0802fb95191a761ec9f9417e65"
+      "sha256": "5d10e10d459269dd718b3385ee13019f564f361cad696965122745b0d329078b"
     },
     {
       "path": ".loom/bin/governance_surface.py",
@@ -53,13 +53,13 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "d67ffd22cacad33d25e1a4ef5dc90b57eb7143aae7a9a65420fcbdcb38fc701d"
+      "sha256": "216adef334fa5db5596d989155e03eb2222bc54b10b64fa2b4f19b92eddba72b"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "229ecdf3171aab0df302fd9662f5a9ce6371e7b8f194ece341909d38ce268bed"
+      "sha256": "e8814b5ef11c120a7909e48f7d3a648f5ce9baf1dde14425f02c9db072495f36"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "e0d0178b76619a82a6d616db872a57efaea90e635bfe0883ef318e42e937232c"
+      "sha256": "09297502d6a5c54a147791dae1e1fa93d0dbee3fc772e3e1230f9726688037e8"
     },
     {
       "path": "AGENTS.md",
@@ -123,6 +123,11 @@
       "path": ".loom/specs/INIT-0001/implementation-contract.md",
       "kind": "implementation-contract",
       "source": "skills/shared/assets/templates/scaffold/implementation-contract.md"
+    },
+    {
+      "path": ".github/PULL_REQUEST_TEMPLATE.md",
+      "kind": "pr-template",
+      "source": "skills/shared/assets/github/PULL_REQUEST_TEMPLATE.md"
     }
   ]
 }

--- a/.loom/companion/README.md
+++ b/.loom/companion/README.md
@@ -1,21 +1,16 @@
-# Loom Self-Governance Companion
+# Repo Companion
 
-This companion declares the repository-owned boundary for Loom managing its own product iteration.
+This companion entry attaches Loom to the existing repository governance surface.
 
-## Managed Scope
+## Preserved Ownership
 
-- Loom core and product iteration are self-managed through the root `.loom` carrier.
-- The next managed productization phase is GitHub issue #410: `Phase: Agent-assisted zero-friction adoption`.
-- Work under #410 must enter execution through Loom Work Items, review records, gate checks, and closeout evidence.
+- Root rules remain in the repository's existing boundary docs.
+- Retained host actions stay host-owned.
+- Repo-native carriers remain the source of truth until a later Loom interop slice stabilizes.
 
-## Boundary
+## Loom Entry Surfaces
 
-- Downstream repositories such as Syvert and WebEnvoy remain adoption fixtures and evidence sources, not root truth for Loom.
-- Repo-specific downstream policies must stay in each downstream repo companion or residue layer.
-- This companion does not make all Loom signals blocking by default; advisory-to-blocking remains explicit and evidence-based.
-
-## Evidence
-
-- Self-governance adoption validation: `docs/evidence/validations/validation-loom-self-governance-adoption.md`
-- Root carrier status: `.loom/status/current.md`
-- Root validation entry: `python3 .loom/bin/loom_init.py verify --target .`
+- Review surface: `.loom/companion/review.md`
+- Merge-ready surface: `.loom/companion/merge-ready.md`
+- Closeout surface: `.loom/companion/closeout.md`
+- Checkpoints surface: `.loom/companion/checkpoints.md`

--- a/.loom/companion/interop.json
+++ b/.loom/companion/interop.json
@@ -1,47 +1,37 @@
 {
   "schema_version": "loom-repo-interop/v1",
-  "host_adapters": [
-    {
-      "id": "github-actions-root-self-governance",
-      "summary": "Read GitHub Actions checks that consume the root Loom carrier.",
-      "surfaces": [
-        "build",
-        "merge_ready"
-      ],
-      "locator": ".github/workflows/loom-check.yml"
-    }
-  ],
+  "host_adapters": [],
   "repo_native_carriers": [
     {
-      "id": "loom-self-governance-evidence",
-      "summary": "Repo-local evidence that binds #410 to the Loom self-managed workflow.",
+      "id": "generated-companion-residue",
+      "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
       "surfaces": [
         "admission",
         "review",
         "merge_ready",
         "closeout"
       ],
-      "locator": "docs/evidence/validations/validation-loom-self-governance-adoption.md"
+      "locator": ".loom/companion"
     }
   ],
   "shadow_surfaces": {
     "admission": {
-      "summary": "Compare self-governance admission parity between Loom and repo-local evidence.",
+      "summary": "Compare admission parity between Loom and the repo-native result.",
       "loom_locator": ".loom/shadow/admission-loom.json",
       "repo_locator": ".loom/shadow/admission-repo.json"
     },
     "review": {
-      "summary": "Compare self-governance review parity between Loom and repo-local evidence.",
+      "summary": "Compare review parity between Loom and the repo-native result.",
       "loom_locator": ".loom/shadow/review-loom.json",
       "repo_locator": ".loom/shadow/review-repo.json"
     },
     "merge_ready": {
-      "summary": "Compare self-governance merge-ready parity between Loom and repo-local evidence.",
+      "summary": "Compare merge_ready parity between Loom and the repo-native result.",
       "loom_locator": ".loom/shadow/merge-ready-loom.json",
       "repo_locator": ".loom/shadow/merge-ready-repo.json"
     },
     "closeout": {
-      "summary": "Compare self-governance closeout parity between Loom and repo-local evidence.",
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
       "loom_locator": ".loom/shadow/closeout-loom.json",
       "repo_locator": ".loom/shadow/closeout-repo.json"
     }

--- a/.loom/companion/repo-interface.json
+++ b/.loom/companion/repo-interface.json
@@ -6,40 +6,21 @@
     "merge_ready": [],
     "closeout": []
   },
-  "specialized_gates": [
-    {
-      "id": "loom-root-self-governance-ci",
-      "summary": "Root Loom carrier must be consumed by CI and local loom_check before product iteration merges.",
-      "locator": ".github/workflows/loom-check.yml",
-      "gate_type": "build"
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": "loom_default",
+      "mode": "loom_default"
     },
-    {
-      "id": "loom-root-carrier-drift-check",
-      "summary": "Root self-adoption carrier drift is checked through loom_check root-self-adoption surface.",
-      "locator": "skills/shared/scripts/loom_check.py",
-      "gate_type": "build"
+    "implementation_review": {
+      "locator": "loom_default",
+      "mode": "loom_default"
     }
-  ],
+  },
   "metadata_contract": {
-    "fields": [
-      {
-        "id": "next_managed_iteration",
-        "summary": "Declares the next Loom productization phase that must consume the root self-governance carrier.",
-        "applicability_locator": ".loom/companion/README.md",
-        "authority_locator": "docs/evidence/validations/validation-loom-self-governance-adoption.md",
-        "enforcement": "advisory"
-      }
-    ]
+    "fields": []
   },
   "context_schema": {
-    "fields": [
-      {
-        "id": "github_phase_issue",
-        "summary": "GitHub phase issue used to bind a Loom product iteration to the self-managed workflow.",
-        "type": "integer",
-        "required": true,
-        "mapping_rule_locator": "docs/evidence/validations/validation-loom-self-governance-adoption.md"
-      }
-    ]
+    "fields": []
   }
 }

--- a/.loom/progress/INIT-0001.md
+++ b/.loom/progress/INIT-0001.md
@@ -3,10 +3,10 @@
 ## Dynamic Facts
 
 - Item ID: INIT-0001
-- Current Checkpoint: merge checkpoint
-- Current Stop: Behavior-first operating-layer closeout slice is on PR #476 with local gates and root carriers aligned.
-- Next Step: Wait for PR #476 CI/review, merge through GitHub, then reconcile #440-#446, #474, #447-#473, and #439.
+- Current Checkpoint: build checkpoint
+- Current Stop: Bootstrap artifacts have been generated and are awaiting downstream review.
+- Next Step: Accept the generated Loom entry and promote the first real repository work item.
 - Blockers: None recorded.
-- Latest Validation Summary: Root .loom/bin verify passed; carrier refresh dry-run has no runtime provenance drift; loom_check gates cover behavior-first docs, locators, and carrier evidence.
+- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.
 - Recovery Boundary: Bootstrap result at `.loom/bootstrap/init-result.json`; bootstrap manifest at `.loom/bootstrap/manifest.json`.
-- Current Lane: behavior-first operating-layer closeout
+- Current Lane: bootstrap verification only

--- a/.loom/reviews/INIT-0001.json
+++ b/.loom/reviews/INIT-0001.json
@@ -1,23 +1,17 @@
 {
   "schema_version": "loom-review/v1",
   "item_id": "INIT-0001",
-  "decision": "allow",
-  "kind": "code_review",
-  "summary": "Behavior-first operating-layer closeout slice reviewed after root runtime, companion, status carrier synchronization, and installer version-gate repair.",
-  "reviewer": "codex-review",
-  "reviewed_head": "b3a7216e2dd868c8b08ca33b62a58fac5235818d",
-  "reviewed_validation_summary": "Root .loom/bin verify passed; carrier refresh dry-run has no runtime provenance drift; loom_check gates cover behavior-first docs, locators, and carrier evidence.",
-  "fallback_to": null,
-  "findings": [],
-  "blocking_issues": [],
-  "follow_ups": [],
-  "consumed_inputs": {
-    "work_item": ".loom/work-items/INIT-0001.md",
-    "recovery_entry": ".loom/progress/INIT-0001.md",
-    "status_surface": ".loom/status/current.md",
-    "build_checkpoint": "pass",
-    "engine_adapter": null,
-    "engine_evidence": null,
-    "normalized_findings": null
-  }
+  "decision": "fallback",
+  "kind": "general_review",
+  "summary": "Bootstrap has not entered formal review yet.",
+  "reviewer": "not yet assigned",
+  "reviewed_head": "bootstrap-placeholder",
+  "reviewed_validation_summary": "Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+  "fallback_to": "admission",
+  "blocking_issues": [
+    "Formal review starts only after downstream work replaces the bootstrap placeholder item."
+  ],
+  "follow_ups": [
+    "Record the first real semantic review before asking merge checkpoint to consume reviewer judgment."
+  ]
 }

--- a/.loom/reviews/INIT-0001.spec.json
+++ b/.loom/reviews/INIT-0001.spec.json
@@ -1,23 +1,17 @@
 {
   "schema_version": "loom-review/v1",
   "item_id": "INIT-0001",
-  "decision": "allow",
+  "decision": "fallback",
   "kind": "spec_review",
-  "summary": "Self-governance adoption spec is approved for binding Loom future iteration to its own workflow.",
-  "reviewer": "codex-self-governance",
-  "reviewed_head": "c9bd5dd7ebf2813069455f71bff931f25631b432",
+  "summary": "Formal spec review has not been completed yet.",
+  "reviewer": "not yet assigned",
+  "reviewed_head": "bootstrap-placeholder",
   "reviewed_validation_summary": "Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
-  "fallback_to": null,
-  "findings": [],
-  "blocking_issues": [],
-  "follow_ups": [],
-  "consumed_inputs": {
-    "work_item": ".loom/work-items/INIT-0001.md",
-    "recovery_entry": ".loom/progress/INIT-0001.md",
-    "status_surface": ".loom/status/current.md",
-    "build_checkpoint": "pass",
-    "engine_adapter": null,
-    "engine_evidence": null,
-    "normalized_findings": null
-  }
+  "fallback_to": "admission",
+  "blocking_issues": [
+    "Spec gate remains open until the formal spec path receives its own review record."
+  ],
+  "follow_ups": [
+    "Record a spec_review decision before implementation review or merge-ready consumes the formal spec path."
+  ]
 }

--- a/.loom/shadow/admission-loom.json
+++ b/.loom/shadow/admission-loom.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "admission",
-  "side": "loom",
   "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
   "source_files": [
-    ".loom/work-items/INIT-0001.md",
-    ".loom/status/current.md"
+    ".loom/work-items/INIT-0001.md"
   ],
   "source_sha256": {
-    ".loom/work-items/INIT-0001.md": "48ae465e436b635d2eeb69943f83c8e9229c51ab92a080b1e37e92b24d3599d3",
-    ".loom/status/current.md": "b26bcac92dcffbc0c61e4677d0265ca70b35bfc4ba641ac75a344501fd47f1ac"
+    ".loom/work-items/INIT-0001.md": "48ae465e436b635d2eeb69943f83c8e9229c51ab92a080b1e37e92b24d3599d3"
   }
 }

--- a/.loom/shadow/admission-repo.json
+++ b/.loom/shadow/admission-repo.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "admission",
-  "side": "repo",
   "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
   "source_files": [
-    ".loom/work-items/INIT-0001.md",
-    ".loom/status/current.md"
+    ".loom/companion/checkpoints.md"
   ],
   "source_sha256": {
-    ".loom/work-items/INIT-0001.md": "48ae465e436b635d2eeb69943f83c8e9229c51ab92a080b1e37e92b24d3599d3",
-    ".loom/status/current.md": "b26bcac92dcffbc0c61e4677d0265ca70b35bfc4ba641ac75a344501fd47f1ac"
+    ".loom/companion/checkpoints.md": "245e9e323298d30fb2023b767ba502c998fcf9bfeff23f518062d2a15b7ffc18"
   }
 }

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "closeout",
-  "side": "loom",
-  "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
+  "result": "done",
   "source_files": [
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md",
-    ".loom/companion/README.md"
+    ".loom/status/current.md"
   ],
   "source_sha256": {
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md": "9733d396aae304e14699178cb612ee53f82a8394f6de164d408746a4f67b76ae",
-    ".loom/companion/README.md": "542c46089dceb64cadc1f8b2f2615feb959a95cf7a645c218f8746e1194cbff0"
+    ".loom/status/current.md": "94986ff8feee998e4ccb4b5fb7e7122f65576536b9bd099c7cf800f437ca8cf5"
   }
 }

--- a/.loom/shadow/closeout-repo.json
+++ b/.loom/shadow/closeout-repo.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "closeout",
-  "side": "repo",
-  "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
+  "result": "done",
   "source_files": [
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md",
-    ".loom/companion/README.md"
+    ".loom/companion/closeout.md"
   ],
   "source_sha256": {
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md": "9733d396aae304e14699178cb612ee53f82a8394f6de164d408746a4f67b76ae",
-    ".loom/companion/README.md": "542c46089dceb64cadc1f8b2f2615feb959a95cf7a645c218f8746e1194cbff0"
+    ".loom/companion/closeout.md": "78e8292cbae37851a38132b6df64087ac937025a4582aa861b4a64861f50a5a7"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "merge_ready",
-  "side": "loom",
   "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
   "source_files": [
-    ".github/workflows/loom-check.yml",
-    "skills/shared/scripts/loom_check.py"
+    ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".github/workflows/loom-check.yml": "94497e146bf2ff0d8652c56bdde95fe9743f76dcfd666f8a3d04b22a8d32d787",
-    "skills/shared/scripts/loom_check.py": "b0b313d362912d5b71b0c3897a64cb7073720041c8c4cdd67ba939f6312c5a50"
+    ".loom/status/current.md": "94986ff8feee998e4ccb4b5fb7e7122f65576536b9bd099c7cf800f437ca8cf5"
   }
 }

--- a/.loom/shadow/merge-ready-repo.json
+++ b/.loom/shadow/merge-ready-repo.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "merge_ready",
-  "side": "repo",
   "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
   "source_files": [
-    ".github/workflows/loom-check.yml",
-    "skills/shared/scripts/loom_check.py"
+    ".loom/companion/merge-ready.md"
   ],
   "source_sha256": {
-    ".github/workflows/loom-check.yml": "94497e146bf2ff0d8652c56bdde95fe9743f76dcfd666f8a3d04b22a8d32d787",
-    "skills/shared/scripts/loom_check.py": "b0b313d362912d5b71b0c3897a64cb7073720041c8c4cdd67ba939f6312c5a50"
+    ".loom/companion/merge-ready.md": "9abde0cc15d2dc28f73f853005deca8f4929ac19877f9035136a7f442aad5471"
   }
 }

--- a/.loom/shadow/review-loom.json
+++ b/.loom/shadow/review-loom.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "review",
-  "side": "loom",
   "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
   "source_files": [
-    ".loom/reviews/INIT-0001.json",
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md"
+    ".loom/reviews/INIT-0001.json"
   ],
   "source_sha256": {
-    ".loom/reviews/INIT-0001.json": "5cc02b2da863be9b4638b8391c3dfc71adfe9d09254cd4645253caba2e1ed6c6",
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md": "9733d396aae304e14699178cb612ee53f82a8394f6de164d408746a4f67b76ae"
+    ".loom/reviews/INIT-0001.json": "cac159984acac0278a6c34c8ded267f23b00286efcca632a98e78055313fcaf4"
   }
 }

--- a/.loom/shadow/review-repo.json
+++ b/.loom/shadow/review-repo.json
@@ -1,15 +1,9 @@
 {
-  "schema_version": "loom-shadow-evidence/v1",
-  "surface": "review",
-  "side": "repo",
   "result": "pass",
-  "parity_value": "self-governance-advisory-pass",
   "source_files": [
-    ".loom/reviews/INIT-0001.json",
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md"
+    ".loom/companion/review.md"
   ],
   "source_sha256": {
-    ".loom/reviews/INIT-0001.json": "5cc02b2da863be9b4638b8391c3dfc71adfe9d09254cd4645253caba2e1ed6c6",
-    "docs/evidence/validations/validation-loom-self-governance-adoption.md": "9733d396aae304e14699178cb612ee53f82a8394f6de164d408746a4f67b76ae"
+    ".loom/companion/review.md": "87834ecdeef377b051387ecaacd29c8ae3d7a3587968e16842c2e5f97de51981"
   }
 }

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,25 +11,31 @@
 - Review Entry: .loom/reviews/INIT-0001.json
 - Validation Entry: python3 .loom/bin/loom_init.py verify --target .
 - Closing Condition: The generated entry, work item, recovery entry, and templates are readable and verified
-- Current Checkpoint: merge checkpoint
-- Current Stop: Behavior-first operating-layer closeout slice is on PR #476 with local gates and root carriers aligned.
-- Next Step: Wait for PR #476 CI/review, merge through GitHub, then reconcile #440-#446, #474, #447-#473, and #439.
+- Current Checkpoint: build checkpoint
+- Current Stop: Bootstrap artifacts have been generated and are awaiting downstream review.
+- Next Step: Accept the generated Loom entry and promote the first real repository work item.
 - Blockers: None recorded.
-- Latest Validation Summary: Root .loom/bin verify passed; carrier refresh dry-run has no runtime provenance drift; loom_check gates cover behavior-first docs, locators, and carrier evidence.
+- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.
 - Recovery Boundary: Bootstrap result at `.loom/bootstrap/init-result.json`; bootstrap manifest at `.loom/bootstrap/manifest.json`.
-- Current Lane: behavior-first operating-layer closeout
+- Current Lane: bootstrap verification only
 
-## Self-Governance Binding
+## Governance Status
 
-- Managed Scope: Loom core and product iteration
-- Next Managed Phase: #439 Phase: Behavior-first project operating layer
-- Next Managed FRs: #440 #441 #442 #443 #444 #445 #446 #474
-- Next Managed Work Items: #447-#473
-- Companion Entry: .loom/companion/README.md
-- Repo Interface: .loom/companion/repo-interface.json
-- Repo Interop: .loom/companion/interop.json
-- Evidence Entry: docs/evidence/validations/validation-loom-self-governance-adoption.md
-- Boundary: downstream examples and adopted repositories remain fixtures, not root truth
+- Item Key: INIT-0001
+- Item Type: work_item
+- Phase: not_declared
+- FR: not_declared
+- Release: not_declared
+- Sprint: not_declared
+- Head SHA: bootstrap-placeholder
+- Status: planning
+- Spec Entry: .loom/specs/INIT-0001/spec.md
+- Plan Entry: .loom/specs/INIT-0001/plan.md
+- Implementation Contract Entry: .loom/specs/INIT-0001/implementation-contract.md
+- Spec Review Entry: .loom/reviews/INIT-0001.spec.json
+- Spec Review Status: pending
+- Review Head Status: bootstrap-placeholder
+- Merge Gate Status: pending
 
 ## Runtime Evidence
 

--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -24,6 +24,8 @@
 
 review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
 
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
 ## 2. `.loom/companion/interop.json`
 
 当前稳定 schema：
@@ -79,6 +81,7 @@ review instruction locator 属于 [repo-companion-contract.md](./repo-companion-
 - `surfaces` 必须是非空数组
 - `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
 - `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
 
 典型对象包括：
 
@@ -100,6 +103,8 @@ review instruction locator 属于 [repo-companion-contract.md](./repo-companion-
 
 - `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
 - 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
 
 典型对象包括：
 
@@ -130,6 +135,7 @@ review instruction locator 属于 [repo-companion-contract.md](./repo-companion-
 - 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
 - `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
 - `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
 
 ### 5.1 shadow evidence envelope
 
@@ -162,6 +168,8 @@ review instruction locator 属于 [repo-companion-contract.md](./repo-companion-
 - `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
 
 任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
 
 ### 5.2 blocking 消费模式
 
@@ -244,6 +252,7 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
 
 - 不把 interop 细节塞回 `repo-interface.json`
 - 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
 - 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
 - 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
 - 不让 Loom 因为读取了 interop contract，就接管宿主底层实现

--- a/docs/methodology/governance/truth-and-sync-boundary.md
+++ b/docs/methodology/governance/truth-and-sync-boundary.md
@@ -14,6 +14,7 @@
 - 哪些对象只能承接 host control truth
 - 哪些对象只是派生读面或运行证据
 - Loom 如何同步，而不是复制第二套真相
+- mirror、retained result 与 derived surface 如何带 provenance 被消费
 
 字段级事实链仍以 [../harness/fact-chain-contract.md](../harness/fact-chain-contract.md) 为准。
 
@@ -29,6 +30,10 @@ Loom 当前固定四层：
   - 从前两层派生的读面
 - runtime / review evidence
   - 被消费的运行或审查证据
+
+读取优先级固定为：authored truth 优先，其次只读消费 host control truth / mirror 与 retained result，最后消费 derived read surfaces。后两者只能解释、证明或暴露 drift，不得反向创建第二套 authored truth。
+
+`init-result` 或 companion locator 的先读只属于 locator discovery，不改变上述事实优先级。
 
 ## 3. Repo Execution Truth
 
@@ -73,6 +78,15 @@ Loom 当前固定四层：
 
 它们不是 repo execution truth 的替代品。
 
+host control truth 被 repo-local 读取后形成的 mirror 只允许承接：
+
+- host object locator
+- 当前 host control-plane 值
+- 读取时间、head / PR / issue / project 等绑定
+- 用于 drift、merge basis、closeout basis 的 provenance
+
+mirror 不得承接 `current_stop`、`next_step`、`latest_validation_summary`、review disposition 或其他仓内 authored 字段。
+
 ## 5. Derived Read Surfaces
 
 以下对象只允许派生读取：
@@ -84,6 +98,8 @@ Loom 当前固定四层：
 
 这些对象可以汇总信息，但不得反向覆盖 authored 真相。
 
+派生读面必须能追溯到被消费的 authored truth、host mirror 或 retained result。若派生读面只给出结论而缺少 locator / binding / source layer，调用方必须把它当成不可消费状态。
+
 ## 6. Runtime / Review Evidence
 
 以下对象进入证据层：
@@ -94,6 +110,8 @@ Loom 当前固定四层：
 - PR 评论中的临时讨论
 
 这些对象可以被 Loom 消费，但默认不是长期 authored 真相。
+
+被保留的 host action result 或 repo-native verdict 属于 retained result。它是证据层里可被长期引用的结果封套，不是独立 authored truth。它可以作为 review、merge-ready 或 closeout 的证据 provenance，但只有在绑定当前对象且没有被更新的 authored truth 或 host control truth 否定时才可消费。
 
 若其中某项需要成为长期真相，必须回写到稳定主载体：
 
@@ -129,7 +147,14 @@ Loom 当前只允许以下同步：
 
 - 先保留两边原值
 - 明确报出 drift
-- 通过专门 sync 入口修复
+- 阻断依赖该事实的 resume / review / merge-ready / closeout 消费
+- 通过专门 sync 入口修复，不在派生读面中自动选择胜者
+
+当 retained result 或 derived read surface 与其来源冲突时：
+
+- retained result 过期或绑定不完整时，标记为 stale evidence
+- derived read surface 与 authored truth 或 host control truth 不一致时，标记为 stale surface
+- 上述情况在 merge-ready、controlled merge、closeout 等放行路径中必须 fail-closed
 
 当前执行面上：
 

--- a/docs/methodology/harness/README.md
+++ b/docs/methodology/harness/README.md
@@ -10,15 +10,15 @@
 - [work-item-contract.md](./work-item-contract.md)
   - 定义唯一默认执行入口与 enforcement 合同
 - [fact-chain-contract.md](./fact-chain-contract.md)
-  - 定义静态真相、动态真相与派生读面的唯一归属关系
+  - 定义静态真相、动态真相、host/control-plane mirror、retained result 与派生读面的读取优先级和 provenance 纪律
 - [execution-context.md](./execution-context.md)
   - 定义每轮正式执行必须绑定和读取的最小上下文语义
 - [item-context-contract.md](./item-context-contract.md)
   - 定义当前活跃 `Work Item` 的最小 machine-readable 上下文字段与读取边界
 - [status-surface-contract.md](./status-surface-contract.md)
-  - 定义 `status control plane v2` 的对象、字段组与消费边界
+  - 定义 `status control plane v2` 的对象、字段组、provenance 与消费边界
 - [status-surface.md](./status-surface.md)
-  - 定义统一状态控制面的字段语义、运行时证据与 closeout 展示
+  - 定义统一状态控制面的字段语义、`runtime_state` / `runtime_evidence` 边界、运行时证据与 closeout 展示
 - [governance-failure-taxonomy.md](./governance-failure-taxonomy.md)
   - 定义 `stale` / `drift` / `gate_failure` 的统一 taxonomy
 - [execution-chain.md](./execution-chain.md)
@@ -62,6 +62,15 @@
 
 这些文件共同表达的不是零散脚本集合，而是从 `Work Item` / fact-chain 到 review / merge / closeout 的统一编排链路。
 当 Loom 需要调用 GitHub、CI、review engine、`git worktree` 或其他宿主能力时，也应先通过 [host-action-contract.md](./host-action-contract.md) 收口结果与去向，再由各专题文件承接细节，而不是在外部再复制一套真相。
+
+读取纪律：
+
+- authored truth 只由 `Work Item`、恢复主入口、review record、merge / closeout basis 等主载体承接
+- host/control-plane mirror 只能提供 issue、PR、project、checks、ruleset 等宿主控制面的只读 provenance
+- retained result 只能作为已发生宿主动作或 repo-native verdict 的证据 provenance，必须绑定当前消费对象
+- repo-native carrier 通过 interop 只提供只读 locator 或 retained result 来源，不自动成为 Loom authored truth 或 host mirror
+- derived surface 只汇总、展示 taxonomy 与阻断原因；不得反向覆盖 authored truth
+- provenance 缺失、绑定过期、parallel truth 或 stale derived surface 在放行路径上必须阻断
 
 ## 行为优先执行层
 

--- a/docs/methodology/harness/fact-chain-contract.md
+++ b/docs/methodology/harness/fact-chain-contract.md
@@ -26,6 +26,8 @@ Loom 的执行真相只允许沿一条事实链流动：
 
 跨 repo 与 GitHub 控制面的真相分层，见 [../governance/truth-and-sync-boundary.md](../governance/truth-and-sync-boundary.md)。
 
+读取事实链时必须同时暴露 provenance：读了哪一层、读到哪个 locator、该值为什么可消费，以及冲突时由哪个层级阻断。
+
 ## 2. 主真相载体
 
 ### 2.1 `work item`
@@ -104,7 +106,44 @@ Loom 的执行真相只允许沿一条事实链流动：
 
 - `authored` 字段只能在主来源中维护。
 - `derived` 字段只能由读取脚本从主来源计算或映射，不得手工改写为第二真相。
+- host / control-plane mirror 只能作为派生读面或 locator provenance 被消费，不得回写成 repo execution truth 的 authored 字段。
+- retained result 只证明某个宿主动作或 repo-native verdict 曾经发生，并且必须带有 producing command / action、target gate / surface、subject locator、head、scope、时间戳或 run id 中适用的绑定；它不得替代当前 authored 停点、下一步或验证摘要。
 - `--activate` 只能显式切换当前 locator，不得通过 `resume`、`handoff` 或其他只读 flow 隐式改写活跃事项。
+
+## 2.5 读取层级与 provenance
+
+事实链读取固定按以下层级解释：
+
+1. locator discovery
+   - `init-result` 中的当前 item 与 carrier locator
+   - 只决定本次要读哪份主载体，不承载事项事实
+2. authored truth
+   - `work item`、恢复主入口、review record 等主载体中的字段
+   - 决定执行事实本身
+3. derived surface
+   - status surface、merge-ready 摘要、closeout 摘要、fact-chain 输出
+   - 只展示组合结果、freshness 与阻断原因
+4. host / control-plane mirror
+   - issue、project、PR、checks、ruleset 或 repo-native control plane 的当前镜像
+   - 只用于 host 状态、绑定链、merge / closeout basis 与 drift 判断
+5. retained result
+   - guardian、integration、repo-native merge readiness、host action 等已保留结果
+   - 只作为可审查证据、locator provenance 或前序结果 provenance 被消费
+
+这里的层级是事实优先级，不是 bootstrap 顺序。`init-result` 先被读取只是为了发现 carrier locator，它本身不参与事实优先级，也不承载实时执行真相。
+
+每个机械输出至少应能说明：
+
+- `source_layer`
+  - `authored_truth | host_control_mirror | retained_result | derived_surface`
+- `source_locator`
+  - 文件、host object、run、comment、result envelope 或等价 locator
+- `source_binding`
+  - `item_id`、`head_sha`、`reviewed_head_sha`、`merge_commit_sha`、时间戳或等价绑定中适用的部分
+- `consumed_as`
+  - `truth | mirror | evidence | locator | summary`
+
+若同一字段同时出现在 authored truth 与 mirror / retained result / derived surface 中，读取方必须以 authored truth 为准，并把其他值作为 provenance 或 drift evidence。若非 authored 层展示了不同值且无法证明只是过期镜像，结果必须阻断。
 
 ## 3. 派生读面
 
@@ -125,6 +164,8 @@ Loom 的执行真相只允许沿一条事实链流动：
 
 若派生读面展示的值与主真相不一致，应视为事实链断裂。
 
+派生读面可以缓存或展示 host mirror 与 retained result，但必须保留原始 locator 与绑定信息。缺少 provenance、绑定过期、或与 authored truth 冲突时，派生读面不得输出 `pass`。
+
 ## 4. 不允许的并行记账
 
 以下情况都属于并行真相，必须报错或阻断：
@@ -143,8 +184,20 @@ Loom 的执行真相只允许沿一条事实链流动：
 2. 再读 `work item`
 3. 再读恢复主入口
 4. 需要状态汇总时，再读派生状态面
+5. 最后按需要读取 host / control-plane mirror 与 retained result 的 locator / evidence
 
 不允许跳过主真相，直接把状态面或 merge checkpoint 输入当成 authored 真相。
+
+冲突处理固定为 fail-closed：
+
+- authored truth 之间冲突
+  - 阻断，并要求回到唯一主载体修复
+- authored truth 与 host / control-plane mirror 冲突
+  - 阻断当前消费，进入 drift / reconciliation 处理；不得用 mirror 覆盖 authored truth
+- retained result 与 producing command / action、target gate / surface、subject locator、当前 `HEAD`、范围、恢复摘要或 gate 前置不匹配
+  - 视为 stale retained result，不能作为 fresh evidence
+- derived surface 与其来源不一致
+  - 视为 stale derived surface，必须重算或修复 provenance 后再消费
 
 当前仓库中的统一读取入口包括：
 

--- a/docs/methodology/harness/status-surface-contract.md
+++ b/docs/methodology/harness/status-surface-contract.md
@@ -4,6 +4,8 @@
 
 它回答的不是“状态写在哪”，而是“resume / review / merge-ready / closeout 至少要从同一个控制面读出哪些治理现场”。
 
+状态控制面是 derived surface。它必须展示 provenance 与阻断原因，但不得新增第二套 authored truth。
+
 ## 1. 目标
 
 `status control plane v2` 至少要同时服务：
@@ -18,6 +20,20 @@
 - host-backed GitHub 状态消费
 
 它不新增 authored 真相，只统一读取已有真相与 host signals。
+
+读取顺序固定为：
+
+1. repo-authored truth
+   - `Work Item`、恢复主入口、review record、merge / closeout basis
+2. host / control-plane mirror
+   - issue、project、PR、checks、ruleset、host binding
+3. retained result
+   - guardian、integration、repo-native verdict、host action result envelope
+4. derived status surface
+   - 汇总展示、taxonomy、最终 `pass | block`
+
+状态面只能把第 2、3 层作为 mirror / evidence / locator provenance 消费，不能把它们提升为第 1 层。
+第 4 层是本次状态面的输出 / 展示层，不是生成当前状态面时可反读的输入。旧状态面最多用于 stale-surface 检测，不能作为当前 `pass | block` 的来源。
 
 ## 2. 统一读取对象
 
@@ -124,6 +140,22 @@
 - `branch_protection`
 - `project`
 
+### 3.8 `provenance`
+
+每个会影响 `pass | block` 的字段组至少要能暴露：
+
+- `source_layer`
+  - `authored_truth | host_control_mirror | retained_result | derived_surface`
+- `source_locator`
+- `source_binding`
+- `freshness`
+  - `fresh | stale | missing | unreadable | not_applicable`
+- `conflict`
+  - `none | drift | stale_surface | stale_retained_result | parallel_truth`
+
+`provenance` 是读取说明，不是新的 authored 字段组。它可以在 JSON 输出中按字段内联，也可以作为并列索引输出，但必须能被机械入口追溯到具体字段。
+若一个字段组混合消费多个来源，provenance 必须能下钻到字段级，不能用组级 provenance 掩盖局部 stale / drift。
+
 ## 4. 总结果语义
 
 统一状态控制面本身只允许输出：
@@ -135,6 +167,8 @@
 
 - 只要存在活跃 `stale` / `drift` / `gate_failure`，结果就是 `block`
 - 只要缺前序 gate 或绑定链不完整，结果就是 `block`
+- 只要关键字段缺少 provenance、provenance 指向不可读来源，或同一事实出现 parallel truth，结果就是 `block`
+- retained result 与 producing command / action、target gate / surface、subject locator、当前 `HEAD`、范围、恢复摘要或 gate 前置不匹配时，结果就是 `block`
 - 只有关键读面全部可消费且前序链完整时，结果才是 `pass`
 
 ## 5. closeout / reconciliation 一体化要求
@@ -155,9 +189,11 @@ v2 必须至少能稳定读出：
 - repo-local 路径可以只依赖 `.loom/` 与本地 git
 - host-backed 路径可以额外消费 issue / PR / project / branch protection / required checks
 - 两条路径必须输出同一套字段组与 taxonomy
+- host-backed 路径输出的 GitHub 值是 host/control-plane mirror；repo-local 路径可以缓存其 locator 或 retained result，但不得把缓存值当成 authored truth
 
 ## 7. 非目标
 
 - 不把状态面升级成第二套 authored 账本
 - 不允许不同 skill 各自拼装私有状态结构
 - 不把 GitHub 私有字段直接冻结为 Loom core 唯一命名
+- 不用 `runtime_state` 代替 status control plane

--- a/docs/methodology/harness/status-surface.md
+++ b/docs/methodology/harness/status-surface.md
@@ -19,6 +19,8 @@
 - 当前 behavior evidence / test evidence 是否覆盖当前范围
 - 最近验证是否仍是 fresh verification evidence
 
+状态面不是 runtime state，也不是 runtime evidence ledger。它只消费这些来源并给出当前可读的 derived control-plane 结论。
+
 ## 2. 字段派生原则
 
 所有字段都必须从既有主真相或 host signals 派生：
@@ -37,10 +39,25 @@
   - 从 closeout / reconciliation 结果派生
 - `binding`
   - 从 host binding surface 派生
+- `github`
+  - 从 host / control-plane mirror 派生
+- retained host / repo-native result
+  - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
   - 从统一失败分类派生
 
 禁止手工维护第二套 authored 状态摘要。
+
+每个影响放行的派生值必须保留来源说明：
+
+- 来源层级
+  - authored truth、host/control-plane mirror、retained result 或 derived surface
+- 来源 locator
+- 与当前 `item_id`、`HEAD`、范围、reviewed head、PR 或 merge commit 的绑定
+- fresh / stale / missing / unreadable / not_applicable 判断
+
+缺少上述来源说明时，该字段不可消费。
+混合来源的字段组必须能下钻到字段级 provenance，不能用组级 provenance 掩盖局部 stale / drift。
 
 行为证据与测试证据也只能派生读取：
 
@@ -87,7 +104,25 @@
 
 字段缺失永远是错误，不等同于不适用。
 
-## 4.1 行为 / 测试证据展示
+## 4.1 `runtime_state` / `runtime_evidence` / status control plane
+
+三者职责固定区分：
+
+- `runtime_state`
+  - 描述 Loom runtime / launcher / carrier 是否可运行、当前入口属于什么安装场景、缺少什么运行输入，以及 lane、run、logs、diagnostics 的 locator 或宿主运行对象状态
+  - 可以阻断命令启动
+  - 不承载事项进度、recovery state、validation verdict、review 结论、merge-ready 结论或 closeout 结论
+- `runtime_evidence`
+  - 描述已经被验证或审查消费的运行证据及其绑定，证明 run / logs / diagnostics / verification / lane 证据在哪里
+  - 不承载下一步、当前停点、blocking owner 或最终 gate verdict
+- status control plane
+  - 汇总 authored truth、host mirror、retained result 与 runtime evidence，输出 `pass | block`、taxonomy 与 provenance
+  - 不反向写入 runtime_state，也不把 runtime_state 当成事项状态面
+
+若 runtime_state 与 runtime_evidence 的绑定不一致，状态面必须把相关 evidence 标记为 `stale` 或 `unreadable`。若调用方试图用 runtime_state 代替恢复主入口或 status control plane，必须视为 parallel truth 风险并阻断。
+`runtime_evidence` 的 `present`、`not_applicable`、`stale`、`missing` 结论仍由状态面或 fact-chain 根据当前 `HEAD`、范围与恢复摘要派生；`Runtime Evidence` 区块本身只提供 locator 读面。
+
+## 4.2 行为 / 测试证据展示
 
 状态面展示行为证据与测试证据时，至少应区分：
 
@@ -111,6 +146,8 @@
 - `gate 已通过`
 - `gate 结论 stale`
 - `gate 因前序缺失不可消费`
+- `gate 结论缺少 provenance`
+- `gate 结论来自过期 retained result`
 
 例如：
 
@@ -123,6 +160,12 @@
 - behavior evidence / test evidence 缺失或 stale
   - 对应消费 gate 必须 `block`
   - `taxonomy.active_failures` 必须含 `evidence_failure`
+- host mirror 与 authored truth 不一致
+  - 对应消费 gate 必须 `block`
+  - `taxonomy.active_failures` 必须含 `drift`
+- retained result 绑定过期、来源不可读或缺少 producing command / action、target gate / surface、subject locator 等关键 provenance
+  - 对应消费 gate 必须 `block`
+  - `taxonomy.active_failures` 必须含 `stale` 或 `gate_failure`
 
 ## 6. closeout / reconciliation 展示
 
@@ -145,8 +188,17 @@
 
 这些入口应输出同一控制面语义，而不是平行结果模型。
 
+输出纪律：
+
+- repo-local 与 host-backed 输出字段组保持一致
+- host-backed 额外值必须标记为 host/control-plane mirror
+- retained result 必须标记原始 result envelope 或等价 locator
+- derived summary 不得遮蔽 authored truth 与 mirror 的冲突
+- 任一关键来源不可读、过期或冲突时输出 `block`
+
 ## 8. 非目标
 
 - 不把状态面写成新的长期进度账本
 - 不用状态面覆盖 `Work Item` / review record / merge checkpoint / closeout basis 的原始权威位置
 - 不允许调用方只读局部字段就跳过前序 gate
+- 不把 runtime_state、runtime_evidence 或 host mirror 改造成事项 authored truth

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/examples/new-project",
+    "target": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/examples/new-project",
     "scenario": "新项目",
     "scenario_key": "new",
     "integration_mode": "root",
@@ -119,7 +119,7 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "78cf0d0022a4c03933a5e46cba676e80cafa5d0802fb95191a761ec9f9417e65"
+      "sha256": "5d10e10d459269dd718b3385ee13019f564f361cad696965122745b0d329078b"
     },
     {
       "path": ".loom/bin/governance_surface.py",
@@ -131,13 +131,13 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "d67ffd22cacad33d25e1a4ef5dc90b57eb7143aae7a9a65420fcbdcb38fc701d"
+      "sha256": "216adef334fa5db5596d989155e03eb2222bc54b10b64fa2b4f19b92eddba72b"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "229ecdf3171aab0df302fd9662f5a9ce6371e7b8f194ece341909d38ce268bed"
+      "sha256": "e8814b5ef11c120a7909e48f7d3a648f5ce9baf1dde14425f02c9db072495f36"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "b0b313d362912d5b71b0c3897a64cb7073720041c8c4cdd67ba939f6312c5a50"
+      "sha256": "09297502d6a5c54a147791dae1e1fa93d0dbee3fc772e3e1230f9726688037e8"
     },
     {
       "path": "AGENTS.md",
@@ -263,12 +263,12 @@
     "scene": "repo-local-demo",
     "carrier": "repo-local-wrapper",
     "entry_family": "loom-init",
-    "install_root": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/skills",
-    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/skills/shared/scripts",
-    "registry_path": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/skills/registry.json",
-    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/skills/install-layout.json",
-    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation",
-    "target_root": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/examples/new-project",
+    "install_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills",
+    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/shared/scripts",
+    "registry_path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/registry.json",
+    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/install-layout.json",
+    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance",
+    "target_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/examples/new-project",
     "checks": {
       "scene_marker": {
         "status": "pass",
@@ -278,21 +278,21 @@
         "status": "pass",
         "summary": "carrier layout exposes an installed skills root and shared runtime tree.",
         "evidence": {
-          "install_root": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/skills"
+          "install_root": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills"
         }
       },
       "registry_contract": {
         "status": "pass",
         "summary": "registry, upgrade contract, and skill entrypoints are consistent.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/skills/registry.json"
+          "path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/registry.json"
         }
       },
       "shared_runtime": {
         "status": "pass",
         "summary": "shared runtime scripts are present and executable roots can be resolved.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation/skills/shared/scripts"
+          "path": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance/skills/shared/scripts"
         }
       },
       "referenced_resources": {
@@ -430,53 +430,53 @@
       }
     },
     "repo_interface": {
-      "availability": "absent",
+      "availability": "present",
       "manifest": {
-        "status": "missing",
+        "status": "present",
         "locator": ".loom/companion/manifest.json",
-        "source": "companion manifest"
+        "source": "repository scan"
       },
       "companion_entry": {
-        "status": "missing",
-        "locator": "unknown",
-        "source": "repo companion manifest"
+        "status": "present",
+        "locator": ".loom/companion/README.md",
+        "source": "repo companion interface.companion_entry"
       },
       "repo_specific_requirements": {
-        "status": "missing",
-        "locator": "unknown",
-        "source": "repo companion interface"
+        "status": "present",
+        "locator": ".loom/companion/repo-interface.json",
+        "source": "repo companion manifest.repo_interface"
       },
       "specialized_gates": {
-        "status": "missing",
-        "locator": "unknown",
-        "source": "repo companion interface"
+        "status": "present",
+        "locator": ".loom/companion/repo-interface.json",
+        "source": "repo companion manifest.repo_interface"
       },
-      "summary": "no repo companion interface is declared for this repository.",
+      "summary": "repo companion manifest and machine-readable repo interface are readable.",
       "missing_inputs": []
     },
     "repo_interop": {
-      "availability": "absent",
+      "availability": "present",
       "contract": {
-        "status": "missing",
+        "status": "present",
         "locator": ".loom/companion/interop.json",
         "source": "repository scan"
       },
       "host_adapters": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/companion/interop.json",
         "source": "repo interop contract"
       },
       "repo_native_carriers": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/companion/interop.json",
         "source": "repo interop contract"
       },
       "shadow_surfaces": {
-        "status": "missing",
-        "locator": "unknown",
+        "status": "present",
+        "locator": ".loom/companion/interop.json",
         "source": "repo interop contract"
       },
-      "summary": "no repo interop contract is declared for this repository.",
+      "summary": "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity.",
       "missing_inputs": []
     },
     "workspace_profile": {
@@ -506,7 +506,7 @@
       "host_worktree": {
         "ownership": "host",
         "status": "present",
-        "locator": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation"
+        "locator": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance"
       },
       "result": "pass",
       "missing_inputs": [],
@@ -523,7 +523,7 @@
           "enforcement": "advisory",
           "host_enforcement": false,
           "summary": "Run the repo-local Loom bootstrap verification entry.",
-          "runtime_present": false
+          "runtime_present": true
         },
         "status": {
           "surface": "status",
@@ -533,7 +533,7 @@
           "enforcement": "advisory",
           "host_enforcement": false,
           "summary": "Read the repo-local Loom status surface.",
-          "runtime_present": false
+          "runtime_present": true
         },
         "merge-ready": {
           "surface": "merge_ready",
@@ -543,7 +543,7 @@
           "enforcement": "advisory",
           "host_enforcement": false,
           "summary": "Run Loom's local merge-ready orchestration without taking over host merge controls.",
-          "runtime_present": false
+          "runtime_present": true
         },
         "closeout-check": {
           "surface": "closeout",
@@ -553,7 +553,7 @@
           "enforcement": "advisory",
           "host_enforcement": false,
           "summary": "Check closeout readiness against local Loom carriers and readable host inputs.",
-          "runtime_present": false
+          "runtime_present": true
         },
         "reconciliation-audit": {
           "surface": "reconciliation",
@@ -563,22 +563,18 @@
           "enforcement": "advisory",
           "host_enforcement": false,
           "summary": "Audit closeout drift without mutating host state.",
-          "runtime_present": false
+          "runtime_present": true
         }
       },
-      "runtime_status": "missing",
+      "runtime_status": "present",
       "authority": "local",
       "enforcement": "advisory",
       "host_enforcement": false,
       "host_enforcement_status": "not_host_enforced",
       "result": "pass",
       "missing_inputs": [],
-      "missing_entrypoints": [
-        ".loom/bin/loom_init.py",
-        ".loom/bin/loom_status.py",
-        ".loom/bin/loom_flow.py"
-      ],
-      "recommended_action": "install or refresh repo-local Loom runtime entries before using gate starter aliases"
+      "missing_entrypoints": [],
+      "recommended_action": "run the repo-local aliases as advisory Loom checks, then configure host-required checks separately"
     },
     "governance_control_plane": {
       "schema_version": "loom-governance-control/v1",
@@ -620,7 +616,7 @@
         "host_worktree": {
           "ownership": "host",
           "status": "present",
-          "locator": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation"
+          "locator": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance"
         },
         "result": "pass",
         "missing_inputs": [],
@@ -637,7 +633,7 @@
             "enforcement": "advisory",
             "host_enforcement": false,
             "summary": "Run the repo-local Loom bootstrap verification entry.",
-            "runtime_present": false
+            "runtime_present": true
           },
           "status": {
             "surface": "status",
@@ -647,7 +643,7 @@
             "enforcement": "advisory",
             "host_enforcement": false,
             "summary": "Read the repo-local Loom status surface.",
-            "runtime_present": false
+            "runtime_present": true
           },
           "merge-ready": {
             "surface": "merge_ready",
@@ -657,7 +653,7 @@
             "enforcement": "advisory",
             "host_enforcement": false,
             "summary": "Run Loom's local merge-ready orchestration without taking over host merge controls.",
-            "runtime_present": false
+            "runtime_present": true
           },
           "closeout-check": {
             "surface": "closeout",
@@ -667,7 +663,7 @@
             "enforcement": "advisory",
             "host_enforcement": false,
             "summary": "Check closeout readiness against local Loom carriers and readable host inputs.",
-            "runtime_present": false
+            "runtime_present": true
           },
           "reconciliation-audit": {
             "surface": "reconciliation",
@@ -677,22 +673,18 @@
             "enforcement": "advisory",
             "host_enforcement": false,
             "summary": "Audit closeout drift without mutating host state.",
-            "runtime_present": false
+            "runtime_present": true
           }
         },
-        "runtime_status": "missing",
+        "runtime_status": "present",
         "authority": "local",
         "enforcement": "advisory",
         "host_enforcement": false,
         "host_enforcement_status": "not_host_enforced",
         "result": "pass",
         "missing_inputs": [],
-        "missing_entrypoints": [
-          ".loom/bin/loom_init.py",
-          ".loom/bin/loom_status.py",
-          ".loom/bin/loom_flow.py"
-        ],
-        "recommended_action": "install or refresh repo-local Loom runtime entries before using gate starter aliases"
+        "missing_entrypoints": [],
+        "recommended_action": "run the repo-local aliases as advisory Loom checks, then configure host-required checks separately"
       },
       "host_binding": {
         "schema_version": "loom-host-binding/v1",
@@ -714,12 +706,12 @@
           },
           "branch": {
             "status": "present",
-            "locator": "work-item-506-skills-source-generation",
+            "locator": "work/536-fact-chain-provenance",
             "authority": "git"
           },
           "worktree": {
             "status": "present",
-            "locator": "/Users/mc/dev/Loom-worktrees/work-item-506-skills-source-generation",
+            "locator": "/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance",
             "authority": "git"
           },
           "implementation_pr": {
@@ -733,7 +725,7 @@
             "authority": "host"
           },
           "closeout": {
-            "status": "host-managed",
+            "status": "present",
             "locator": "reconciliation audit + closeout gate",
             "authority": "loom + host"
           }
@@ -1005,8 +997,6 @@
           ],
           "strong": [
             "standard",
-            "repo_interface",
-            "repo_interop",
             "host_enforced_control_plane",
             "pr_merge_path",
             "controlled_merge_basis",
@@ -1040,20 +1030,6 @@
             }
           ],
           "strong": [
-            {
-              "id": "repo_interface",
-              "layer": "repo-owned-residue",
-              "required": true,
-              "defaulting": "scaffold",
-              "recommended_action": "install or repair the repo companion interface"
-            },
-            {
-              "id": "repo_interop",
-              "layer": "repo-owned-residue",
-              "required": true,
-              "defaulting": "scaffold",
-              "recommended_action": "install or repair the repo interop contract"
-            },
             {
               "id": "github_controlled_merge",
               "layer": "github-profile",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -41,7 +41,7 @@
       "path": ".loom/bin/fact_chain_support.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/fact_chain_support.py",
-      "sha256": "78cf0d0022a4c03933a5e46cba676e80cafa5d0802fb95191a761ec9f9417e65"
+      "sha256": "5d10e10d459269dd718b3385ee13019f564f361cad696965122745b0d329078b"
     },
     {
       "path": ".loom/bin/governance_surface.py",
@@ -53,13 +53,13 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "d67ffd22cacad33d25e1a4ef5dc90b57eb7143aae7a9a65420fcbdcb38fc701d"
+      "sha256": "216adef334fa5db5596d989155e03eb2222bc54b10b64fa2b4f19b92eddba72b"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "229ecdf3171aab0df302fd9662f5a9ce6371e7b8f194ece341909d38ce268bed"
+      "sha256": "e8814b5ef11c120a7909e48f7d3a648f5ce9baf1dde14425f02c9db072495f36"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "b0b313d362912d5b71b0c3897a64cb7073720041c8c4cdd67ba939f6312c5a50"
+      "sha256": "09297502d6a5c54a147791dae1e1fa93d0dbee3fc772e3e1230f9726688037e8"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.65",
+      "version": "0.1.66",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-init/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-resume/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-retire/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-review/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/fact_chain_support.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/skills/shared/scripts/fact_chain_support.py
+++ b/skills/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],

--- a/src/skills/shared/scripts/fact_chain_support.py
+++ b/src/skills/shared/scripts/fact_chain_support.py
@@ -68,6 +68,15 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +97,23 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -324,6 +350,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -345,6 +404,203 @@ def expected_status_values(
         "latest_validation_summary": recovery_entry["latest_validation_summary"],
         "recovery_boundary": recovery_entry["recovery_boundary"],
         "current_lane": recovery_entry["current_lane"],
+    }
+
+
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
     }
 
 
@@ -380,10 +636,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -398,7 +672,8 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
     work_item_path, work_item_path_errors = resolve_repo_relative_path(
@@ -419,7 +694,7 @@ def inspect_fact_chain(
     errors.extend(work_item_path_errors)
     errors.extend(recovery_path_errors)
     errors.extend(status_path_errors)
-    if errors:
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
         return {}, errors
     assert work_item_path is not None
     assert recovery_path is not None
@@ -437,36 +712,84 @@ def inspect_fact_chain(
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
     recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
     status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
-    if errors:
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -477,117 +800,120 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -1280,6 +1280,11 @@ def require_shadow_parity_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
+    elif payload.get("result") == "block" and not blocking_failures:
+        failures.append(Failure(category, f"{context} blocking mode must expose blocking_failures when it blocks"))
     top_level_details = payload.get("missing_details")
     if top_level_details is not None:
         require_missing_details(
@@ -2023,6 +2028,54 @@ def require_runtime_state_payload(
             failures.append(Failure(category, f"{context} runtime_state check `{key}` returned an unknown status"))
         if not isinstance(check.get("summary"), str) or not check.get("summary"):
             failures.append(Failure(category, f"{context} runtime_state check `{key}` must include non-empty `summary`"))
+
+
+def require_fact_chain_provenance(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must return a JSON object"))
+        return
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        failures.append(Failure(category, f"{context} must include non-empty `provenance`"))
+    else:
+        allowed_kinds = {
+            "authored_truth",
+            "host_control_mirror",
+            "retained_result",
+            "derived_surface",
+            "runtime_state",
+            "runtime_evidence",
+        }
+        for entry in provenance:
+            if not isinstance(entry, dict):
+                failures.append(Failure(category, f"{context} provenance entries must be objects"))
+                continue
+            for field in ("kind", "carrier", "field", "authority", "freshness", "trusted_because"):
+                if not isinstance(entry.get(field), str) or not entry.get(field):
+                    failures.append(Failure(category, f"{context} provenance entries must include `{field}`"))
+            if entry.get("kind") not in allowed_kinds:
+                failures.append(Failure(category, f"{context} provenance kind must stay within the stable vocabulary"))
+            if not isinstance(entry.get("path"), str) and not isinstance(entry.get("locator"), str):
+                failures.append(Failure(category, f"{context} provenance entries must include `path` or `locator`"))
+    readiness = payload.get("recovery_readiness")
+    if not isinstance(readiness, dict):
+        failures.append(Failure(category, f"{context} must include `recovery_readiness`"))
+    else:
+        if readiness.get("result") not in {"pass", "block"}:
+            failures.append(Failure(category, f"{context} recovery_readiness.result must be pass or block"))
+        if not isinstance(readiness.get("summary"), str) or not readiness.get("summary"):
+            failures.append(Failure(category, f"{context} recovery_readiness must include a summary"))
+        if not isinstance(readiness.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} recovery_readiness must include `missing_inputs`"))
+    blocking_failures = payload.get("blocking_failures")
+    if not isinstance(blocking_failures, list):
+        failures.append(Failure(category, f"{context} must include `blocking_failures`"))
 
 
 def require_route_payload(
@@ -3372,6 +3425,13 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_carrier="repo-local-wrapper",
                 allowed_results={"pass"},
             )
+        if label == "fact-chain":
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`fact-chain`.report",
+                payload=payload.get("report"),
+            )
         if label == "state-check":
             require_runtime_state_payload(
                 failures,
@@ -3426,6 +3486,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif reconciliation.get("result") not in {"pass", "warn", "fix-needed", "block", "not_applicable"}:
                     failures.append(Failure("daily-execution-cli", "`loom_status` closeout reconciliation result must stay within the stable set"))
             require_governance_surface(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=payload,
+            )
+            require_fact_chain_provenance(
                 failures,
                 category="daily-execution-cli",
                 context="`loom_status`",
@@ -3692,6 +3758,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow resume` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow resume`",
+                payload=payload,
+            )
         if label == "flow-handoff":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow handoff` must report `command: flow`"))
@@ -3761,6 +3833,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     )
                 if not isinstance(state_check.get("checks"), dict):
                     failures.append(Failure("daily-execution-cli", "`flow handoff` must include `state_check.checks`"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow handoff`",
+                payload=payload,
+            )
         if label == "flow-review":
             if payload.get("command") != "flow":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
@@ -3812,6 +3890,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 context="`flow review` repo_specific_requirements",
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="review",
+            )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload,
             )
         if label == "review-read":
             if payload.get("command") != "review":
@@ -3989,6 +4073,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload.get("repo_specific_requirements"),
                 expected_surface="merge_ready",
             )
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload,
+            )
             if payload.get("result") != "fallback":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` must return `fallback` for the bootstrap demo"))
             if payload.get("fallback_to") != "admission":
@@ -3997,6 +4087,80 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` build checkpoint must fall back to `admission` for the bootstrap demo"))
             if isinstance(payload.get("merge_checkpoint"), dict) and payload["merge_checkpoint"].get("fallback_to") != "admission":
                 failures.append(Failure("daily-execution-cli", "`flow merge-ready` merge checkpoint must fall back to `admission` for the bootstrap demo"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-fact-chain-provenance-") as tmp:
+        stale_target = Path(tmp) / "stale-status"
+        shutil.copytree(example_target, stale_target)
+        status_path = stale_target / ".loom/status/current.md"
+        status_text = status_path.read_text(encoding="utf-8")
+        status_path.write_text(
+            status_text.replace(
+                "- Next Step: Accept the generated Loom entry and promote the first real repository work item.",
+                "- Next Step: Stale derived status should not override recovery.",
+            ).replace(
+                "- Latest Validation Summary: Bootstrap manifest exists; init-result JSON can be read mechanically; the first work item, status surface, and spec/plan artifacts exist.",
+                "- Latest Validation Summary: Stale status summary must be rejected.",
+            ),
+            encoding="utf-8",
+        )
+        for label, args in (
+            (
+                "stale status fact-chain",
+                ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status flow resume",
+                ["python3", "tools/loom_flow.py", "flow", "resume", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+            (
+                "stale status control",
+                ["python3", "tools/loom_status.py", "--target", str(stale_target), "--item", "INIT-0001"],
+            ),
+        ):
+            payload, error = load_command_json(root, args)
+            if error:
+                failures.append(Failure("daily-execution-cli", f"`{label}` failed: {error}"))
+                continue
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", f"`{label}` must block stale derived status surfaces"))
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context=f"`{label}`",
+                payload=payload.get("report") if label.endswith("fact-chain") else payload,
+            )
+            failure_blob = json.dumps(payload.get("blocking_failures") or payload.get("report", {}).get("blocking_failures"), ensure_ascii=False)
+            if "stale" not in failure_blob and "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", f"`{label}` must expose stale/drift blocking failures"))
+
+        mirror_target = Path(tmp) / "host-mirror-overwrite"
+        shutil.copytree(example_target, mirror_target)
+        init_path = mirror_target / ".loom/bootstrap/init-result.json"
+        init_payload = json.loads(init_path.read_text(encoding="utf-8"))
+        init_payload.setdefault("fact_chain", {})["host_mirror"] = {
+            "next_step": "Host mirror attempted to override recovery.",
+            "latest_validation_summary": "Retained result attempted to override recovery.",
+        }
+        init_path.write_text(json.dumps(init_payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "fact-chain", "--target", str(mirror_target), "--item", "INIT-0001"],
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`host mirror overwrite` failed: {error}"))
+        else:
+            if payload.get("result") != "block":
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must block parallel authored recovery fields"))
+            report = payload.get("report")
+            require_fact_chain_provenance(
+                failures,
+                category="daily-execution-cli",
+                context="`host mirror overwrite`.report",
+                payload=report,
+            )
+            failure_blob = json.dumps(report.get("blocking_failures") if isinstance(report, dict) else [], ensure_ascii=False)
+            if "parallel_truth_drift" not in failure_blob:
+                failures.append(Failure("daily-execution-cli", "`host mirror overwrite` must expose parallel_truth_drift"))
 
     with tempfile.TemporaryDirectory(prefix="loom-check-review-run-") as tmp:
         source_snapshot = Path(tmp) / "source-snapshot"

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -1296,13 +1296,14 @@ def run_git(root: Path, args: list[str]) -> subprocess.CompletedProcess[str] | N
         return None
 
 
-def run_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+def run_process(args: list[str], cwd: Path, *, timeout_seconds: float | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        timeout=timeout_seconds,
     )
 
 
@@ -1404,7 +1405,10 @@ def cleanup_scratch_tree(target_root: Path, scratch_dir: Path) -> None:
 
 
 def gh_json(root: Path, args: list[str]) -> tuple[dict[str, Any] | None, list[str]]:
-    result = run_process(["gh", *args], root)
+    try:
+        result = run_process(["gh", *args], root, timeout_seconds=20)
+    except subprocess.TimeoutExpired:
+        return None, [f"gh {' '.join(args)} timed out after 20s"]
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh command failed"
         return None, [detail]
@@ -2421,15 +2425,21 @@ def build_review_flow_payload(
             "fallback_to": "admission",
             "steps": steps,
             "runtime_state": runtime_state,
+            **fact_chain_error_contract(errors, output_relative=output_relative),
         }
 
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -2585,6 +2595,11 @@ def build_review_flow_payload(
         for message in repo_specific_requirements.get("missing_inputs", []):
             if message not in missing_inputs:
                 missing_inputs.append(message)
+    recovery_readiness = report_recovery_readiness(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = f"{operation} flow rebuilt context but recovery readiness is blocking."
 
     return {
         "command": "flow",
@@ -2601,6 +2616,9 @@ def build_review_flow_payload(
         "fallback_to": fallback_to,
         "steps": steps,
         "runtime_state": runtime_state,
+        "provenance": report_provenance(context["report"]),
+        "recovery_readiness": recovery_readiness,
+        "blocking_failures": report_blocking_failures(context["report"]),
         "state_check": {
             "result": state_payload["result"],
             "summary": state_payload["summary"],
@@ -4314,6 +4332,7 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
                 "summary": "fact-chain command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -4329,13 +4348,23 @@ def handle_fact_chain(args: argparse.Namespace) -> int:
             }
         )
 
+    blocking_failures = report_blocking_failures(report)
+    result = "block" if blocking_failures else "pass"
     return emit(
         {
             "command": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain can be read and validated from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": result,
+            "summary": (
+                "fact chain can be read and validated from a single entry."
+                if result == "pass"
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(report),
+            "fallback_to": "admission" if result == "block" else None,
+            "provenance": report_provenance(report),
+            "recovery_readiness": report_recovery_readiness(report),
+            "derived_status_surface": report.get("derived_status_surface"),
+            "blocking_failures": blocking_failures,
             "report": report,
         }
     )
@@ -4370,6 +4399,99 @@ def runtime_evidence_from_report(report: dict[str, Any]) -> tuple[dict[str, Any]
             "source": entry.get("source"),
         }
     return fields, missing_inputs
+
+
+def report_provenance(report: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = report.get("provenance")
+    return provenance if isinstance(provenance, list) else []
+
+
+def report_recovery_readiness(report: dict[str, Any]) -> dict[str, Any]:
+    readiness = report.get("recovery_readiness")
+    if isinstance(readiness, dict):
+        return readiness
+    return {
+        "result": "block",
+        "summary": "recovery readiness was not reported by the fact-chain reader.",
+        "missing_inputs": ["fact-chain recovery_readiness"],
+        "fallback_to": "admission",
+        "checks": {},
+    }
+
+
+def report_blocking_failures(report: dict[str, Any]) -> list[dict[str, Any]]:
+    failures = report.get("blocking_failures")
+    return failures if isinstance(failures, list) else []
+
+
+def report_blocking_messages(report: dict[str, Any]) -> list[str]:
+    messages: list[str] = []
+    for failure in report_blocking_failures(report):
+        if not isinstance(failure, dict):
+            continue
+        message = failure.get("message") or failure.get("summary") or failure.get("kind")
+        if isinstance(message, str) and message and message not in messages:
+            messages.append(message)
+    readiness = report_recovery_readiness(report)
+    if readiness.get("result") == "block":
+        for message in readiness.get("missing_inputs", []):
+            if isinstance(message, str) and message not in messages:
+                messages.append(message)
+    return messages
+
+
+def fact_chain_error_contract(
+    errors: list[str],
+    *,
+    output_relative: str = ".loom/bootstrap/init-result.json",
+) -> dict[str, Any]:
+    missing_inputs = [f"fact-chain: {message}" for message in errors]
+    blocking_failures = [
+        {
+            "category": "gate_failure",
+            "kind": "fact_chain_unreadable",
+            "carrier": "init_result",
+            "field": "fact_chain",
+            "authority": "locator_discovery",
+            "message": message,
+            "blocking": True,
+            "fallback_to": "admission",
+            "locator": output_relative,
+        }
+        for message in missing_inputs
+    ]
+    return {
+        "provenance": [
+            {
+                "kind": "host_control_mirror",
+                "carrier": "init_result",
+                "field": "fact_chain",
+                "authority": "locator_discovery",
+                "freshness": "unreadable",
+                "trusted_because": "init-result must be readable before authored truth carriers can be selected.",
+                "locator": output_relative,
+            }
+        ],
+        "recovery_readiness": {
+            "result": "block",
+            "status": "blocked",
+            "summary": "recovery is blocked because fact-chain locator discovery failed.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "admission",
+            "checks": {
+                "locator_discovery": "block",
+                "authored_work_item": "unknown",
+                "authored_recovery_entry": "unknown",
+                "derived_status_surface": "unknown",
+                "parallel_truth": "unknown",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": None,
+            "parallel_truth_drift": [],
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
 
 
 def handle_runtime_evidence(args: argparse.Namespace) -> int:
@@ -6677,6 +6799,12 @@ def closeout_payload(
     skip_gate: bool,
 ) -> tuple[dict[str, Any], list[str]]:
     missing_inputs: list[str] = []
+    context, context_errors = load_context(target_root, ".loom/bootstrap/init-result.json", None)
+    fact_chain_context: dict[str, Any] | None = context if not context_errors else None
+    if context_errors:
+        missing_inputs.extend(f"fact-chain: {message}" for message in context_errors)
+    elif fact_chain_context is not None:
+        missing_inputs.extend(report_blocking_messages(fact_chain_context["report"]))
     governance_surface = build_governance_surface(target_root)
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -6833,6 +6961,15 @@ def closeout_payload(
             "pr": pr_payload,
             "project": project_payload,
             "repo_specific_requirements": repo_specific_requirements,
+            **(
+                {
+                    "provenance": report_provenance(fact_chain_context["report"]),
+                    "recovery_readiness": report_recovery_readiness(fact_chain_context["report"]),
+                    "blocking_failures": report_blocking_failures(fact_chain_context["report"]),
+                }
+                if fact_chain_context is not None
+                else fact_chain_error_contract(context_errors)
+            ),
             **({"reconciliation": reconciliation_payload} if reconciliation_payload is not None else {}),
         },
         [],
@@ -7280,6 +7417,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "summary": "review command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -7589,6 +7727,7 @@ def handle_recovery(args: argparse.Namespace) -> int:
                 "summary": "recovery command could not read a valid Loom fact chain.",
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8128,6 +8267,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                 "fallback_to": "admission",
                 "steps": steps,
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -8150,10 +8290,15 @@ def handle_flow(args: argparse.Namespace) -> int:
     steps.append(
         {
             "name": "fact-chain",
-            "result": "pass",
-            "summary": "fact chain is readable from a single entry.",
-            "missing_inputs": [],
-            "fallback_to": None,
+            "result": "block" if report_blocking_failures(context["report"]) else "pass",
+            "summary": (
+                "fact chain is readable from a single entry."
+                if not report_blocking_failures(context["report"])
+                else "fact chain is readable, but provenance or derived-surface drift is blocking."
+            ),
+            "missing_inputs": report_blocking_messages(context["report"]),
+            "fallback_to": "admission" if report_blocking_failures(context["report"]) else None,
+            "blocking_failures": report_blocking_failures(context["report"]),
         }
     )
 
@@ -8398,6 +8543,14 @@ def handle_flow(args: argparse.Namespace) -> int:
             "guided_adoption_plan": guided,
         }
 
+    fact_chain_provenance = report_provenance(context["report"])
+    recovery_readiness = report_recovery_readiness(context["report"])
+    blocking_failures = report_blocking_failures(context["report"])
+    if recovery_readiness.get("result") == "block" and result == "pass":
+        result = "block"
+        fallback_to = fallback_to or recovery_readiness.get("fallback_to") or "admission"
+        summary = "flow rebuilt context but recovery readiness is blocking."
+
     return emit(
         {
             "command": "flow",
@@ -8414,6 +8567,9 @@ def handle_flow(args: argparse.Namespace) -> int:
             "fallback_to": fallback_to,
             "steps": steps,
             "runtime_state": runtime_state,
+            "provenance": fact_chain_provenance,
+            "recovery_readiness": recovery_readiness,
+            "blocking_failures": blocking_failures,
             **({"governance_surface": governance_surface} if args.operation == "resume" else {}),
             **({"maturity_upgrade_path": upgrade_path} if args.operation == "resume" else {}),
             **({"adoption_guidance": adoption_guidance} if args.operation == "resume" else {}),
@@ -8598,6 +8754,18 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
             for detail in details:
                 if detail not in missing_details:
                     missing_details.append(detail)
+    blocking_failures = [
+        {
+            "category": "drift" if report.get("classification") == "drift" else "gate_failure",
+            "kind": "parallel_truth_drift" if report.get("result") == "mismatch" else "shadow_parity_unreadable",
+            "surface": report.get("surface"),
+            "message": report.get("summary"),
+            "blocking": mode == "blocking",
+            "fallback_to": "manual-reconciliation",
+        }
+        for report in blocking_reports
+        if isinstance(report, dict)
+    ]
 
     payload = {
         "command": "shadow-parity",
@@ -8610,6 +8778,7 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
         "runtime_state": runtime_state,
         "governance_surface": governance_surface,
         "reports": reports,
+        "blocking_failures": blocking_failures,
     }
     if missing_details:
         payload["missing_details"] = missing_details

--- a/src/skills/shared/scripts/loom_status.py
+++ b/src/skills/shared/scripts/loom_status.py
@@ -12,10 +12,15 @@ from loom_flow import (
     closeout_payload,
     detect_github_repo,
     emit,
+    fact_chain_error_contract,
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
     load_context,
+    report_blocking_failures,
+    report_blocking_messages,
+    report_provenance,
+    report_recovery_readiness,
     runtime_state_payload,
     spec_review_gate_payload,
 )
@@ -402,6 +407,7 @@ def main(argv: list[str]) -> int:
                 "missing_inputs": [f"fact-chain: {message}" for message in errors],
                 "fallback_to": "admission",
                 "runtime_state": runtime_state,
+                **fact_chain_error_contract(errors, output_relative=args.output),
             }
         )
 
@@ -429,6 +435,19 @@ def main(argv: list[str]) -> int:
         github_status=github_status,
         github_errors=github_errors,
     )
+    fact_chain_failures = report_blocking_failures(context["report"])
+    if fact_chain_failures:
+        classifications = control_status.get("classifications")
+        if not isinstance(classifications, list):
+            classifications = []
+        for failure in fact_chain_failures:
+            if not isinstance(failure, dict):
+                continue
+            classification = failure.get("kind") or failure.get("category")
+            if isinstance(classification, str) and classification not in classifications:
+                classifications.append(classification)
+        control_status["classifications"] = classifications
+        control_status["result"] = "block"
     closeout = full_closeout_status_payload(
         target_root,
         phase_number=args.phase,
@@ -454,6 +473,9 @@ def main(argv: list[str]) -> int:
     for message in control_status.get("missing_inputs", []):
         if message not in missing_inputs:
             missing_inputs.append(str(message))
+    for message in report_blocking_messages(context["report"]):
+        if message not in missing_inputs:
+            missing_inputs.append(message)
 
     result = "pass" if not missing_inputs else "block"
     summary = (
@@ -469,6 +491,9 @@ def main(argv: list[str]) -> int:
             "missing_inputs": missing_inputs,
             "fallback_to": "admission" if missing_inputs else None,
             "runtime_state": runtime_state,
+            "provenance": report_provenance(context["report"]),
+            "recovery_readiness": report_recovery_readiness(context["report"]),
+            "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],
                 "goal": context["goal"],


### PR DESCRIPTION
## Summary

Closes #536. Covers #537, #538, #539, #540.

This tightens the fact-chain contract and runtime outputs so status, resume, handoff, review, merge-ready, and closeout can expose which truth was read, why it is trusted, whether the derived surface is fresh, and which blocking failure prevents consumption on drift.

## User Visible Result

Users restoring a Work Item can now see status provenance, recovery readiness, derived status freshness, and drift/blocking failures directly in `fact-chain`, `loom_status`, and `flow resume/handoff/merge-ready` outputs. Host mirrors and retained results remain evidence/locators only and cannot override authored recovery truth.

## Validation

- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py .loom/bin/*.py examples/new-project/.loom/bin/*.py` -> OK
- `python3 tools/skills_surface.py check` -> OK
- `python3 tools/loom_check.py` -> OK, checked 23 surfaces
- `python3 tools/loom_flow.py fact-chain --target examples/new-project --item INIT-0001` -> pass, exposes provenance/recovery_readiness
- `python3 tools/loom_status.py --target examples/new-project --item INIT-0001` -> expected demo block, exposes provenance/recovery_readiness/blocking_failures
- `python3 tools/loom_flow.py flow resume --target examples/new-project --item INIT-0001` -> pass
- `python3 tools/loom_flow.py flow handoff --target examples/new-project --item INIT-0001` -> pass
- `python3 tools/loom_flow.py flow merge-ready --target examples/new-project --item INIT-0001` -> expected demo fallback, exposes provenance/recovery_readiness
- `python3 tools/loom_flow.py shadow-parity --target examples/new-project --blocking` -> pass
- `python3 .loom/bin/loom_flow.py fact-chain --target . --item INIT-0001` -> pass, repo-local runtime exposes provenance/recovery_readiness
- Temporary root `.loom/bin` regressions: host mirror / retained result authored fields block as `parallel_truth_drift`; unreadable init-result returns provenance/recovery_readiness/blocking_failures; stale status surface reports `derived_surface_stale`.
- `npm test --prefix packages/loom-installer` -> 16 tests pass
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main` -> OK (`0.1.65 -> 0.1.66`)

## Binding Evidence

- Work Item scope: #536, covering #537-#540 only
- Branch: `work/536-fact-chain-provenance`
- Workspace: `/Users/mc/dev/Loom-worktrees/work-536-fact-chain-provenance`
- PR: #645
- Head SHA: `19aa4858a048df00f8516bd22c6fbadc84c1f384`

## Non-goals

This does not expand into #541 ledger, #546 workspace, #551 host action, or #556 conformance.
