### PR TITLE
feat: 建立编排一致性验证 profiles

### DIFF
--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -1,0 +1,67 @@
+# Orchestration Conformance Profiles
+
+本文件定义 Loom v0.7.0 的 orchestration conformance profiles。
+
+这些 profiles 回答的是“当前 release 的编排能力是否可证明”，不得替代 governance maturity profile。
+
+## 1. Profile 分工
+
+| Profile | 目标 | 默认阻断性 | 权威输入 |
+| --- | --- | --- | --- |
+| `orchestration-core` | 证明 Loom core 恢复、workspace、ledger、merge-ready、closeout 与生成面可在本仓稳定运行 | blocking | `loom_check`、skills surface、installer payload、repo-local demo、main gates |
+| `orchestration-extension` | 证明可选宿主能力、repo companion、repo interop、dynamic tool / host action locator 边界可被读取和 fail-closed | profile-local blocking / advisory | repo companion、repo interop、host action contract、adapter boundary fixtures |
+| `orchestration-live` | 证明至少一个 adopted repo 或 adopted-repo smoke path 能给 release confidence 提供真实反馈 | non-blocking by default | versioned live smoke evidence |
+
+## 2. `orchestration-core`
+
+`orchestration-core` 是普通 PR 和 release closeout 的默认 blocking profile。
+
+最小覆盖面：
+
+- fact-chain / recovery entry / execution ledger 读取一致
+- workspace locate / attach / cleanup / retire 边界一致
+- resume / handoff / merge-ready 消费同一 recovery / ledger contract
+- generated `skills/**`、`.loom-runtime/**`、`examples/new-project/.loom/**` 与 `src/skills/**` 同步
+- installer payload、version surface、runtime-state 和 `loom_check` 自检可运行
+
+Core 缺口必须 fail closed，因为这些能力构成 Loom v0.7.0 的可恢复 harness 执行控制面。
+
+## 3. `orchestration-extension`
+
+`orchestration-extension` 只覆盖可选宿主能力和 adopted repo 扩展面。
+
+最小覆盖面：
+
+- repo companion / repo interop locator-only 合同
+- host action / dynamic tool declaration-time locator contract
+- required locator missing / unreadable / invalid boundary 的 fail-closed 行为
+- optional / advisory missing in-repo locator 只进入 profile-local `missing_optional`
+- adapter drift、shadow parity、external runtime、repo-native carrier 只作为 retained evidence 或 advisory/profile-local gate 消费
+
+Extension 缺口不得污染 `orchestration-core` pass/fail。若某 adopted repo 显式启用 stronger extension gate，该启用点必须记录 owner、fallback、override path 与 authority-of-truth。
+
+## 4. `orchestration-live`
+
+`orchestration-live` 是 release confidence profile，不是普通 PR 的默认 blocking gate。
+
+最小覆盖面：
+
+- 至少一个 adopted repo 或 adopted-repo smoke path
+- 明确记录 target、branch/commit/worktree、命令、结果与日期
+- smoke 不可运行时，必须输出 explicit skip / unavailable evidence，说明缺少的宿主、路径、凭据或环境前置
+- live smoke 失败可以降低 release confidence，但不得自动替代 `orchestration-core` 的 blocking 判定
+
+Live profile 的目标是防止 release 只在模型内自洽；它提供真实反馈证据，但不把外部仓库可用性变成每个普通 PR 的默认阻断条件。
+
+## 5. 与 Governance Maturity Profile 的关系
+
+Governance maturity profile 回答的是一个仓库处于 `light -> standard -> strong` 的哪一档。
+
+Orchestration conformance profiles 回答的是 Loom release 的编排能力是否具备可消费证据。
+
+二者关系固定如下：
+
+- `orchestration-core` 可以作为 release readiness 的 blocking 输入
+- `orchestration-extension` 只在对应 extension scope 内阻断或 advisory
+- `orchestration-live` 只提升或降低 release confidence
+- 任何 orchestration profile 都不得把下游仓库成熟度改写成 Loom core truth

