### PR TITLE
fix: stabilize portable bootstrap default branch output

### DIFF
--- a/examples/new-project/.loom/bin/loom_init.py
+++ b/examples/new-project/.loom/bin/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -345,7 +345,7 @@
     },
     "github_control_plane": {
       "repository": "MC-and-his-Agents/Loom",
-      "default_branch": "main",
+      "default_branch": "${CURRENT_BRANCH}",
       "branch_protection": "enabled",
       "required_checks": [
         "py-compile",
@@ -784,7 +784,7 @@
             "authority": "loom + host"
           }
         },
-        "default_branch": "main",
+        "default_branch": "${CURRENT_BRANCH}",
         "missing_inputs": [],
         "result": "pass",
         "summary": "host binding surface can relate the active Work Item to branch, worktree, PR, merge commit, and closeout."

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -113,7 +113,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "842a6420a5e44e6190c952fce5dc2bab0c55e8a834cfe2d3680eafb84db0106d"
+      "sha256": "6a3a9c010949e00c07d55f2559329a54a2f1c17513005076b77fb42c5eca36c9"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",
@@ -345,7 +345,7 @@
     },
     "github_control_plane": {
       "repository": "MC-and-his-Agents/Loom",
-      "default_branch": "${CURRENT_BRANCH}",
+      "default_branch": "main",
       "branch_protection": "enabled",
       "required_checks": [
         "py-compile",
@@ -784,7 +784,7 @@
             "authority": "loom + host"
           }
         },
-        "default_branch": "${CURRENT_BRANCH}",
+        "default_branch": "main",
         "missing_inputs": [],
         "result": "pass",
         "summary": "host binding surface can relate the active Work Item to branch, worktree, PR, merge commit, and closeout."

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -35,7 +35,7 @@
       "path": ".loom/bin/loom_init.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_init.py",
-      "sha256": "842a6420a5e44e6190c952fce5dc2bab0c55e8a834cfe2d3680eafb84db0106d"
+      "sha256": "6a3a9c010949e00c07d55f2559329a54a2f1c17513005076b77fb42c5eca36c9"
     },
     {
       "path": ".loom/bin/fact_chain_support.py",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.75",
+      "version": "0.1.76",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.75",
+  "version": "0.1.76",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:

--- a/src/skills/shared/scripts/loom_init.py
+++ b/src/skills/shared/scripts/loom_init.py
@@ -1081,14 +1081,22 @@ def git_branch_name(target_root: Path) -> str | None:
     return branch
 
 
-def portable_bootstrap_value(value: object, replacements: list[tuple[str, str]], current_branch: str | None) -> object:
+def portable_bootstrap_value(
+    value: object,
+    replacements: list[tuple[str, str]],
+    current_branch: str | None,
+    path: tuple[str, ...] = (),
+) -> object:
     if isinstance(value, dict):
-        return {key: portable_bootstrap_value(child, replacements, current_branch) for key, child in value.items()}
+        return {
+            key: portable_bootstrap_value(child, replacements, current_branch, path + (key,))
+            for key, child in value.items()
+        }
     if isinstance(value, list):
-        return [portable_bootstrap_value(child, replacements, current_branch) for child in value]
+        return [portable_bootstrap_value(child, replacements, current_branch, path) for child in value]
     if not isinstance(value, str):
         return value
-    if current_branch and value == current_branch:
+    if current_branch and value == current_branch and path[-1:] != ("default_branch",):
         return "${CURRENT_BRANCH}"
     portable = value
     for source, replacement in replacements:


### PR DESCRIPTION
## Summary
- Fixes the post-merge #571 closeout drift where portable bootstrap output treated `default_branch` as the active branch on `main`.
- Makes portable branch placeholder replacement path-aware so `default_branch` remains host truth while active branch locators can still use `${CURRENT_BRANCH}`.
- Regenerates skill surfaces and demo bootstrap output so `make check` is stable on both issue branches and main.
- Bumps `@mc-and-his-agents/loom-installer` from `0.1.75` to `0.1.76` because the installer payload changed.

## Validation
- `python3 -m py_compile src/skills/shared/scripts/loom_init.py skills/shared/scripts/loom_init.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `npm run check:payload --prefix packages/loom-installer`
- `make check` (pass; demo bootstrap `write.touched: []` on final rerun)
- `git status --short --ignored=matching .loom/runtime/attempts` (only ignored `.loom/runtime/attempts/`)

Related: #571
Post-merge closeout repair for #715 / merge commit `1c4d076351710a8b550b88f1997a2be10fd280d6`.