### PR TITLE
feat: 定义 deferred roadmap tree 语义

### DIFF
--- a/docs/adoption/github-profile.md
+++ b/docs/adoption/github-profile.md
@@ -31,6 +31,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/docs/evidence/fixtures/deferred-roadmap-tree.json
+++ b/docs/evidence/fixtures/deferred-roadmap-tree.json
@@ -1,0 +1,174 @@
+{
+  "schema_version": "loom-deferred-roadmap-fixtures/v1",
+  "fixtures": [
+    {
+      "name": "valid #649-style deferred tree",
+      "expect": "pass",
+      "issues": [
+        {
+          "number": 649,
+          "type": "phase",
+          "state": "open",
+          "labels": ["phase"],
+          "body": "## Activation Policy\nFR / Work Item child issues are closed with `deferred-roadmap`; closed state means deferred, not completed.\n\n## Roadmap Inventory\nFR: #650, #654\nWork Items: #652, #653\nThese child issues are intentionally closed with `deferred-roadmap`; closed deferred children are deferred, not completed.\nDuplicate/retry artifacts: #651\n"
+        },
+        {
+          "number": 650,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["fr", "deferred-roadmap"],
+          "parent": 649
+        },
+        {
+          "number": 654,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["fr", "deferred-roadmap"],
+          "parent": 649
+        },
+        {
+          "number": 652,
+          "type": "work-item",
+          "state": "closed",
+          "labels": ["work-item", "deferred-roadmap"],
+          "parent": 650,
+          "closeout_basis": null
+        },
+        {
+          "number": 653,
+          "type": "work-item",
+          "state": "closed",
+          "labels": ["work-item", "deferred-roadmap"],
+          "parent": 650
+        },
+        {
+          "number": 651,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["duplicate", "deferred-roadmap"],
+          "parent": 649,
+          "duplicate_of": 650
+        }
+      ]
+    },
+    {
+      "name": "missing roadmap inventory",
+      "expect": "fail",
+      "issues": [
+        {
+          "number": 700,
+          "type": "phase",
+          "state": "open",
+          "labels": ["phase"],
+          "body": "## Activation Policy\nClosed children use `deferred-roadmap`; closed deferred children are deferred, not completed.\n"
+        },
+        {
+          "number": 701,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["fr", "deferred-roadmap"],
+          "parent": 700
+        }
+      ]
+    },
+    {
+      "name": "completed delivery confusion",
+      "expect": "fail",
+      "issues": [
+        {
+          "number": 710,
+          "type": "phase",
+          "state": "open",
+          "labels": ["phase"],
+          "body": "## Activation Policy\nClosed children are delivery children.\n\n## Roadmap Inventory\nFR: #711\nWork Items: #712\nClosed child #712 is completed delivery.\n"
+        },
+        {
+          "number": 711,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["fr"],
+          "parent": 710
+        },
+        {
+          "number": 712,
+          "type": "work-item",
+          "state": "closed",
+          "labels": ["work-item"],
+          "parent": 711,
+          "closeout_basis": null
+        }
+      ]
+    },
+    {
+      "name": "duplicate included in canonical inventory",
+      "expect": "fail",
+      "issues": [
+        {
+          "number": 720,
+          "type": "phase",
+          "state": "open",
+          "labels": ["phase"],
+          "body": "## Activation Policy\nClosed children use `deferred-roadmap`.\n\n## Roadmap Inventory\nFR: #721, #722\nWork Items: #723\nClosed deferred children are deferred, not completed.\nDuplicate/retry artifacts: #722\n"
+        },
+        {
+          "number": 721,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["fr", "deferred-roadmap"],
+          "parent": 720
+        },
+        {
+          "number": 722,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["duplicate", "deferred-roadmap"],
+          "parent": 720,
+          "duplicate_of": 721
+        },
+        {
+          "number": 723,
+          "type": "work-item",
+          "state": "closed",
+          "labels": ["work-item", "deferred-roadmap"],
+          "parent": 721
+        }
+      ]
+    },
+    {
+      "name": "inventory child outside phase tree",
+      "expect": "fail",
+      "issues": [
+        {
+          "number": 730,
+          "type": "phase",
+          "state": "open",
+          "labels": ["phase"],
+          "body": "## Activation Policy\nClosed children use `deferred-roadmap`.\n\n## Roadmap Inventory\nFR: #731\nWork Items: #732\nClosed deferred children are deferred, not completed.\nDuplicate/retry artifacts: #733\n"
+        },
+        {
+          "number": 731,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["fr", "deferred-roadmap"],
+          "parent": 999
+        },
+        {
+          "number": 732,
+          "type": "work-item",
+          "state": "closed",
+          "labels": ["work-item", "deferred-roadmap"],
+          "parent": 731,
+          "closeout_basis": null
+        },
+        {
+          "number": 733,
+          "type": "fr",
+          "state": "closed",
+          "labels": ["duplicate", "deferred-roadmap"],
+          "parent": 730,
+          "duplicate_of": 731
+        }
+      ]
+    }
+  ]
+}