--- a/docs/evidence/v0.7.0-release-readiness.md
+++ b/docs/evidence/v0.7.0-release-readiness.md
@@ -1,0 +1,57 @@
+# v0.7.0 Release Readiness
+
+本文件把 v0.7.0 release readiness 绑定到 orchestration conformance profiles。
+
+它不替代 governance maturity profile，也不把 live smoke 升级成普通 PR 的默认 blocking gate。
+
+## 1. Release Inputs
+
+v0.7.0 release readiness 必须消费：
+
+- `orchestration-core`
+  - blocking release input
+  - 失败时 `fallback_to: core-orchestration-repair`
+  - blocking reason 必须指出缺失的 core surface，例如 recovery、workspace、ledger、merge-ready、closeout、skills surface、installer payload 或 `loom_check`
+- `orchestration-extension`
+  - profile-local input
+  - 失败时 `fallback_to: extension-boundary-repair`
+  - required locator / adapter / retained evidence 缺口只阻断对应 extension claim
+  - optional / advisory 缺口只能进入 `missing_optional` 或 profile-local advisory
+- `orchestration-live`
+  - release confidence input
+  - 失败或不可运行时 `fallback_to: live-smoke-retry-or-record-unavailable`
+  - 不默认阻断普通 PR，不替代 core gates
+
+## 2. Blocking Rules
+
+Release readiness 必须 fail closed when:
+
+- `orchestration-core` 没有版本控制内证据
+- `loom_check` 无法验证 v0.7.0 orchestration profiles
+- merged main gates 没有通过
+- closeout basis 不能绑定 PR、head SHA、merge commit、target branch 和 issue 状态
+
+Release readiness must not fail core when:
+
+- `orchestration-extension` 只有 optional / advisory locator 缺口
+- `orchestration-live` 因宿主不可用、路径不可用或凭据不可用输出 explicit unavailable evidence
+- adopted repo live smoke 只作为 confidence signal 失败，而 core profile 已经有本仓主干证据
+
+## 3. User-Visible Outcome
+
+v0.7.0 的用户可见结果必须可证明：
+
+- 用户能恢复一个 Work Item
+- 用户能看清状态来源、drift、workspace 绑定、ledger 新鲜度和 merge-ready blocker
+- 发布阶段存在最小 adopted repo live smoke 或 explicit unavailable evidence 作为真实反馈
+
+## 4. Closeout Template
+
+最终 #530 closeout basis 必须记录：
+
+- 四批 PR、head SHA、merge commit、target branch
+- merged main gates 与 guardian verdict
+- `orchestration-core` 结果
+- `orchestration-extension` 结果
+- `orchestration-live` confidence evidence
+- remaining risk，尤其是 live smoke 非默认 blocking 边界

