### PR TITLE
feat: 收紧 host action 与 dynamic tool 边界

### DIFF
--- a/docs/adoption/repo-companion-contract.md
+++ b/docs/adoption/repo-companion-contract.md
@@ -89,7 +89,7 @@
 其中：
 
 - `v1` 继续保持可读，作为下游兼容口径
-- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract 与 context schema
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
 
 ### 4.1 `v1` 兼容合同
 
@@ -140,20 +140,23 @@
   },
   "context_schema": {
     "fields": []
-  }
+  },
+  "dynamic_tool_locators": []
 }
 ```
 
-`v2` 在 `v1` 之上新增两个可选顶层 section：
+`v2` 在 `v1` 之上新增四个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
+- `dynamic_tool_locators`
 
 稳定约束：
 
 - `metadata_contract` 与 `context_schema` 只在 `v2` 合法
 - `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
 
@@ -215,7 +218,49 @@
 - `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
 - missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
 
-### 4.5 `metadata_contract`
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -260,7 +305,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.5.1 明确禁止上移的字段模式
+### 4.6.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -283,7 +328,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.5.2 与 `context_schema` 的边界
+### 4.6.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -298,7 +343,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.5.3 与 `interop.json` 的边界
+### 4.6.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -317,7 +362,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.6 `context_schema`
+### 4.7 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -335,13 +380,14 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.7 纪律重申
+### 4.8 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 
 - `manifest.json` 仍 locator-only
 - `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
 - `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
 - `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
 - repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
 - host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`

--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -18,11 +18,14 @@
 - repo runtime state、review summary、validation status
 - spec review / implementation review instruction locator
 - host action result 的 authored 真相副本
+- dynamic tool availability locator
 - 新的 blocking merge gate
 
 换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
 
 review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
 
 `interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
 