--- a/docs/methodology/governance/github-delivery-funnel.md
+++ b/docs/methodology/governance/github-delivery-funnel.md
@@ -33,6 +33,17 @@ Loom 冻结的是对象语义、前置关系与绑定链，不冻结 GitHub 私�
 负责把阶段目标映射到一组稳定治理范围。
 只承载阶段边界，不承接执行现场。
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/docs/methodology/governance/issue-model.md
+++ b/docs/methodology/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -7,7 +7,7 @@
     "contract_version": "1.3.0"
   },
   "run": {
-    "target": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/examples/new-project",
+    "target": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/examples/new-project",
     "scenario": "新项目",
     "scenario_key": "new",
     "integration_mode": "root",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "dce8bac53c736f890be83eb3bd4f6e4a0ace1fd5f816b0333516596ca7d64a4d"
+      "sha256": "47fe871caf9f276cc609d2205a512731e905f9f253969e96d2ea434aec477658"
     },
     {
       "path": "AGENTS.md",
@@ -263,12 +263,12 @@
     "scene": "repo-local-demo",
     "carrier": "repo-local-wrapper",
     "entry_family": "loom-init",
-    "install_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills",
-    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/shared/scripts",
-    "registry_path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/registry.json",
-    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/install-layout.json",
-    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness",
-    "target_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/examples/new-project",
+    "install_root": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/skills",
+    "runtime_root": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/skills/shared/scripts",
+    "registry_path": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/skills/registry.json",
+    "layout_or_manifest_path": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/skills/install-layout.json",
+    "source_repo_root": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics",
+    "target_root": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/examples/new-project",
     "checks": {
       "scene_marker": {
         "status": "pass",
@@ -278,21 +278,21 @@
         "status": "pass",
         "summary": "carrier layout exposes an installed skills root and shared runtime tree.",
         "evidence": {
-          "install_root": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills"
+          "install_root": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/skills"
         }
       },
       "registry_contract": {
         "status": "pass",
         "summary": "registry, upgrade contract, and skill entrypoints are consistent.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/registry.json"
+          "path": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/skills/registry.json"
         }
       },
       "shared_runtime": {
         "status": "pass",
         "summary": "shared runtime scripts are present and executable roots can be resolved.",
         "evidence": {
-          "path": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness/skills/shared/scripts"
+          "path": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics/skills/shared/scripts"
         }
       },
       "referenced_resources": {
@@ -513,7 +513,7 @@
       "host_worktree": {
         "ownership": "host",
         "status": "present",
-        "locator": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness"
+        "locator": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics"
       },
       "result": "pass",
       "missing_inputs": [],
@@ -623,7 +623,7 @@
         "host_worktree": {
           "ownership": "host",
           "status": "present",
-          "locator": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness"
+          "locator": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics"
         },
         "result": "pass",
         "missing_inputs": [],
@@ -713,12 +713,12 @@
           },
           "branch": {
             "status": "present",
-            "locator": "work/556-conformance-live-readiness",
+            "locator": "work/670-deferred-roadmap-tree-semantics",
             "authority": "git"
           },
           "worktree": {
             "status": "present",
-            "locator": "/Users/mc/dev/Loom-worktrees/work-556-conformance-live-readiness",
+            "locator": "/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics",
             "authority": "git"
           },
           "implementation_pr": {

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "dce8bac53c736f890be83eb3bd4f6e4a0ace1fd5f816b0333516596ca7d64a4d"
+      "sha256": "47fe871caf9f276cc609d2205a512731e905f9f253969e96d2ea434aec477658"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.70",
+      "version": "0.1.71",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-adopt/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-adopt/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-handoff/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-handoff/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-init/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-init/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-init/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-init/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-init/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-pre-review/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-pre-review/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-resume/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-resume/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-retire/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-retire/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-review/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-review/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-review/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-review/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-review/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/references/adoption/github-profile.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/loom-spec-review/.loom-runtime/shared/references/governance/github-delivery-funnel.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/loom-spec-review/.loom-runtime/shared/references/governance/issue-model.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/references/adoption/github-profile.md
+++ b/skills/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/skills/shared/references/governance/github-delivery-funnel.md
+++ b/skills/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/skills/shared/references/governance/issue-model.md
+++ b/skills/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/references/adoption/github-profile.md
+++ b/src/skills/shared/references/adoption/github-profile.md
@@ -30,6 +30,10 @@ GitHub profile 至少应能表达：
   - 版本目标、阶段树或等价治理目标面
 - `Phase`
   - 阶段级 issue 或等价规划对象
+  - deferred Phase container 必须声明 `Activation Policy` 与 `Roadmap Inventory`
+  - `Roadmap Inventory` 必须列出 canonical FR children 与 canonical Work Item children
+  - closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独标明，并排除出 canonical inventory
 - `FR`
   - formal spec / planning issue
 - `Work Item`

--- a/src/skills/shared/references/governance/github-delivery-funnel.md
+++ b/src/skills/shared/references/governance/github-delivery-funnel.md
@@ -40,6 +40,17 @@ Loom 只冻结这条路径的语义，不冻结 GitHub 之外宿主的具体对�
 - 哪些 `FR` 属于同一阶段
 - 阶段边界何时允许收口
 
+Deferred Phase container 可以提前保留未来 roadmap tree，但必须暴露：
+
+- `Activation Policy`
+  - 说明何时从 deferred roadmap 转入 active execution
+  - 明确 deferred child 激活前不需要 PR、merge 或 closeout evidence
+- `Roadmap Inventory`
+  - 明确列出 canonical FR children
+  - 明确列出 canonical Work Item children
+  - 明确说明 closed deferred children are deferred, not completed
+  - duplicate/retry artifacts 必须单独列出，并排除出 canonical inventory
+
 ### 2.3 `FR`
 
 `FR` 默认承接 formal spec / planning 层。

--- a/src/skills/shared/references/governance/issue-model.md
+++ b/src/skills/shared/references/governance/issue-model.md
@@ -53,6 +53,24 @@ Loom 当前固定三类 issue：
 - 不得把尚未进入实施的 child issue 提前写成进行中
 - 当 parent 只承担汇总与收口时，应让真正实施落在 child issue
 
+### 3.1 deferred roadmap issue
+
+`deferred roadmap issue` 是 GitHub truth 中的路线图保留语义。
+
+当 issue 以 `closed + deferred-roadmap` 出现在 roadmap tree 中时，它表示 roadmap reservation，不是 `closed_out`，也不是 completed delivery。
+
+稳定约束：
+
+- open Phase 可以持有 closed deferred FR / Work Item children
+- deferred child 在激活前不得被 closeout 或 completed delivery 消费
+- deferred child 不要求 PR、merge commit、review 或 closeout basis
+- 激活必须显式转换：reopen / reactivate，或重新绑定为 active execution issue
+- duplicate/retry artifacts 必须指向 canonical issue，不能进入 Roadmap Inventory
+
+deferred roadmap 只允许表达未来范围已进入 host truth。它不得把未激活的 child issue 伪装成已经完成的执行结果。
+
+检查输出应区分 `deferred_roadmap` 与 `completed_delivery`，避免把路线图保留语义消费成完成交付语义。
+
 ## 4. 激活规则
 
 ### 4.1 issue 级激活

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -6116,8 +6116,9 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 elif "implementation-drift-only" not in json.dumps(payload, ensure_ascii=False):
                     failures.append(Failure("daily-execution-cli", "`installed checkpoint merge` drift negative must expose implementation-drift-only review head binding"))
 
+    live_github_opt_in = os.environ.get("LOOM_CHECK_LIVE_GITHUB") == "1"
     gh_auth_probe = None
-    if shutil.which("gh") is not None:
+    if live_github_opt_in and shutil.which("gh") is not None:
         try:
             gh_auth_probe = run_command(root, ["gh", "auth", "status"], timeout_seconds=5)
         except subprocess.TimeoutExpired:
@@ -9093,6 +9094,322 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def deferred_roadmap_inventory_section(body: str) -> str:
+    match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
+    return match.group(1).strip() if match else ""
+
+
+def markdown_issue_numbers(text: str) -> set[str]:
+    return set(re.findall(r"#(\d+)", text))
+
+
+def deferred_roadmap_fixture_failures(name: str, body: str) -> list[str]:
+    failures: list[str] = []
+    text = body.lower()
+    has_deferred_semantics = (
+        "deferred-roadmap" in text
+        or "closed deferred children are deferred, not completed" in text
+        or "deferred, not completed" in text
+    )
+    if has_deferred_semantics:
+        if "## Activation Policy" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Activation Policy")
+        if "## Roadmap Inventory" not in body:
+            failures.append(f"{name}: deferred_roadmap fixture must expose Roadmap Inventory")
+
+    inventory = deferred_roadmap_inventory_section(body)
+    if "## Roadmap Inventory" in body:
+        if not re.search(r"(?im)^FR:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list FR children")
+        if not re.search(r"(?im)^Work Items:\s*#\d+", inventory):
+            failures.append(f"{name}: deferred_roadmap Roadmap Inventory must list Work Item children")
+        if "closed deferred children are deferred, not completed" not in text:
+            failures.append(f"{name}: deferred_roadmap fixture must say closed deferred children are deferred, not completed")
+
+        duplicate_lines = [
+            line
+            for line in inventory.splitlines()
+            if "duplicate" in line.lower() or "retry artifact" in line.lower()
+        ]
+        duplicate_numbers = set().union(*(markdown_issue_numbers(line) for line in duplicate_lines)) if duplicate_lines else set()
+        canonical_lines = [
+            line
+            for line in inventory.splitlines()
+            if not ("duplicate" in line.lower() or "retry artifact" in line.lower())
+        ]
+        canonical_numbers = set().union(*(markdown_issue_numbers(line) for line in canonical_lines)) if canonical_lines else set()
+        overlap = sorted(duplicate_numbers & canonical_numbers)
+        if overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in overlap)
+            )
+
+    if (
+        "completed delivery" in text
+        and "closeout basis" not in text
+        and "deferred-roadmap" not in text
+    ):
+        failures.append(
+            f"{name}: completed_delivery closed child must have closeout basis or explicit deferred_roadmap semantics"
+        )
+    return failures
+
+
+def normalized_issue_labels(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label).lower() for label in labels}
+
+
+def parse_roadmap_inventory(body: str) -> dict[str, set[int]]:
+    inventory = deferred_roadmap_inventory_section(body)
+    parsed = {"fr": set(), "work_item": set(), "duplicates": set()}
+    if not inventory:
+        return parsed
+    for line in inventory.splitlines():
+        lower = line.lower()
+        numbers = {int(number) for number in markdown_issue_numbers(line)}
+        if "duplicate" in lower or "retry artifact" in lower:
+            parsed["duplicates"].update(numbers)
+        elif re.match(r"(?i)^fr:\s*", line.strip()):
+            parsed["fr"].update(numbers)
+        elif re.match(r"(?i)^work items:\s*", line.strip()):
+            parsed["work_item"].update(numbers)
+    return parsed
+
+
+def is_duplicate_roadmap_artifact(issue: dict[str, Any]) -> bool:
+    labels = normalized_issue_labels(issue)
+    return "duplicate" in labels or issue.get("duplicate_of") is not None
+
+
+def validate_deferred_roadmap_graph_fixture(name: str, issues: list[dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    by_number = {
+        int(issue["number"]): issue
+        for issue in issues
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    phases = [issue for issue in by_number.values() if issue.get("type") == "phase"]
+    if not phases:
+        return [f"{name}: deferred_roadmap graph fixture must include a phase issue"]
+
+    for phase in phases:
+        phase_number = int(phase["number"])
+        body = str(phase.get("body") or "")
+        inventory = parse_roadmap_inventory(body)
+        canonical_fr: set[int] = set()
+        canonical_work_items: set[int] = set()
+        inventory_numbers = inventory["fr"] | inventory["work_item"]
+
+        for number, issue in by_number.items():
+            labels = normalized_issue_labels(issue)
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            under_phase = parent == phase_number or (
+                isinstance(parent_issue, dict) and parent_issue.get("parent") == phase_number
+            )
+            if not under_phase or "deferred-roadmap" not in labels or is_duplicate_roadmap_artifact(issue):
+                continue
+            if issue.get("type") == "fr" and parent == phase_number:
+                canonical_fr.add(number)
+            elif issue.get("type") == "work-item":
+                canonical_work_items.add(number)
+
+        if canonical_fr or canonical_work_items:
+            if "## Activation Policy" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Activation Policy")
+            if "## Roadmap Inventory" not in body:
+                failures.append(f"{name}: deferred_roadmap phase #{phase_number} must expose Roadmap Inventory")
+            if "closed deferred children are deferred, not completed" not in body.lower():
+                failures.append(
+                    f"{name}: deferred_roadmap phase #{phase_number} must say closed deferred children are deferred, not completed"
+                )
+
+        missing_fr = sorted(canonical_fr - inventory["fr"])
+        missing_work_items = sorted(canonical_work_items - inventory["work_item"])
+        if missing_fr:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing FR children: "
+                + ", ".join(f"#{number}" for number in missing_fr)
+            )
+        if missing_work_items:
+            failures.append(
+                f"{name}: deferred_roadmap Roadmap Inventory missing Work Item children: "
+                + ", ".join(f"#{number}" for number in missing_work_items)
+            )
+
+        duplicate_overlap = sorted((inventory["fr"] | inventory["work_item"]) & inventory["duplicates"])
+        if duplicate_overlap:
+            failures.append(
+                f"{name}: deferred_roadmap duplicate/retry artifacts must be excluded from canonical inventory: "
+                + ", ".join(f"#{number}" for number in duplicate_overlap)
+            )
+
+        for number in sorted(inventory_numbers):
+            issue = by_number.get(number)
+            if issue is None:
+                failures.append(f"{name}: Roadmap Inventory references unknown issue #{number}")
+                continue
+            expected_type = "fr" if number in inventory["fr"] else "work-item"
+            if issue.get("type") != expected_type:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must be a {expected_type}, got {issue.get('type')}"
+                )
+            parent = issue.get("parent")
+            parent_issue = by_number.get(parent) if isinstance(parent, int) else None
+            belongs_to_phase = parent == phase_number or (
+                expected_type == "work-item"
+                and isinstance(parent_issue, dict)
+                and parent_issue.get("parent") == phase_number
+            )
+            if not belongs_to_phase:
+                failures.append(
+                    f"{name}: Roadmap Inventory issue #{number} must belong to phase #{phase_number} through parent references"
+                )
+            if is_duplicate_roadmap_artifact(issue):
+                failures.append(f"{name}: duplicate/retry artifact #{number} must not be canonical inventory")
+            labels = normalized_issue_labels(issue)
+            if (
+                str(issue.get("state", "")).lower() == "closed"
+                and "deferred-roadmap" not in labels
+                and not issue.get("closeout_basis")
+            ):
+                failures.append(
+                    f"{name}: completed_delivery issue #{number} needs closeout basis or deferred_roadmap label"
+                )
+
+    return failures
+
+
+def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    required_anchors = {
+        "docs/methodology/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "src/skills/shared/references/governance/issue-model.md": [
+            "deferred roadmap issue",
+            "`closed + deferred-roadmap`",
+            "roadmap reservation",
+            "不是 `closed_out`",
+            "open Phase",
+            "duplicate/retry artifacts",
+            "Roadmap Inventory",
+            "`deferred_roadmap`",
+            "`completed_delivery`",
+        ],
+        "docs/methodology/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/governance/github-delivery-funnel.md": [
+            "Deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "src/skills/shared/references/adoption/github-profile.md": [
+            "deferred Phase container",
+            "`Activation Policy`",
+            "`Roadmap Inventory`",
+            "canonical FR children",
+            "canonical Work Item children",
+            "closed deferred children are deferred, not completed",
+            "duplicate/retry artifacts",
+            "canonical inventory",
+        ],
+        "docs/evidence/fixtures/deferred-roadmap-tree.json": [
+            "loom-deferred-roadmap-fixtures/v1",
+            "valid #649-style deferred tree",
+            "missing roadmap inventory",
+            "completed delivery confusion",
+            "duplicate included in canonical inventory",
+            "deferred-roadmap",
+            "duplicate_of",
+            "closeout_basis",
+        ],
+    }
+    for relative, anchors in required_anchors.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("deferred-roadmap", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("deferred-roadmap", f"`{relative}` must mention `{anchor}`"))
+
+    fixture_path = root / "docs/evidence/fixtures/deferred-roadmap-tree.json"
+    try:
+        fixture_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure("deferred-roadmap", f"`docs/evidence/fixtures/deferred-roadmap-tree.json` is unreadable: {exc}"))
+        return failures
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` must expose fixtures list"))
+        return failures
+    for fixture in fixtures:
+        if not isinstance(fixture, dict):
+            failures.append(Failure("deferred-roadmap", "`deferred-roadmap-tree.json` fixture entries must be objects"))
+            continue
+        name = str(fixture.get("name") or "unnamed fixture")
+        issues = fixture.get("issues")
+        if not isinstance(issues, list):
+            failures.append(Failure("deferred-roadmap", f"`{name}` must expose issues list"))
+            continue
+        fixture_failures = validate_deferred_roadmap_graph_fixture(
+            name,
+            [issue for issue in issues if isinstance(issue, dict)],
+        )
+        expect = fixture.get("expect")
+        if expect == "pass" and fixture_failures:
+            failures.append(
+                Failure("deferred-roadmap", f"`{name}` expected pass, got failures: {fixture_failures}")
+            )
+        elif expect == "fail" and not fixture_failures:
+            failures.append(
+                Failure(
+                    "deferred-roadmap",
+                    f"`{name}` expected deferred_roadmap fixture failure but passed",
+                )
+            )
+
+    return failures
+
+
 def is_within(path: Path, root: Path) -> bool:
     try:
         path.relative_to(root)
@@ -9138,12 +9455,13 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_markdown_links(root))
     return failures
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 24
+    categories_checked = 25
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")


### PR DESCRIPTION
## Parent / Children

Parent FR: #670
Children: #671, #672, #673
Duplicate retry artifacts to close after merge: #666, #667, #668, #669

## User-visible result

Loom now has a formal deferred roadmap tree contract. A closed issue with `deferred-roadmap` is roadmap reservation truth, not completed delivery or `closed_out`, and deferred roadmap children cannot be consumed as completed work before activation.

## Files / capability changes

- Governance issue model defines deferred roadmap issues, activation conversion, duplicate/retry artifact boundaries, and `deferred_roadmap` vs `completed_delivery` output semantics.
- GitHub delivery funnel and GitHub profile define deferred Phase containers with `Activation Policy` and `Roadmap Inventory`.
- `loom_check` validates the deferred roadmap contract with version-controlled graph fixtures, including label, parent, type, duplicate, closeout-basis, and inventory shape.
- Historical live GitHub closeout sample in default `loom_check` is now explicit opt-in via `LOOM_CHECK_LIVE_GITHUB=1`.
- Skill/reference/generated runtime surfaces were regenerated, demo runtime refreshed, installer bumped to `0.1.71`.

## Test evidence

- `python3 -m py_compile src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_check.py examples/new-project/.loom/bin/loom_check.py`
- `python3 tools/skills_surface.py check`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `npm --prefix packages/loom-installer run check:versions`
- `npm --prefix packages/loom-installer run check:payload`
- `npm test --prefix packages/loom-installer` (16 pass)
- `python3 tools/loom_check.py` (`checked 25 surfaces`)
- `git diff --check`

## Loom binding chain

#670 -> `work/670-deferred-roadmap-tree-semantics` -> `/Users/mc/dev/Loom-worktrees/work-670-deferred-roadmap-tree-semantics` -> this PR -> head `f54b84b893ead524f44560b60748b09059954b20`

## Guardian verdict

Guardian review initially blocked on default live GitHub behavior and incomplete tree-shape fixture coverage. Fixes moved the historical host sample behind `LOOM_CHECK_LIVE_GITHUB=1`, added version-controlled graph fixtures, and validated inventory children against labels, parent relationships, type, duplicate state, and closeout/deferred basis. Final verdict: ALLOW.