--- a/docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md
+++ b/docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md
@@ -1,0 +1,68 @@
+# v0.7.0 Live Orchestration Smoke
+
+本记录归档 v0.7.0 的最小 adopted repo live smoke evidence。
+
+它是 `orchestration-live` release confidence 输入，不是普通 PR 的默认 blocking gate。
+
+## 1. Target
+
+- Adopted repo family: Syvert-style strong governance adopted repo
+- Prior smoke evidence: [validation-syvert-reverse-consumption-smoke.md](./validation-syvert-reverse-consumption-smoke.md)
+- Smoke branch recorded there: `chore/loom-phase-d-smoke-companion`
+- Smoke commit recorded there: `9a7b2923b6ab39631d8a3eafc1be8e5090709b9d`
+- Smoke worktree recorded there: `/Users/mc/dev/syvert-loom-phase-d-smoke`
+
+This v0.7.0 evidence consumes that existing adopted repo smoke path as real feedback for release readiness. It does not require the Syvert smoke branch to be merged into Syvert `main`.
+
+## 2. Commands
+
+The live smoke path is considered available when the adopted repo worktree exists locally:
+
+```bash
+test -d /Users/mc/dev/syvert-loom-phase-d-smoke
+python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke
+python3 <loom_repo_root>/tools/loom_flow.py governance-profile upgrade-plan --target /Users/mc/dev/syvert-loom-phase-d-smoke
+python3 <loom_repo_root>/tools/loom_flow.py runtime-parity validate --target /Users/mc/dev/syvert-loom-phase-d-smoke
+python3 <loom_repo_root>/tools/loom_flow.py shadow-parity --target /Users/mc/dev/syvert-loom-phase-d-smoke
+python3 <loom_repo_root>/tools/loom_flow.py shadow-parity --target /Users/mc/dev/syvert-loom-phase-d-smoke --blocking
+python3 <loom_repo_root>/tools/loom_flow.py flow resume --target /Users/mc/dev/syvert-loom-phase-d-smoke --item INIT-0001
+```
+
+If the adopted repo worktree, host credentials, or branch is unavailable, the smoke must emit explicit `skip` / `unavailable` evidence with the missing path or host precondition. It must not silently pass.
+
+## 3. Evidence Status
+
+Current release evidence status: `versioned-prior-pass`.
+
+Basis:
+
+- The Syvert reverse-consumption smoke is versioned in this repository.
+- It records target, smoke branch, smoke commit, worktree and command set.
+- It demonstrates Loom can consume an adopted repo strong-governance surface without copying that repo's guardian or release-specific rules into Loom core.
+
+Current environment fallback:
+
+- If `/Users/mc/dev/syvert-loom-phase-d-smoke` is unavailable during a normal PR, `orchestration-live` reports `unavailable` and remains non-blocking for the ordinary PR.
+- Release closeout may choose to rerun the live smoke or consume this versioned prior-pass evidence as confidence input.
+
+## 4. Current PR Availability Evidence
+
+- Date: 2026-05-08
+- Loom checkout: `/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness`
+- Adopted repo target: `/Users/mc/dev/syvert-loom-phase-d-smoke`
+- Result: `unavailable`
+- Missing precondition: adopted repo worktree is not present at `/Users/mc/dev/syvert-loom-phase-d-smoke`
+- Commands run: `test -d /Users/mc/dev/syvert-loom-phase-d-smoke`
+- Commands not run: governance-profile status, governance-profile upgrade-plan, runtime-parity validate, shadow-parity, blocking shadow-parity, flow resume
+- Release interpretation: explicit unavailable evidence is a non-blocking confidence input for the ordinary PR; it does not silently pass and does not replace the versioned prior-pass basis.
+
+## 5. Release Boundary
+
+This smoke raises release confidence for v0.7.0 because it exercises a real adopted repo path.
+
+It does not:
+
+- replace `orchestration-core`
+- become a default PR blocking gate
+- require Syvert `main` migration
+- promote Syvert repo-native guardian, sprint, release or integration-contract semantics into Loom core

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/examples/new-project",
+    "target": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/examples/new-project",
     "scenario": "新项目",
     "scenario_key": "new",
     "integration_mode": "root",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "0f8b937e6725f233882ab26441c2d8c8d76abfd2c48fc0f758d50287d7bbfb90"