@@ -75,13 +78,23 @@ review instruction locator 属于 [repo-companion-contract.md](./repo-companion-
 - `summary`
 - `surfaces`
 - `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
 
 其中：
 
 - `surfaces` 必须是非空数组
 - `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
 - `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
 - 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
 典型对象包括：
 
@@ -98,13 +111,22 @@ review instruction locator 属于 [repo-companion-contract.md](./repo-companion-
 - `summary`
 - `surfaces`
 - `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
 
 其中：
 
 - `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
 - 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
 - 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
 - repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 
 典型对象包括：
 
@@ -254,6 +276,7 @@ blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
 - 不让 `interop.json` 承载运行态或 authored state
 - 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
 - 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
 - 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
 - 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
 - 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority

--- a/docs/methodology/harness/host-action-contract.md
+++ b/docs/methodology/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -26,6 +32,11 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -97,7 +108,43 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
@@ -114,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/examples/new-project/.loom/bin/governance_surface.py
+++ b/examples/new-project/.loom/bin/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/examples/new-project/.loom/bin/loom_init.py
+++ b/examples/new-project/.loom/bin/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/examples/new-project",
+    "target": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/examples/new-project",
     "scenario": "新项目",
     "scenario_key": "new",
     "integration_mode": "root",
@@ -113,7 +113,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "531c69bbd420ed8547ab522f44b2b3b6b411be1fc67278dda262434acd0e5580"
+      "sha256": "21e3da23e82efdcbc81bff7d9bd7110d5579d8d87fffc9b4cd8e2c6adbb2e78d"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -125,13 +125,13 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "4500b495576057261941492dfce10163f1aff5823f17b996a692729226be8322"
+      "sha256": "b9429ee3eb91bd0431aab3692d885cb7c4987c999075d6737cfb81b7d2bb4ffd"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "5b4b51032f329a18057b53dfb69afc74b1818e31716d45f9bc6e121f27c8db07"
+      "sha256": "7ad209be6e6aee0eb23a6f0e6b01cf995e1745b90118567abe64f17e4b0584f9"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "d2816e34dd38261f60a2c92e3b4e54e95cf22be583a9a8bae844bcf31a2c7fed"
+      "sha256": "0f8b937e6725f233882ab26441c2d8c8d76abfd2c48fc0f758d50287d7bbfb90"
     },
     {
       "path": "AGENTS.md",
@@ -263,12 +263,12 @@
     "scene": "repo-local-demo",
     "carrier": "repo-local-wrapper",
     "entry_family": "loom-init",
-    "install_root": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/skills",
-    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/skills/shared/scripts",
-    "registry_path": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/skills/registry.json",
-    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/skills/install-layout.json",
-    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle",
-    "target_root": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/examples/new-project",
+    "install_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills",
+    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/shared/scripts",
+    "registry_path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/registry.json",
+    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/install-layout.json",
+    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary",
+    "target_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/examples/new-project",
     "checks": {
       "scene_marker": {
         "status": "pass",
@@ -278,21 +278,21 @@
         "status": "pass",
         "summary": "carrier layout exposes an installed skills root and shared runtime tree.",
         "evidence": {
-          "install_root": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/skills"
+          "install_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills"
         }
       },
       "registry_contract": {
         "status": "pass",
         "summary": "registry, upgrade contract, and skill entrypoints are consistent.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/skills/registry.json"
+          "path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/registry.json"
         }
       },
       "shared_runtime": {
         "status": "pass",
         "summary": "shared runtime scripts are present and executable roots can be resolved.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle/skills/shared/scripts"
+          "path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/shared/scripts"
         }
       },
       "referenced_resources": {
@@ -345,18 +345,23 @@
     },
     "github_control_plane": {
       "repository": "MC-and-his-Agents/Loom",
-      "default_branch": "unknown",
-      "branch_protection": "unknown",
-      "required_checks": "unknown",
-      "pr_reviews": "unknown",
+      "default_branch": "main",
+      "branch_protection": "enabled",
+      "required_checks": [
+        "py-compile",
+        "demo-bootstrap",
+        "repo-local-cli",
+        "loom-check"
+      ],
+      "pr_reviews": "not_required",
       "rulesets": {
-        "status": "unknown",
-        "enforced": "unknown",
-        "count": "unknown"
+        "status": "verified",
+        "enforced": false,
+        "count": 0
       },
       "ci_check_presence": {
         "schema_version": "loom-ci-check-presence/v1",
-        "workflow_exists": false,
+        "workflow_exists": true,
         "workflow_locator": ".github/workflows/loom-check.yml",
         "stable_check_names": [
           "py-compile",
@@ -364,32 +369,52 @@
           "repo-local-cli",
           "loom-check"
         ],
-        "check_ran": "unknown",
-        "required_checks_configured": "unknown",
-        "host_enforcement_status": "unverified",
+        "check_ran": true,
+        "required_checks_configured": true,
+        "host_enforcement_status": "verified",
         "recommended_action": "install the workflow and configure its stable check names as host-required checks"
       },
       "host_enforcement": {
-        "branch_protection_or_ruleset": "unknown",
-        "required_checks": "unknown",
-        "verification_status": "unverified"
+        "branch_protection_or_ruleset": true,
+        "required_checks": true,
+        "workflow_exists": true,
+        "check_ran": true,
+        "verification_status": "verified"
       },
       "api_snapshot": {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "cached_non_merge",
-        "verification_status": "unverified",
-        "fallback_status": "host_unavailable",
+        "verification_status": "verified",
+        "fallback_status": null,
         "cache_scope": "process",
         "requests": [
           {
             "method": "GET",
             "path": "repos/MC-and-his-Agents/Loom",
             "purpose": "repository default branch"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/branches/main",
+            "purpose": "branch protection"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/actions/workflows",
+            "purpose": "workflow presence"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/commits/main/check-runs",
+            "purpose": "recent check runs"
+          },
+          {
+            "method": "GET",
+            "path": "repos/MC-and-his-Agents/Loom/rulesets",
+            "purpose": "branch ruleset enforcement"
           }
         ],
-        "errors": [
-          "github control plane: error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com"
-        ],
+        "errors": [],
         "budget": {
           "schema_version": "loom-host-api-budget/v1",
           "default_non_merge_read_mode": "cached_non_merge",
@@ -426,8 +451,14 @@
         "locator": ".loom/companion/repo-interface.json",
         "source": "repo companion manifest.repo_interface"
       },
+      "dynamic_tool_locators": {
+        "status": "present",
+        "locator": ".loom/companion/repo-interface.json",
+        "source": "repo companion manifest.repo_interface"
+      },
       "summary": "repo companion manifest and machine-readable repo interface are readable.",
-      "missing_inputs": []
+      "missing_inputs": [],
+      "missing_optional": []
     },
     "repo_interop": {
       "availability": "present",
@@ -452,7 +483,8 @@
         "source": "repo interop contract"
       },
       "summary": "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity.",
-      "missing_inputs": []
+      "missing_inputs": [],
+      "missing_optional": []
     },
     "workspace_profile": {
       "schema_version": "loom-workspace-profile/v1",
@@ -481,7 +513,7 @@
       "host_worktree": {
         "ownership": "host",
         "status": "present",
-        "locator": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle"
+        "locator": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary"
       },
       "result": "pass",
       "missing_inputs": [],
@@ -591,7 +623,7 @@
         "host_worktree": {
           "ownership": "host",
           "status": "present",
-          "locator": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle"
+          "locator": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary"
         },
         "result": "pass",
         "missing_inputs": [],
@@ -681,12 +713,12 @@
           },
           "branch": {
             "status": "present",
-            "locator": "work/546-workspace-worker-lifecycle",
+            "locator": "work/551-host-action-tool-boundary",
             "authority": "git"
           },
           "worktree": {
             "status": "present",
-            "locator": "/Users/mc/dev/Loom-worktrees/work-546-workspace-worker-lifecycle",
+            "locator": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary",
             "authority": "git"
           },
           "implementation_pr": {
@@ -705,12 +737,10 @@
             "authority": "loom + host"
           }
         },
-        "default_branch": "unknown",
-        "missing_inputs": [
-          "github default branch"
-        ],
-        "result": "block",
-        "summary": "host binding surface is readable, but required binding facts are missing or host-managed."
+        "default_branch": "main",
+        "missing_inputs": [],
+        "result": "pass",
+        "summary": "host binding surface can relate the active Work Item to branch, worktree, PR, merge commit, and closeout."
       },
       "taxonomy": {
         "spec_stale": "Approved spec no longer covers the implementation surface.",
@@ -1098,9 +1128,7 @@
       }
     },
     "summary": "repository is treated as new; Loom can plan the first governance carriers and bootstrap entrypoints without adding a second truth source.",
-    "missing_inputs": [
-      "github control plane: error connecting to api.github.com\ncheck your internet connection or https://githubstatus.com"
-    ]
+    "missing_inputs": []
   },
   "lifecycle_expectations": {
     "schema_version": "loom-workspace-lifecycle/v1",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -35,7 +35,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "531c69bbd420ed8547ab522f44b2b3b6b411be1fc67278dda262434acd0e5580"
+      "sha256": "21e3da23e82efdcbc81bff7d9bd7110d5579d8d87fffc9b4cd8e2c6adbb2e78d"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -47,13 +47,13 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "4500b495576057261941492dfce10163f1aff5823f17b996a692729226be8322"
+      "sha256": "b9429ee3eb91bd0431aab3692d885cb7c4987c999075d6737cfb81b7d2bb4ffd"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "5b4b51032f329a18057b53dfb69afc74b1818e31716d45f9bc6e121f27c8db07"
+      "sha256": "7ad209be6e6aee0eb23a6f0e6b01cf995e1745b90118567abe64f17e4b0584f9"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "d2816e34dd38261f60a2c92e3b4e54e95cf22be583a9a8bae844bcf31a2c7fed"
+      "sha256": "0f8b937e6725f233882ab26441c2d8c8d76abfd2c48fc0f758d50287d7bbfb90"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.68",
+      "version": "0.1.69",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-adopt/.loom-runtime/install-layout.json
+++ b/skills/loom-adopt/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-handoff/.loom-runtime/install-layout.json
+++ b/skills/loom-handoff/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-init/.loom-runtime/install-layout.json
+++ b/skills/loom-init/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-init/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-init/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-init/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-merge-ready/.loom-runtime/install-layout.json
+++ b/skills/loom-merge-ready/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-pre-review/.loom-runtime/install-layout.json
+++ b/skills/loom-pre-review/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-resume/.loom-runtime/install-layout.json
+++ b/skills/loom-resume/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-retire/.loom-runtime/install-layout.json
+++ b/skills/loom-retire/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-review/.loom-runtime/install-layout.json
+++ b/skills/loom-review/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-spec-review/.loom-runtime/install-layout.json
+++ b/skills/loom-spec-review/.loom-runtime/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/shared/references/adoption/repo-companion-contract.md
+++ b/skills/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/skills/shared/references/adoption/repo-interop-contract.md
+++ b/skills/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/skills/shared/references/harness/host-action-contract.md
+++ b/skills/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/src/skills/install-layout.json
+++ b/src/skills/install-layout.json
@@ -70,6 +70,8 @@
     "shared/references/adoption/lightweight-retrofit-default.md",
     "shared/references/adoption/deep-existing-repo-default.md",
     "shared/references/adoption/routing-and-checkpoints.md",
+    "shared/references/adoption/repo-companion-contract.md",
+    "shared/references/adoption/repo-interop-contract.md",
     "loom-init",
     "loom-adopt",
     "loom-resume",

--- a/src/skills/shared/references/adoption/repo-companion-contract.md
+++ b/src/skills/shared/references/adoption/repo-companion-contract.md
@@ -1,0 +1,424 @@
+# Repo Companion Contract
+
+本文冻结 Loom 面向既有仓库的 `repo companion` 主合同。
+
+术语约束：
+
+- 正式术语统一使用 `repo companion`
+- 历史材料中的 `companion docs` 只作为迁移/回溯表述保留，不再作为当前正式合同名
+
+## 1. 目标与边界
+
+`repo companion` 用于既有仓库的增量 adoption。
+
+它只承接以下对象：
+
+- repo-specific 规则入口
+- repo-specific requirements 的机读声明
+- specialized gates 的机读声明
+- 仓库级 adoption / workflow 挂接入口
+
+与之并行但单独分离的 companion-owned 读面：
+
+- retained host action result / repo-native carrier / shadow parity 的只读入口
+  - 由 [repo-interop-contract.md](../adoption/repo-interop-contract.md) 承接
+
+它不承接以下 authored truth：
+
+- work item
+- recovery 进度
+- review 结论
+- current stop / next step / blockers / validation summary
+- closeout 已完成状态
+
+这些 authored truth 继续由现有 `harness/`、`governance/`、review record、recovery carrier 与 closeout 合同承接。
+
+## 2. Ownership Boundary
+
+- Loom core
+  - 持有通用 governance truth、checkpoint 语义、review layering、host-action 与 closeout 合同
+- repo companion
+  - 持有 repo-specific requirements、specialized gates、repo-level workflow 挂接与 locator
+- host adapter / host platform
+  - 持有 branch / PR / worktree / CI / ruleset / project 等 retained host actions 的底层实现
+
+稳定约束：
+
+- `repo companion` 不得把 repo-specific 规则伪装成 Loom core 默认规则
+- `repo companion` 不得改写 retained host actions 的 ownership
+- retained host actions 继续以 [host-action-contract.md](../harness/host-action-contract.md) 与 [closeout-gate.md](../harness/closeout-gate.md) 为唯一主落点
+
+## 3. `.loom/companion/manifest.json`
+
+`.loom/companion/manifest.json` 是 `repo companion` 的 locator-only manifest。
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-companion-manifest/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_interface": ".loom/companion/repo-interface.json"
+}
+```
+
+字段约束：
+
+- `schema_version` 固定为 `loom-repo-companion-manifest/v1`
+- `companion_entry` 必须指向可读的 `repo companion` 主文档
+- `repo_interface` 必须指向可读的 `.loom/companion/repo-interface.json`
+
+禁止事项：
+
+- 增加实时 authored state
+- 增加 review summary / current stop / blockers / validation summary
+- 增加 closeout result 或任何“已经完成”的运行态声明
+- 把 manifest 扩成第二套状态面
+
+换句话说，manifest 只负责定位 companion 入口与机读接口，不负责承载运行态真相。
+
+## 4. `.loom/companion/repo-interface.json`
+
+`.loom/companion/repo-interface.json` 是 companion-owned 的最小机读合同，供 `governance_surface` 与 `loom_flow` 消费。
+
+当前兼容读取两个 schema：
+
+- `loom-repo-interface/v1`
+- `loom-repo-interface/v2`
+
+其中：
+
+- `v1` 继续保持可读，作为下游兼容口径
+- `v2` 是当前正式扩展口径，用于承接 typed `specialized_gates`、repo-specific metadata contract、context schema 与 dynamic tool locator
+
+### 4.1 `v1` 兼容合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v1",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": []
+}
+```
+
+`v1` 字段约束：
+
+- `schema_version` 固定为 `loom-repo-interface/v1`
+- `companion_entry` 必须指向可读的 companion 主文档
+- `repo_specific_requirements` 必须同时声明 `review`、`merge_ready`、`closeout` 三个 surface
+- `specialized_gates` 必须存在，可为空数组
+
+### 4.2 `v2` 扩展合同
+
+```json
+{
+  "schema_version": "loom-repo-interface/v2",
+  "companion_entry": ".loom/companion/README.md",
+  "repo_specific_requirements": {
+    "review": [],
+    "merge_ready": [],
+    "closeout": []
+  },
+  "specialized_gates": [],
+  "review_instruction_locators": {
+    "spec_review": {
+      "locator": ".loom/companion/review-instructions/spec.md",
+      "mode": "repo_declared"
+    },
+    "implementation_review": {
+      "locator": ".loom/companion/review-instructions/implementation.md",
+      "mode": "repo_declared"
+    }
+  },
+  "metadata_contract": {
+    "fields": []
+  },
+  "context_schema": {
+    "fields": []
+  },
+  "dynamic_tool_locators": []
+}
+```
+
+`v2` 在 `v1` 之上新增四个可选顶层 section：
+
+- `review_instruction_locators`
+- `metadata_contract`
+- `context_schema`
+- `dynamic_tool_locators`
+
+稳定约束：
+
+- `metadata_contract` 与 `context_schema` 只在 `v2` 合法
+- `review_instruction_locators` 只在 `v2` 合法
+- `dynamic_tool_locators` 只在 `v2` 合法
+- `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
+- `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
+
+### 4.3 通用字段纪律
+
+`repo_specific_requirements` 的每条 requirement 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `enforcement`
+
+其中：
+
+- `enforcement` 只允许 `blocking | advisory`
+- `locator` 必须指向仓内可读路径
+
+`specialized_gates` 的每条 gate 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `gate_type` 可选
+
+其中：
+
+- `gate_type` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `gate_type` 只用于说明 gate 所属 Loom surface，不承载 repo-specific 运行态细节
+
+### 4.4 `review_instruction_locators`
+
+`review_instruction_locators` 用于声明仓库已有 review instruction 的机读入口。它回答的是：
+
+- formal spec review 应读取哪份 repo-owned instruction
+- implementation review 应读取哪份 repo-owned instruction
+- 目标仓库是否显式选择 Loom default review instruction
+
+当前固定 key：
+
+- `spec_review`
+- `implementation_review`
+
+每个 locator entry 固定字段：
+
+- `locator`
+- `mode`
+
+其中：
+
+- `locator` 必须指向仓内可读路径
+- `mode` 只允许 `repo_declared | loom_default`
+
+稳定约束：
+
+- 成熟既有仓库和 deep-existing attach path 必须优先声明 repo-owned locator，不得让 Loom 猜测文件名
+- lightweight / new repository 可以显式使用 `loom_default`，但仍必须把选择写进 `repo-interface.json`
+- 不得把 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径硬编码成 Loom 默认查找路径
+- repo-owned instruction 应说明该仓库如何检查 behavior evidence、test evidence 与 fresh verification evidence
+- `review_instruction_locators` 只定位 review instruction，不承载 review verdict、review summary、finding disposition、validation status 或 retained host action result
+- missing、unreadable 或 unsafe locator 在 mature / deep-existing 仓库中必须 fail closed；轻量仓库必须显式声明 `loom_default` 才能走默认 instruction
+
+### 4.5 `dynamic_tool_locators`
+
+`dynamic_tool_locators` 用于声明 repo-specific 或 host-provided dynamic tool 的 declaration-time locator。它回答的是：
+
+- Loom 应去哪里读取工具可用性声明
+- 该 locator 的真实 owner 是谁
+- 缺失时按 required、optional 还是 advisory 处理
+- 缺失时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- 工具是否在一次具体尝试中 advertised、unavailable、unsupported 或 failed
+- 工具调用结果是什么
+- Loom 应如何接管 host/platform/tool 的执行协议
+- retained host action result 应写在哪里
+
+`dynamic_tool_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+其中：
+
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述工具调用
+
+稳定约束：
+
+- `required` 缺口进入 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
+- retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
+
+### 4.6 `metadata_contract`
+
+`metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
+
+它回答的是：
+
+- 这组 repo-specific metadata 在什么条件下适用
+- 真正的权威承载面位于哪里
+- Loom 应按什么阻断强度消费它
+
+它不回答：
+
+- Loom 运行时当前处于什么状态
+- review / validation / merge / closeout 已经得出了什么结论
+- retained host action 的结果是什么
+- 跨仓默认应统一使用哪些字段名
+
+换句话说，`metadata_contract.fields[*]` 是 locator-first 的“这组 repo-local metadata 去哪里读、何时读、按什么强度读”，不是“Loom core 现在认可哪些 metadata 字段名”的总表。
+
+`metadata_contract.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `applicability_locator`
+- `authority_locator`
+- `enforcement`
+
+其中：
+
+- `applicability_locator` 指向“何时需要这组 metadata”的 companion 或 repo-local 权威说明
+- `authority_locator` 指向 metadata 真正承载的 repo-native carrier、模板或权威入口
+- `enforcement` 只允许 `blocking | advisory`
+
+当前已被样本证明有价值、但仍保持 repo-specific example 的字段族包括：
+
+- `integration_check`
+- `gate_applicability`
+- `live_evidence_record`
+
+稳定约束：
+
+- 这些名字可以作为 repo-specific metadata block example 出现在 companion 合同中
+- 它们不得被回写成 Loom core 默认字段名
+- Loom 不为它们提供跨仓统一 taxonomy 承诺
+
+### 4.6.1 明确禁止上移的字段模式
+
+`metadata_contract` 不得承接以下字段模式：
+
+- runtime state
+  - 例如 `runtime_state`、`current_lane`、`run_entry`、`logs_entry`、`diagnostics_entry`、`verification_entry`
+- authored execution state
+  - 例如 `current_stop`、`next_step`、`blockers`、`latest_validation_summary`
+- review summary / review verdict
+  - 例如 `review_summary`、`review_decision`、`reviewed_validation_summary`
+- validation / merge / closeout status
+  - 例如 `validation_status`、`merge_verdict`、`closeout_result`
+- retained host action result
+  - 例如 `guardian_verdict`、`ruleset_result`、`host_action_result`
+
+这些字段模式分别属于：
+
+- `harness/` 与 recovery / status carriers
+- review record 与 closeout 合同
+- companion-owned `interop.json`
+
+它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
+
+### 4.6.2 与 `context_schema` 的边界
+
+`metadata_contract` 与 `context_schema` 的分工固定如下：
+
+- `metadata_contract`
+  - 声明 repo-local metadata block 的适用条件、权威入口与阻断强度
+- `context_schema`
+  - 声明 Loom 运行某个 surface 时必须提供哪些 repo-specific 上下文字段
+
+明确禁止事项：
+
+- 不得在 `metadata_contract` 中声明 `issue`、`item_key`、`release`、`sprint`、`guardian_lane` 这类调用上下文字段
+- 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
+- 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
+
+### 4.6.3 与 `interop.json` 的边界
+
+`metadata_contract` 不得声明以下 locator：
+
+- retained host action result 的 locator
+- repo-native carrier truth 的 locator
+- `shadow parity` compare surface 的 locator
+- external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
+
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
+external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
+
+明确禁止事项：
+
+- 不得把 guardian / integration / ruleset / merge-native verdict 的结果 locator 写进 `metadata_contract`
+- 不得把 `shadow_surfaces` 的 `loom_locator` / `repo_locator` 回塞到 `repo-interface.json`
+- 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
+- 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
+
+### 4.7 `context_schema`
+
+`context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
+
+`context_schema.fields[*]` 固定字段：
+
+- `id`
+- `summary`
+- `type`
+- `required`
+- `mapping_rule_locator`
+
+其中：
+
+- `type` 只允许基础类型：`string | integer | number | boolean`
+- `required` 必须是布尔值
+- `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
+
+### 4.8 纪律重申
+
+无论 `v1` 或 `v2`，以下纪律保持不变：
+
+- `manifest.json` 仍 locator-only
+- `repo-interface.json` 仍不承载运行态、review summary、current stop、validation status 或 host action result
+- `review_instruction_locators` 只承接 repo-owned review instruction 入口，不得承接 review disposition 或 review result
+- `dynamic_tool_locators` 只承接 dynamic tool availability locator，不得承接 attempt-time result 或 host action result
+- `metadata_contract` 仍只是 repo-specific metadata block 的 locator contract，不定义 Loom core 默认 taxonomy
+- repo-specific 规则仍通过 companion 合同挂接，不得伪装成 Loom core 默认规则
+- host adapter / repo-native carrier / shadow parity 入口继续留在独立的 `interop.json`，不得回塞到 `repo-interface.json`
+
+## 5. 读面语义
+
+`governance_surface.repo_interface` 当前只允许暴露以下四类状态：
+
+- `absent`
+  - 仓库没有 `repo companion` manifest
+- `companion_docs_only`
+  - 仓库有旧式 companion docs，但没有稳定机读 manifest
+- `incomplete`
+  - manifest 或 repo-interface 存在，但 locator / schema / required surface 不完整
+- `present`
+  - manifest 与 repo-interface 都可读且满足最小合同
+
+稳定约束：
+
+- `companion_docs_only` 不得被伪装成稳定 repo interface
+- `incomplete` 必须显式报缺口，不得猜测 requirements
+- `present` 只表示接口可读，不表示 repo-specific requirements 已被 Loom core 满足
+
+## 6. 与从属合同的关系
+
+`repo companion` 是仓库级 adoption 主合同。
+
+agent-assisted adoption 的读、判断、回写与验证闭环由 [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md) 承接。该从属合同只能消费本文件已经冻结的 manifest、`repo-interface.json`、metadata/context 与 ownership 边界，不得把 companion 扩成运行态真相源。
+
+若后续需要 companion-oriented workflow 或 migration 文档：
+
+- 只能作为从属合同
+- 只能消费本文件已经冻结的边界
+- 不得反向扩张为 Loom 全局 issue-model 或 parent/sub-issue 默认规则