+      "sha256": "dce8bac53c736f890be83eb3bd4f6e4a0ace1fd5f816b0333516596ca7d64a4d"
     },
     {
       "path": "AGENTS.md",
@@ -263,12 +263,12 @@
     "scene": "repo-local-demo",
     "carrier": "repo-local-wrapper",
     "entry_family": "loom-init",
-    "install_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills",
-    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/shared/scripts",
-    "registry_path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/registry.json",
-    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/install-layout.json",
-    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary",
-    "target_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/examples/new-project",
+    "install_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills",
+    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/shared/scripts",
+    "registry_path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/registry.json",
+    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/install-layout.json",
+    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness",
+    "target_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/examples/new-project",
     "checks": {
       "scene_marker": {
         "status": "pass",
@@ -278,21 +278,21 @@
         "status": "pass",
         "summary": "carrier layout exposes an installed skills root and shared runtime tree.",
         "evidence": {
-          "install_root": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills"
+          "install_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills"
         }
       },
       "registry_contract": {
         "status": "pass",
         "summary": "registry, upgrade contract, and skill entrypoints are consistent.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/registry.json"
+          "path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/registry.json"
         }
       },
       "shared_runtime": {
         "status": "pass",
         "summary": "shared runtime scripts are present and executable roots can be resolved.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary/skills/shared/scripts"
+          "path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/shared/scripts"
         }
       },
       "referenced_resources": {
@@ -513,7 +513,7 @@
       "host_worktree": {
         "ownership": "host",
         "status": "present",
-        "locator": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary"
+        "locator": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness"
       },
       "result": "pass",
       "missing_inputs": [],
@@ -623,7 +623,7 @@
         "host_worktree": {
           "ownership": "host",
           "status": "present",
-          "locator": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary"
+          "locator": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness"
         },
         "result": "pass",
         "missing_inputs": [],
@@ -713,12 +713,12 @@
           },
           "branch": {
             "status": "present",
-            "locator": "work/551-host-action-tool-boundary",
+            "locator": "work/556-conformance-live-readiness",
             "authority": "git"
           },
           "worktree": {
             "status": "present",
-            "locator": "/Users/mc/dev/Loom-worktrees/work-551-host-action-tool-boundary",
+            "locator": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness",
             "authority": "git"
           },
           "implementation_pr": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "0f8b937e6725f233882ab26441c2d8c8d76abfd2c48fc0f758d50287d7bbfb90"
+      "sha256": "dce8bac53c736f890be83eb3bd4f6e4a0ace1fd5f816b0333516596ca7d64a4d"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.69",
+      "version": "0.1.70",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.69",
+  "version": "0.1.70",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -9065,6 +9065,34 @@ def check_operating_layer_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-core",
+            "orchestration-extension",
+            "orchestration-live",
+            "non-blocking by default",
+            "不得替代 governance maturity profile",
+            "Core 缺口必须 fail closed",
+            "Extension 缺口不得污染 `orchestration-core` pass/fail",
+            "explicit skip / unavailable evidence",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("orchestration-conformance", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("orchestration-conformance", f"`{relative}` must mention `{anchor}`"))
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9109,12 +9137,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_generated_artifacts_untracked(root))
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
+    failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 23
+    categories_checked = 24
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")


### PR DESCRIPTION
## Parent / Children

Parent FR: #556
Children: #557, #558, #559, #560

## User-visible result

v0.7.0 now has explicit orchestration conformance profiles:

- `orchestration-core` is the default blocking profile for recovery, workspace, ledger, merge-ready, closeout, generated skills, installer payload, and `loom_check`.
- `orchestration-extension` keeps optional host/repo adapter surfaces profile-local so extension/live gaps do not pollute core pass/fail.
- `orchestration-live` records adopted-repo smoke evidence as release confidence only, not as an ordinary PR blocking gate.

## Files / capability changes

- Added `docs/evidence/orchestration-conformance-profiles.md`.
- Added `docs/evidence/v0.7.0-release-readiness.md`.
- Added `docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md` with current unavailable evidence and prior Syvert smoke basis.
- Extended `loom_check` with an `orchestration-conformance` default check for the profile contract only.
- Regenerated skill/runtime surfaces and the repo-local demo runtime.
- Bumped `packages/loom-installer` to `0.1.70`.

## Test evidence

- `python3 -m py_compile src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_check.py examples/new-project/.loom/bin/loom_check.py`
- `python3 tools/skills_surface.py check`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `npm --prefix packages/loom-installer run check:versions`
- `npm --prefix packages/loom-installer run check:payload`
- `npm test --prefix packages/loom-installer` (16 pass)
- `python3 tools/loom_check.py` (`checked 24 surfaces`)
- `git diff --check`

## Loom binding chain

#556 -> `work/556-conformance-live-readiness` -> `/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness` -> this PR -> head `70b9e264d9a59a170cf269fc6403316b6a060131`

## Guardian verdict

Guardian-style review initially blocked on default `loom_check` treating release/live evidence as a normal gate and on unavailable live-smoke evidence shape. Fixes narrowed the default gate to the conformance profile contract, recorded current `unavailable` live evidence, and replaced hard-coded main checkout commands with `<loom_repo_root>`. Final verdict: ALLOW.