--- a/src/skills/shared/references/adoption/repo-interop-contract.md
+++ b/src/skills/shared/references/adoption/repo-interop-contract.md
@@ -1,0 +1,295 @@
+# Repo Interop Contract
+
+本文冻结 Loom 面向成熟既有仓库的 `repo interop` 主合同。
+
+它承接的是 companion-owned 的只读消费面，而不是新的宿主执行层。
+
+## 1. 目标与边界
+
+`.loom/companion/interop.json` 用于声明三类只读入口：
+
+- retained host action result 的读取入口
+- repo-native carrier / evidence / truth 的读取入口
+- `shadow mode` parity compare 的读取入口
+
+它不承接：
+
+- branch / PR / worktree / merge 的执行命令
+- repo runtime state、review summary、validation status
+- spec review / implementation review instruction locator
+- host action result 的 authored 真相副本
+- dynamic tool availability locator
+- 新的 blocking merge gate
+
+换句话说，`interop.json` 只告诉 Loom “去哪里读”，不告诉 Loom “如何替宿主执行”。
+
+review instruction locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `review_instruction_locators`，因为它定位的是 repo-owned review rule 入口，不是 retained host action result、repo-native carrier 或 shadow parity evidence。
+
+dynamic tool availability locator 属于 [repo-companion-contract.md](./repo-companion-contract.md) 的 `dynamic_tool_locators`，因为它定位的是工具声明入口，不是 retained host action result。
+
+`interop.json` 中声明的入口在 fact-chain 中只能被消费为 host/control-plane mirror、retained result、repo-native carrier locator 或 locator provenance。它不得成为新的 Loom-authored truth，也不得覆盖 `Work Item`、恢复主入口、review record、merge checkpoint 或 closeout basis。
+
+## 2. `.loom/companion/interop.json`
+
+当前稳定 schema：
+
+```json
+{
+  "schema_version": "loom-repo-interop/v1",
+  "host_adapters": [],
+  "repo_native_carriers": [],
+  "shadow_surfaces": {
+    "admission": {
+      "summary": "Compare admission parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/admission-loom.json",
+      "repo_locator": ".loom/shadow/admission-repo.json"
+    },
+    "review": {
+      "summary": "Compare review parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/review-loom.json",
+      "repo_locator": ".loom/shadow/review-repo.json"
+    },
+    "merge_ready": {
+      "summary": "Compare merge-ready parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/merge-ready-loom.json",
+      "repo_locator": ".loom/shadow/merge-ready-repo.json"
+    },
+    "closeout": {
+      "summary": "Compare closeout parity between Loom and the repo-native result.",
+      "loom_locator": ".loom/shadow/closeout-loom.json",
+      "repo_locator": ".loom/shadow/closeout-repo.json"
+    }
+  }
+}
+```
+
+顶层字段约束：
+
+- `schema_version` 固定为 `loom-repo-interop/v1`
+- `host_adapters` 必须存在，可为空数组
+- `repo_native_carriers` 必须存在，可为空数组
+- `shadow_surfaces` 必须同时声明 `admission`、`review`、`merge_ready`、`closeout`
+
+## 3. `host_adapters`
+
+`host_adapters[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `surfaces` 必须是非空数组
+- `surfaces[*]` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `locator` 只描述 Loom 如何读取 retained host action 的结果，不描述如何执行动作本身
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 读取结果必须作为 retained result 消费，并保留原始 locator、绑定对象与 fresh/stale 判断
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+- `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
+
+典型对象包括：
+
+- guardian verdict
+- integration contract verdict
+- repo settings / ruleset verdict
+- repo-native merge readiness verdict
+
+## 4. `repo_native_carriers`
+
+`repo_native_carriers[*]` 固定字段：
+
+- `id`
+- `summary`
+- `surfaces`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `locator` 可以指向 repo-native truth / evidence 目录、文件或生成结果
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径
+- 这些 carrier 继续保留为仓库原生真相，不要求先迁成 Loom carrier
+- 若 repo-native carrier 与 Loom authored truth 表达同一事实，Loom 不自动选择 repo-native 值；该差异只能进入 provenance / drift / parity 结果
+- repo-native carrier 不会因为被 `interop.json` 声明就自动变成 host/control-plane mirror；除非另有权威合同声明，它只是只读 locator 或 retained result 来源
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- `required` locator 缺失或指向不可读路径必须 fail closed
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
+
+典型对象包括：
+
+- exec-plan 目录
+- governance status 输出
+- integration contract 输出
+- repo-native evidence ledger
+
+## 5. `shadow_surfaces`
+
+`shadow_surfaces` 当前只承接四个固定比对面：
+
+- `admission`
+- `review`
+- `merge_ready`
+- `closeout`
+
+每个 surface 固定字段：
+
+- `summary`
+- `loom_locator`
+- `repo_locator`
+
+稳定约束：
+
+- parity compare 结果只允许 `match | mismatch | unreadable`
+- 默认 `shadow mode` 在本树内只做 validation / parity，不直接成为 merge gate
+- 只有显式 `blocking` 消费模式可以把 `mismatch` / `unreadable` 升级为阻断结果
+- `shadow_surfaces` 只描述比对入口，不声明“哪一方自动获胜”
+- `loom_locator` 与 `repo_locator` 必须指向 shadow evidence envelope，而不是裸状态值
+- `shadow_surfaces` 输出不得被消费为 authored truth；它只证明派生读面或 repo-native carrier 是否同源、可读、可比较
+
+### 5.1 shadow evidence envelope
+
+每个 shadow evidence JSON 必须包含：
+
+- `source_files`
+- `source_sha256`
+- 一个可比较值字段：`parity_value | result | decision | status | verdict | value`
+
+`source_files` 必须是非空数组，且只允许仓库内相对路径。`source_sha256` 必须以相同 key set 记录这些 source file 的 sha256。
+
+示例：
+
+```json
+{
+  "result": "pass",
+  "source_files": ["native/status/review.json"],
+  "source_sha256": {
+    "native/status/review.json": "..."
+  }
+}
+```
+
+运行时必须校验：
+
+- source 文件存在且不是目录
+- source 路径不得是绝对路径，不得越出仓库
+- `source_files` 与 `source_sha256` key set 完全一致
+- sha256 必须匹配当前文件内容
+- `.loom/shadow/*.json` 中除 `.loom/shadow/shadow-parity.json` 外，只允许被 `shadow_surfaces` 显式声明
+
+任一条件失败时，对应 surface 必须进入 `unreadable`，blocking 模式下升级为 `block`。
+
+若 envelope 可读但 `source_sha256` 对应的源文件已不再匹配当前消费对象，结果必须视为 stale retained result 或 stale carrier evidence，不得作为 fresh verification evidence。
+
+### 5.2 blocking 消费模式
+
+`interop.json` 仍然只描述读取入口。它不得承载 blocking owner、override decision 或 final verdict。
+
+若 strong governance profile 显式启用 blocking 消费，启用点必须在 `interop.json` 之外声明：
+
+- owner
+- fallback
+- override path
+- authority-of-truth
+- live evidence
+
+默认命令仍是 validation-only：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo>
+```
+
+blocking 模式必须显式开启：
+
+```bash
+python3 tools/loom_flow.py shadow-parity --target <repo> --blocking
+```
+
+blocking 模式只改变消费结果，不改变 `shadow_surfaces` schema：
+
+- `match` -> `pass`
+- `mismatch` -> `block`
+- `unreadable` -> `block`
+
+### 5.2 从默认 validation-only 升级前必须满足的证据标准
+
+要讨论是否从 validation-only 升级到更强治理面，必须同时满足以下条件：
+
+1. 至少两个新增的 live adopted repo
+   - 不得只重复消费当前下游基线样本表述
+2. 每个样本都提供版本化 parity 记录
+   - 至少覆盖 `admission`
+   - `review`
+   - `merge_ready`
+   - `closeout`
+3. `mismatch` 必须能稳定分型
+   - 至少区分：
+     - contract drift
+     - surface unreadable
+     - Loom bug
+     - repo-native lag
+4. 必须证明更强 gate 的收益
+   - 也就是自动升级后能减少真实错误放行
+   - 同时不会制造不可接受的误阻断
+5. blocking ownership、override path、authority-of-truth 必须落在 `interop.json` 之外的权威合同
+   - 例如 host action、closeout gate、review / checkpoint 合同
+
+只要以上任一条件未满足，`shadow parity` 就不得成为默认 blocking gate。
+
+### 5.3 当前明确不做
+
+在本树当前阶段，明确不做以下升级：
+
+- 不把 `mismatch` 默认视为 blocking merge gate
+- 不把 `unreadable` 视为 repo-native 失败或 Loom 自动获胜
+- 不在 `interop.json` 中声明 blocking owner、override decision 或 final verdict
+- 不要求 `shadow parity` 代替 review、merge-ready 或 closeout 的正式 authority-of-truth
+
+## 6. 与其他合同的关系
+
+- `repo-interface.json`
+  - 承接 repo-specific rules、requirements、typed gates、metadata/context contract
+- `interop.json`
+  - 承接 retained host action result、repo-native carrier 与 shadow parity 的只读入口
+- [zero-friction-adoption-contract.md](./zero-friction-adoption-contract.md)
+  - 承接 agent-assisted adoption 中生成或更新 `interop.json` 的读、判断、回写与验证闭环
+- [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)
+  - 承接从 vendored `.loom/bin` 到 versioned external Loom runtime 的迁移路径
+- [host-action-contract.md](../harness/host-action-contract.md)
+  - 承接宿主动作 ownership、结果语义与 fallback discipline
+
+纪律重申：
+
+- 不把 interop 细节塞回 `repo-interface.json`
+- 不让 `interop.json` 承载运行态或 authored state
+- 不让 `interop.json` 承载 status control plane 的结论或 runtime_state
+- 不让 `interop.json` 承载 spec review / implementation review instruction locator；这些 locator 必须通过 `repo-interface.json` 的 `review_instruction_locators` 声明
+- 不让 `interop.json` 承载 dynamic tool availability locator；这些 locator 必须通过 `repo-interface.json` 的 `dynamic_tool_locators` 声明
+- 不让 `interop.json` 承载 external-runtime locator、runtime version、rollback mode 或 runtime provenance
+- 不让 Loom 因为读取了 interop contract，就接管宿主底层实现
+- 不让 `interop.json` 定义 blocking owner、override path 或 final merge authority
+- 不让 zero-friction adoption 把 validation-only shadow parity 自动升级成 blocking gate
+
+## 7. 与 external-runtime / de-vendor migration 的边界
+
+external-runtime 迁移只改变 Loom runtime 的执行来源，不改变 interop 读取的 repo-native truth。
+
+稳定约束：
+
+- `.loom/companion/interop.json` 在 vendored runtime 与 external runtime 下必须保持同一只读 locator 语义
+- `host_adapters`、`repo_native_carriers`、`shadow_surfaces` 不得因为 runtime locator 改变而改写 truth
+- shadow evidence envelope 的 `source_files` 与 `source_sha256` 必须继续以仓内文件为 authority
+- external-runtime locator 必须落在 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)，不得写入 `interop.json`
+- de-vendor 后的失败回滚必须回到 vendored `.loom/bin` 或重新 bootstrap，不得通过篡改 interop 结果伪装通过

--- a/src/skills/shared/references/harness/host-action-contract.md
+++ b/src/skills/shared/references/harness/host-action-contract.md
@@ -12,6 +12,12 @@
 - 每类入口允许返回什么结果，以及 `fallback_to` 指向哪里
 - Loom 与宿主平台各自拥有哪部分动作，不新增新的宿主产品或自动化层
 
+它同时冻结 v0.7 的 dynamic tool availability / host action declaration 边界：
+
+- 只声明 locator、owner、requirement、surface、fallback_to 与 fail-closed 强度
+- 不定义 attempt-time advertised / unavailable / unsupported / failed 结果词表；这些属于后续工具调用尝试合同
+- 不让 Loom 接管 host、platform 或 external tool 的 ownership
+
 ## 1. 能力定位
 
 Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身。
@@ -20,7 +26,17 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 宿主对象边界读取
 - 宿主 gate / required checks / merge controls 的放行消费
-- `GitHub controlled merge` 前后的 drift 审计与控制面对齐
+- post-merge 的 drift 审计与控制面对齐
+
+当成熟既有仓库需要把 retained host action result 暴露给 Loom 时：
+
+- 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
+- Loom 只消费这些结果，不接管动作执行本身
+
+当成熟既有仓库需要声明 dynamic tool availability 时：
+
+- 工具 locator 通过 companion-owned `.loom/companion/repo-interface.json` 的 `dynamic_tool_locators` 声明
+- Loom 只校验 locator 是否可消费，不调用工具、不探测运行时可用性、不写入尝试结果
 
 具体专题落点仍保持拆分：
 
@@ -36,13 +52,13 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 | 类别 | 稳定入口 | 宿主写入 | 说明 |
 | --- | --- | --- | --- |
-| boundary read | `python3 skills/shared/scripts/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
-| merge control read | `python3 skills/shared/scripts/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
-| merge control summary | `python3 skills/loom-merge-ready/scripts/loom-merge-ready.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 `GitHub controlled merge` 前的统一放行摘要 |
-| drift audit | `python3 skills/shared/scripts/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
-| control-plane sync | `python3 skills/shared/scripts/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
-| closeout check | `python3 skills/shared/scripts/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
-| closeout sync | `python3 skills/shared/scripts/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
+| boundary read | `python3 tools/loom_flow.py host-lifecycle --target <repo> [--item <id>]` | 否 | 读取 workspace / branch / PR / git worktree 的 ownership boundary |
+| merge control read | `python3 tools/loom_flow.py checkpoint merge --target <repo> [--item <id>]` | 否 | 读取 Loom 对 required checks / validation / review / risk rollback 的放行结论 |
+| merge control summary | `python3 tools/loom_flow.py flow merge-ready --target <repo> [--item <id>]` | 否 | 汇总进入 host merge 前的统一放行摘要 |
+| drift audit | `python3 tools/loom_flow.py reconciliation audit --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 只读 issue / PR / project 控制面并输出 drift findings |
+| control-plane sync | `python3 tools/loom_flow.py reconciliation sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>] [--comment-file <path>] [--dry-run]` | 是 | 只修机械可证明的 reconciliation drift |
+| closeout check | `python3 tools/loom_flow.py closeout check --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 否 | 校验 main、issue、PR、project 与仓内结果是否一致 |
+| closeout sync | `python3 tools/loom_flow.py closeout sync --target <repo> [--issue <n>] [--pr <n>] [--project <n>]` | 是 | 在可同步条件下继续做 closeout 控制面对齐 |
 
 以下内容继续明确排除在 Loom 宿主动作面之外：
 
@@ -78,8 +94,8 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 | 入口 | 允许结果 | `fallback_to` 纪律 |
 | --- | --- | --- |
 | `host-lifecycle` | `pass` / `block` | 只在事实链无法读取时回到 `admission`；正常边界读取不产生 `fallback` 结果 |
-| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate，不得指向宿主控制面动作 |
-| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 gate 摘要，不得把 host merge 伪装成回退目标 |
+| `checkpoint merge` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint，不得指向宿主控制面动作 |
+| `flow merge-ready` | `pass` / `block` / `fallback` | `fallback_to` 只能指向 Loom 内部 checkpoint 摘要，不得把 host merge 伪装成回退目标 |
 | `reconciliation audit` | `pass` / `warn` / `fix-needed` / `block` | 非 `pass` 时只允许 `manual-reconciliation` 或 `null`；它负责报 drift，不把 drift 伪装成 `fallback` |
 | `reconciliation sync` | `pass` / `block` | `block` 时只允许指向 `manual-reconciliation` 或 `null`；`--dry-run` 也不得把未解决 drift 伪装成通过 |
 | `closeout check` | `pass` / `block` | 普通 closeout 缺口指向 `merge`；若 reconciliation 为 `fix-needed` 必须指向 `reconciliation-sync`；若 reconciliation 为 `block` 必须指向 `manual-reconciliation` |
@@ -87,19 +103,54 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 补充纪律：
 
-- `fallback` 结果只用于 Loom 内部前序 gate / flow 的回退，不用于 closeout 或 reconciliation
+- `fallback` 结果只用于 Loom 内部前序 checkpoint / flow 的回退，不用于 closeout 或 reconciliation
 - `warn` 与 `fix-needed` 只作为 `reconciliation audit` 的顶层结果存在
 - `fallback_to` 是下一步去向，不等价于把 `result` 改写成 `fallback`
 - 宿主动作不得把 branch / PR / worktree 的真实生命周期命令当作 `fallback_to`
 
-## 5. Ownership Boundary
+## 5. Dynamic Tool 与 Host Action Locator
+
+v0.7 只冻结 declaration-time locator contract。
+
+每个 dynamic tool 或 retained host action locator 必须声明：
+
+- `id`
+- `summary`
+- `locator`
+- `owner`
+- `requirement`
+- `surface`
+- `fallback_to`
+
+字段纪律：
+
+- `owner` 只描述真实拥有者，可为 `repo`、`repo-companion`、`host`、`host-adapter`、`platform` 或 `external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `surface` 只允许 `admission | pre_review | review | build | merge_ready | closeout`
+- `fallback_to` 只描述声明不可消费时回到哪个 Loom surface 或人工路径，不描述如何调用工具
+
+消费纪律：
+
+- locator 绝对路径、越界或非法路径对所有 requirement 都必须 fail closed，进入 blocking `missing_inputs`
+- `required` locator 缺失或指向不可读路径必须 fail closed，进入对应 surface 的 blocking `missing_inputs`
+- `optional` / `advisory` locator 缺失或指向不可读路径只能进入 profile-local `missing_optional` / advisory evidence，不得污染 core pass/fail
+- locator 校验不得执行宿主动作、不得调用 dynamic tool、不得写 attempt-time result
+- retained host action result locator 留在 `.loom/companion/interop.json`
+- dynamic tool availability locator 留在 `.loom/companion/repo-interface.json`
+
+明确排除：
+
+- 不定义 advertised / unavailable / unsupported / failed 等尝试期结果
+- 不在 Loom core 中定义 host/platform 的调用协议
+- 不把 optional/advisory 缺口升级成普通 PR blocking gate
+
+## 6. Ownership Boundary
 
 Loom 当前承接：
 
 - workspace execution semantics
 - required checks / validation / review / risk rollback 的放行消费
 - 对宿主对象绑定、drift 与 absorbed 结论的读取和校验
-- `status control plane` 所需的宿主控制面读面
 - closeout 前后的控制面对齐判断
 
 宿主平台当前承接：
@@ -110,7 +161,7 @@ Loom 当前承接：
 
 因此，Loom 可以报告、消费、阻断或要求回退，但不会在这里扩展成新的宿主自动化产品。
 
-## 6. 专题文件分工
+## 7. 专题文件分工
 
 - [host-lifecycle-boundary.md](./host-lifecycle-boundary.md)
   - 只定义 workspace、branch、PR、git worktree 的 ownership boundary

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -204,7 +204,14 @@ REPO_INTERFACE_GATE_TYPES = {
 REPO_INTERFACE_CONTEXT_TYPES = {"string", "integer", "number", "boolean"}
 REPO_INTERFACE_MANIFEST_KEYS = {"schema_version", "companion_entry", "repo_interface"}
 REPO_INTERFACE_V1_KEYS = {"schema_version", "companion_entry", "repo_specific_requirements", "specialized_gates"}
-REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {"review_instruction_locators", "metadata_contract", "context_schema"}
+REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
+    "review_instruction_locators",
+    "metadata_contract",
+    "context_schema",
+    "dynamic_tool_locators",
+}
+DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
+DECLARED_LOCATOR_OWNERS = {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}
 REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 REPO_INTEROP_SCHEMA = "loom-repo-interop/v1"
 REPO_INTEROP_KEYS = {"schema_version", "host_adapters", "repo_native_carriers", "shadow_surfaces"}
@@ -885,21 +892,82 @@ def validate_context_schema(
     return missing_inputs
 
 
+def locator_field_missing(value: object) -> bool:
+    return not isinstance(value, str) or not value.strip()
+
+
+def validate_dynamic_tool_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"dynamic_tool_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "surface", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    surface = entry.get("surface")
+    if surface not in REPO_INTEROP_COLLECTION_SURFACES:
+        blocking.append(
+            f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+        )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
 def validate_repo_interop_collection_entry(
     *,
     root: Path,
     collection: str,
     entry: object,
     index: int,
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     prefix = f"{collection}[{index}]"
     if not isinstance(entry, dict):
-        return [f"{prefix} must be an object"]
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
     missing_inputs: list[str] = []
-    for field in ("id", "summary", "locator"):
+    missing_optional: list[str] = []
+    for field in ("id", "summary", "owner", "requirement", "fallback_to"):
         value = entry.get(field)
         if not isinstance(value, str) or not value.strip():
             missing_inputs.append(f"{prefix} missing `{field}`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
     surfaces = entry.get("surfaces")
     if not isinstance(surfaces, list) or not surfaces:
         missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
@@ -909,12 +977,24 @@ def validate_repo_interop_collection_entry(
                 missing_inputs.append(
                     f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
                 )
-    locator, target = resolve_locator(root, entry.get("locator"))
-    if locator is None or target is None:
-        missing_inputs.append(locator_boundary_error(entry.get("locator"), label=f"{prefix} locator"))
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
     elif not target.exists():
-        missing_inputs.append(f"{prefix} locator points to missing path `{locator}`")
-    return missing_inputs
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            missing_optional.append(locator_error)
+        else:
+            missing_inputs.append(locator_error)
+    return missing_inputs, missing_optional
 
 
 def validate_shadow_surface(
@@ -950,10 +1030,13 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "companion_entry": carrier_entry("missing", "unknown", "repo companion manifest"),
         "repo_specific_requirements": carrier_entry("missing", "unknown", "repo companion interface"),
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
+        "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not manifest_path.exists():
         if has_legacy_companion_docs(root):
@@ -1003,6 +1086,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     )
     repo_interface_surface["repo_specific_requirements"] = manifest_repo_interface
     repo_interface_surface["specialized_gates"] = manifest_repo_interface.copy()
+    repo_interface_surface["dynamic_tool_locators"] = manifest_repo_interface.copy()
     if manifest_repo_interface_error:
         missing_inputs.append(manifest_repo_interface_error)
 
@@ -1098,6 +1182,19 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             entry=context_schema,
                         )
                     )
+                dynamic_tool_locators = interface_payload.get("dynamic_tool_locators")
+                if dynamic_tool_locators is not None:
+                    if not isinstance(dynamic_tool_locators, list):
+                        missing_inputs.append("dynamic_tool_locators must be a list")
+                    else:
+                        for index, entry in enumerate(dynamic_tool_locators):
+                            blocking, optional = validate_dynamic_tool_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
 
     if missing_inputs:
         repo_interface_surface["availability"] = "incomplete"
@@ -1107,9 +1204,12 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
     else:
         repo_interface_surface["availability"] = "present"
         repo_interface_surface["summary"] = (
-            "repo companion manifest and machine-readable repo interface are readable."
+            "repo companion interface is readable with optional tool locator advisories."
+            if missing_optional
+            else "repo companion manifest and machine-readable repo interface are readable."
         )
     repo_interface_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interface_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interface_surface, list(dict.fromkeys(missing_inputs))
 
 
@@ -1123,8 +1223,10 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         "shadow_surfaces": carrier_entry("missing", "unknown", "repo interop contract"),
         "summary": "no repo interop contract is declared for this repository.",
         "missing_inputs": [],
+        "missing_optional": [],
     }
     missing_inputs: list[str] = []
+    missing_optional: list[str] = []
 
     if not interop_path.exists():
         return repo_interop_surface, missing_inputs
@@ -1159,28 +1261,28 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
             missing_inputs.append("repo interop contract must include `host_adapters` as a list")
         else:
             for index, entry in enumerate(host_adapters):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="host_adapters",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="host_adapters",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         repo_native_carriers = interop_payload.get("repo_native_carriers")
         if not isinstance(repo_native_carriers, list):
             missing_inputs.append("repo interop contract must include `repo_native_carriers` as a list")
         else:
             for index, entry in enumerate(repo_native_carriers):
-                missing_inputs.extend(
-                    validate_repo_interop_collection_entry(
-                        root=root,
-                        collection="repo_native_carriers",
-                        entry=entry,
-                        index=index,
-                    )
+                blocking, optional = validate_repo_interop_collection_entry(
+                    root=root,
+                    collection="repo_native_carriers",
+                    entry=entry,
+                    index=index,
                 )
+                missing_inputs.extend(blocking)
+                missing_optional.extend(optional)
 
         shadow_surfaces = interop_payload.get("shadow_surfaces")
         if not isinstance(shadow_surfaces, dict):
@@ -1209,8 +1311,13 @@ def detect_repo_interop(root: Path) -> tuple[dict[str, Any], list[str]]:
         repo_interop_surface["summary"] = "repo interop contract exists, but the machine-readable read surface is incomplete."
     else:
         repo_interop_surface["availability"] = "present"
-        repo_interop_surface["summary"] = "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        repo_interop_surface["summary"] = (
+            "repo interop contract is readable with optional locator advisories."
+            if missing_optional
+            else "repo interop contract is readable for host adapters, repo-native carriers, and shadow parity."
+        )
     repo_interop_surface["missing_inputs"] = list(dict.fromkeys(missing_inputs))
+    repo_interop_surface["missing_optional"] = list(dict.fromkeys(missing_optional))
     return repo_interop_surface, list(dict.fromkeys(missing_inputs))
 
 

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -1143,7 +1143,7 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates"):
+    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators"):
         require_locator_entry(
             failures,
             category=category,
@@ -1155,6 +1155,8 @@ def require_repo_interface_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_interop_payload(
@@ -1188,6 +1190,8 @@ def require_repo_interop_payload(
         failures.append(Failure(category, f"{context} must include non-empty `summary`"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} must include `missing_inputs` as a list"))
+    if not isinstance(payload.get("missing_optional"), list):
+        failures.append(Failure(category, f"{context} must include `missing_optional` as a list"))
 
 
 def require_repo_specific_requirements_payload(
@@ -6791,6 +6795,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 }
             ]
         },
+        "dynamic_tool_locators": [
+            {
+                "id": "repo-review-tool",
+                "summary": "Declare a repo-owned review helper locator without executing it.",
+                "locator": ".loom/companion/review.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "review",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-merge-tool",
+                "summary": "Declare an optional merge helper locator.",
+                "locator": ".loom/companion/missing-optional-tool.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            },
+            {
+                "id": "advisory-build-tool",
+                "summary": "Declare an advisory helper with no installed locator.",
+                "owner": "repo-companion",
+                "requirement": "advisory",
+                "surface": "build",
+                "fallback_to": "build",
+            },
+        ],
     }
 
     with tempfile.TemporaryDirectory(prefix="loom-check-repo-companion-") as tmp:
@@ -6917,6 +6949,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [
+                    {
+                        "id": "bad-tool",
+                        "summary": "Broken tool locator",
+                        "locator": "../outside-tool.json",
+                        "owner": "loom-core",
+                        "requirement": "required",
+                        "surface": "attempt_time",
+                        "fallback_to": "host-action",
+                    }
+                ],
             },
         )
         invalid_v2_surface = build_governance_surface(invalid_v2_target)
@@ -6929,6 +6972,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(invalid_v2_interface, dict) or invalid_v2_interface.get("availability") != "incomplete":
             failures.append(Failure("repo-companion", "invalid v2 repo companion interface sample must report `availability: incomplete`"))
+
+        invalid_optional_escape_target = base / "invalid-optional-dynamic-tool-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_companion(
+            invalid_optional_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        interface_path = invalid_optional_escape_target / ".loom" / "companion" / "repo-interface.json"
+        interface_payload = json.loads(interface_path.read_text(encoding="utf-8"))
+        interface_payload["dynamic_tool_locators"] = [
+            {
+                "id": "optional-escaped-tool",
+                "summary": "Optional tool locator must still respect repository path boundaries.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interface_path, interface_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interface = invalid_optional_escape_surface.get("repo_interface")
+        if not isinstance(invalid_optional_interface, dict) or invalid_optional_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must fail closed"))
+        elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -6965,6 +7036,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interface, dict) or present_interface.get("availability") != "present":
             failures.append(Failure("repo-companion", "present v2 repo companion sample must report `availability: present`"))
+        elif "missing-optional-tool.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must stay in missing_optional"))
+        elif "advisory-build-tool" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-optional-tool.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
 
         review_requirements = repo_specific_requirements_payload(
             present_interface,
@@ -7124,6 +7203,26 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read guardian review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "build",
+            },
+            {
+                "id": "optional-host-summary",
+                "summary": "Read an optional host summary when the repo declares one.",
+                "surfaces": ["closeout"],
+                "locator": "host/missing-optional-summary.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "manual-reconciliation",
+            },
+            {
+                "id": "advisory-host-note",
+                "summary": "Read an advisory host note when available.",
+                "surfaces": ["review"],
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7132,6 +7231,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7187,6 +7289,9 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
                         "summary": "Broken adapter",
                         "surfaces": ["guardian"],
                         "locator": "host/missing.json",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "fallback_to": "build",
                     }
                 ],
                 "repo_native_carriers": [],
@@ -7210,6 +7315,30 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         if not isinstance(invalid_interop, dict) or invalid_interop.get("availability") != "incomplete":
             failures.append(Failure("repo-interop", "invalid repo interop sample must report `availability: incomplete`"))
 
+        invalid_optional_escape_target = base / "invalid-optional-host-escape"
+        shutil.copytree(example_target, invalid_optional_escape_target)
+        install_interop(invalid_optional_escape_target, interop=valid_interop)
+        interop_path = invalid_optional_escape_target / ".loom" / "companion" / "interop.json"
+        interop_payload = json.loads(interop_path.read_text(encoding="utf-8"))
+        interop_payload["host_adapters"] = [
+            {
+                "id": "optional-escaped-host",
+                "summary": "Optional host adapter locator must still respect repository path boundaries.",
+                "surfaces": ["review"],
+                "locator": "../outside-host.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "fallback_to": "build",
+            }
+        ]
+        write_json(interop_path, interop_payload)
+        invalid_optional_escape_surface = build_governance_surface(invalid_optional_escape_target)
+        invalid_optional_interop = invalid_optional_escape_surface.get("repo_interop")
+        if not isinstance(invalid_optional_interop, dict) or invalid_optional_interop.get("availability") != "incomplete":
+            failures.append(Failure("repo-interop", "optional host action path escape must fail closed"))
+        elif "outside-host.json" not in json.dumps(invalid_optional_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action path escape must stay in blocking missing_inputs"))
+
         present_target = base / "present"
         shutil.copytree(example_target, present_target)
         install_interop(present_target, interop=valid_interop)
@@ -7223,6 +7352,14 @@ def check_repo_interop_contracts(root: Path) -> list[Failure]:
         )
         if not isinstance(present_interop, dict) or present_interop.get("availability") != "present":
             failures.append(Failure("repo-interop", "present repo interop sample must report `availability: present`"))
+        elif "missing-optional-summary.json" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must stay in missing_optional"))
+        elif "advisory-host-note" not in json.dumps(present_interop.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must stay in missing_optional"))
+        if isinstance(present_interop, dict) and "missing-optional-summary.json" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "optional host action locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interop, dict) and "advisory-host-note" in json.dumps(present_interop.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-interop", "advisory host action missing locator field must not pollute core missing_inputs"))
 
         parity_payload, error = load_command_json(
             root,
@@ -7651,6 +7788,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native review verdicts without reimplementing the host action.",
                 "surfaces": ["review", "merge_ready"],
                 "locator": "host/guardian-review.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "fallback_to": "review",
             }
         ],
         "repo_native_carriers": [
@@ -7659,6 +7799,9 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                 "summary": "Read repo-native governance status output without migrating carriers.",
                 "surfaces": ["admission", "review", "merge_ready", "closeout"],
                 "locator": "native/status",
+                "owner": "repo",
+                "requirement": "required",
+                "fallback_to": "manual-reconciliation",
             }
         ],
         "shadow_surfaces": {
@@ -7747,6 +7890,7 @@ def check_adversarial_adoption_fixture(root: Path) -> list[Failure]:
                         }
                     ]
                 },
+                "dynamic_tool_locators": [],
             },
         )
 

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -588,6 +588,7 @@ def default_repo_interface() -> dict[str, Any]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -601,6 +602,9 @@ def default_repo_interop() -> dict[str, Any]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {

--- a/src/skills/shared/scripts/loom_init.py
+++ b/src/skills/shared/scripts/loom_init.py
@@ -1222,6 +1222,7 @@ def repo_interface_payload() -> dict[str, object]:
         },
         "metadata_contract": {"fields": []},
         "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
     }
 
 
@@ -1235,6 +1236,9 @@ def repo_interop_payload() -> dict[str, object]:
                 "summary": "Repo-owned adoption residue generated as explicit write targets; Loom reads it without promoting the repo-specific rules into core.",
                 "surfaces": list(SHADOW_PARITY_SURFACES),
                 "locator": ".loom/companion",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "adoption",
             }
         ],
         "shadow_surfaces": {


### PR DESCRIPTION
## Parent / children

- Parent FR: Closes #551
- Children: Closes #552, Closes #553, Closes #554, Closes #555

## User-visible result

- Users can declare dynamic tool availability through repo companion locators without Loom calling or owning the tool.
- Users can declare retained host action result locators through repo interop while preserving host/platform ownership.
- Required locator gaps fail closed; optional/advisory missing in-repo locators surface as `missing_optional`; path escape/absolute/invalid locators block for every requirement level.

## Files / capability changes

- Extended `docs/methodology/harness/host-action-contract.md` with the v0.7 declaration-time boundary for locator, owner, requirement, surface, fallback, and fail-closed behavior.
- Extended `docs/adoption/repo-companion-contract.md` with `dynamic_tool_locators` for repo companion v2.
- Extended `docs/adoption/repo-interop-contract.md` so `host_adapters` and `repo_native_carriers` declare owner, requirement, and fallback while staying locator-only.
- Updated `governance_surface.py` to validate dynamic tool and host action locator declarations.
- Updated `loom_check.py` fixtures for required missing, optional/advisory missing, path escape blocking, invalid owner/requirement/surface, and generated/runtime payload consistency.
- Regenerated `skills/**`, `.loom-runtime/**`, and `examples/new-project/.loom/**` through the skills surface/demo generators.
- Bumped `packages/loom-installer` patch version to `0.1.69`.

## Test evidence

- `python3 -m py_compile src/skills/shared/scripts/governance_surface.py src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py src/skills/shared/scripts/loom_init.py skills/shared/scripts/governance_surface.py skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py skills/shared/scripts/loom_init.py examples/new-project/.loom/bin/governance_surface.py examples/new-project/.loom/bin/loom_flow.py examples/new-project/.loom/bin/loom_check.py examples/new-project/.loom/bin/loom_init.py`
- `python3 tools/skills_surface.py check`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `npm --prefix packages/loom-installer run check:versions`
- `npm --prefix packages/loom-installer run check:payload`
- `npm test --prefix packages/loom-installer` (16 passing)
- `python3 tools/loom_check.py` (OK, 23 surfaces)
- `git diff --check`

## Loom binding chain

`#551 -> work/551-host-action-tool-boundary -> /Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary -> PR -> a768355bcc1d94d94087588f8a1e45f192e35cbb`

## Guardian verdict

Guardian-style review via subagent `Gauss`: final verdict `allow` after blocking findings were fixed. Confirmed optional/advisory missing locators route to `missing_optional`, locator escape/absolute/invalid failures block for all requirement levels, and generated/runtime surfaces are consistent.

## Remaining risk

- v0.7 intentionally does not define attempt-time advertised/unavailable/unsupported/failed tool result taxonomy; that remains out of scope for this PR and belongs to the later tool-attempt contract.