### PR TITLE
feat: add structured event evidence fixtures

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -74,9 +74,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-571",
-      "work_item": ".loom/work-items/WI-571.md",
-      "recovery_entry": ".loom/progress/WI-571.md",
+      "current_item_id": "WI-576",
+      "work_item": ".loom/work-items/WI-576.md",
+      "recovery_entry": ".loom/progress/WI-576.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-571.md
+++ b/.loom/progress/WI-571.md
@@ -3,12 +3,12 @@
 ## Dynamic Facts
 
 - Item ID: WI-571
-- Current Checkpoint: merge checkpoint
-- Current Stop: WI-571 approval/sandbox policy read surface implementation, generated carriers, demo bootstrap artifacts, reviews, and validation evidence are aligned on the batch branch.
-- Next Step: Push the #571 branch, open the batch PR, wait for host checks, merge to main, then run closeout for #572-#575.
+- Current Checkpoint: retired
+- Current Stop: WI-571 approval/sandbox policy read surface shipped through PR #715, post-merge bootstrap drift repair shipped through PR #716, #572-#575 are closed, and #571 is closed.
+- Next Step: not_applicable
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed shared scripts; python3 tools/skills_surface.py check passed; policy fixture smoke returned failures 0; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed; python3 tools/loom_check.py passed with 26 surfaces; make check passed twice, with the second demo-bootstrap run reporting write.touched: [].
-- Recovery Boundary: Branch work/571-approval-sandbox-read-surface; active item WI-571; policy readiness evidence is derived from companion locators and must not replace recovery truth, execution_attempt evidence, retained host action results, or host permission/sandbox systems.
+- Latest Validation Summary: PR #715 checks passed; PR #716 checks passed; final main `make check` passed with `loom_check: OK` and demo bootstrap `write.touched: []`; closeout checks passed for #572-#575.
+- Recovery Boundary: Retired; historical branch work/571-approval-sandbox-read-surface; policy readiness evidence remains derived evidence and does not replace recovery truth, execution_attempt evidence, retained host action results, or host permission/sandbox systems.
 - Current Lane: v0.8.0 / #531 / #571 approval and sandbox policy read surface
 
 ## Execution Ledger

--- a/.loom/progress/WI-576.md
+++ b/.loom/progress/WI-576.md
@@ -3,11 +3,11 @@
 ## Dynamic Facts
 
 - Item ID: WI-576
-- Current Checkpoint: build checkpoint
-- Current Stop: WI-576 structured event evidence contract, validator, fake orchestration fixtures, generated surfaces, and initial validation are being assembled on the batch branch.
-- Next Step: Complete review evidence, run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
+- Current Checkpoint: merge checkpoint
+- Current Stop: WI-576 structured event evidence implementation, generated surfaces, installer version, and review evidence are aligned on the batch branch.
+- Next Step: Run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
 - Recovery Boundary: Branch work/576-structured-event-evidence; active item WI-576; event evidence is evidence-only and must not replace Work Item, recovery, review, merge-ready, closeout, issue, tracker, or scheduler truth.
 - Current Lane: v0.8.0 / #531 / #576 structured event evidence and fake orchestration fixtures
 

--- a/.loom/progress/WI-576.md
+++ b/.loom/progress/WI-576.md
@@ -1,0 +1,21 @@
+# WI-576 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-576
+- Current Checkpoint: build checkpoint
+- Current Stop: WI-576 structured event evidence contract, validator, fake orchestration fixtures, generated surfaces, and initial validation are being assembled on the batch branch.
+- Next Step: Complete review evidence, run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
+- Blockers: None recorded.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Recovery Boundary: Branch work/576-structured-event-evidence; active item WI-576; event evidence is evidence-only and must not replace Work Item, recovery, review, merge-ready, closeout, issue, tracker, or scheduler truth.
+- Current Lane: v0.8.0 / #531 / #576 structured event evidence and fake orchestration fixtures
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-576/plan.md
+- Acceptance Locator: .loom/specs/WI-576/spec.md
+- Validation Evidence Locator: make check
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current

--- a/.loom/reviews/WI-576.json
+++ b/.loom/reviews/WI-576.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#576 implementation adds the event evidence contract, path-synchronized skill references, loom_check validator, fake agent success/failure/tool failure fixtures, fake tracker active/closed/drift fixtures, and installer version alignment without introducing a second truth source.",
   "reviewer": "codex",
-  "reviewed_head": "50c236ca90b32d18863668411d37036554629abb",
+  "reviewed_head": "9e9dcc63e7c0020691c7e7205d0c95d886a3c24d",
   "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-576.json
+++ b/.loom/reviews/WI-576.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#576 implementation adds the event evidence contract, path-synchronized skill references, loom_check validator, fake agent success/failure/tool failure fixtures, fake tracker active/closed/drift fixtures, and installer version alignment without introducing a second truth source.",
   "reviewer": "codex",
-  "reviewed_head": "ae137762449ccd995056f11f06e3e891d191858e",
+  "reviewed_head": "50c236ca90b32d18863668411d37036554629abb",
   "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-576.json
+++ b/.loom/reviews/WI-576.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-576",
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "#576 implementation adds the event evidence contract, path-synchronized skill references, loom_check validator, fake agent success/failure/tool failure fixtures, fake tracker active/closed/drift fixtures, and installer version alignment without introducing a second truth source.",
+  "reviewer": "codex",
+  "reviewed_head": "ae137762449ccd995056f11f06e3e891d191858e",
+  "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-576.md",
+    "recovery_entry": ".loom/progress/WI-576.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/reviews/WI-576.spec.json
+++ b/.loom/reviews/WI-576.spec.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-576",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "#576 spec defines structured event evidence as evidence-only, requires rejection of copied authored truth, and scopes fake agent/fake tracker fixtures to orchestration proof without real host calls.",
+  "reviewer": "codex",
+  "reviewed_head": "ae137762449ccd995056f11f06e3e891d191858e",
+  "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-576.md",
+    "recovery_entry": ".loom/progress/WI-576.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "f0c6510fdc9f9dcfe8b2cf610102dcebc8bda9cb1d79ea249257e844560813d6"
+    ".loom/status/current.md": "182741c84cd45fffaa0dfb310551942e3f02550df276c30c3a093d3eed3310c8"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "f0c6510fdc9f9dcfe8b2cf610102dcebc8bda9cb1d79ea249257e844560813d6"
+    ".loom/status/current.md": "182741c84cd45fffaa0dfb310551942e3f02550df276c30c3a093d3eed3310c8"
   }
 }

--- a/.loom/specs/WI-576/implementation-contract.md
+++ b/.loom/specs/WI-576/implementation-contract.md
@@ -1,0 +1,15 @@
+# WI-576 Implementation Contract
+
+## Ownership
+
+- `docs/methodology/harness/structured-event-evidence.md` owns the stable event evidence schema and evidence-only boundary.
+- `docs/methodology/harness/status-surface-contract.md` owns optional status exposure rules for event evidence.
+- `docs/methodology/harness/host-action-contract.md` owns the rule that host-backed tracker state remains evidence, not host/tracker truth.
+- `docs/evidence/orchestration-conformance-profiles.md` owns orchestration profile expectations for fake agent and fake tracker fixtures.
+- `src/skills/shared/scripts/loom_check.py` owns mechanical event validation and fake orchestration fixtures.
+
+## Guardrails
+
+- Do not let event evidence author recovery, issue, tracker, review, merge-ready, closeout, or scheduler truth.
+- Do not call real models, real tools, real trackers, or host mutation APIs from fake fixtures.
+- Do not let optional host tracker availability pollute core `orchestration-core` pass/fail.

--- a/.loom/specs/WI-576/plan.md
+++ b/.loom/specs/WI-576/plan.md
@@ -1,0 +1,23 @@
+# WI-576 Plan
+
+## Steps
+
+1. Add the structured event evidence contract and connect it to harness/status/host action docs.
+2. Add `loom_check` event evidence validation for required fields, result vocabulary, provenance, and forbidden authored truth fields.
+3. Add fake agent fixtures for success, failure, and tool failure.
+4. Add fake tracker fixtures for active, closed, and drift states.
+5. Regenerate installed skill references and runtime script copies.
+6. Bump installer payload version when generated payload behavior changes.
+7. Run targeted checks and `make check`.
+8. Record review evidence, open the #576 PR, merge, verify main, and close #577-#580 through the batch PR.
+
+## Validation
+
+- `python3 -m py_compile src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_check.py`
+- `python3 tools/skills_surface.py check`
+- `python3 tools/loom_check.py`
+- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
+- `npm run check:payload --prefix packages/loom-installer`
+- `python3 tools/loom_flow.py flow merge-ready --target . --item WI-576`
+- `python3 tools/loom_status.py --target . --item WI-576`
+- `make check`

--- a/.loom/specs/WI-576/spec.md
+++ b/.loom/specs/WI-576/spec.md
@@ -1,0 +1,23 @@
+# WI-576 Spec
+
+## Goal
+
+Define structured event evidence and fake orchestration fixtures so Loom can validate orchestration behavior without real model calls, real tool calls, or real tracker mutation.
+
+## Acceptance Criteria
+
+- The stable event schema is `loom-event-evidence/v1`.
+- Event evidence includes item, session, attempt, event, source, subject, result, summary, observation, and provenance fields.
+- Event evidence rejects copied authored truth fields such as `next_step`, `blockers`, `latest_validation_summary`, `recovery`, and `authored_truth`.
+- `loom_check` validates missing required fields and forbidden authored truth fields.
+- Fake agent fixtures cover success, failure, and tool failure.
+- Fake tracker fixtures cover active, closed, and drift states.
+- Tracker and agent fixtures do not call real hosts, real models, real tools, or schedulers.
+- `make check` passes with no tracked verification drift.
+
+## Non-Goals
+
+- Do not introduce a scheduler state machine.
+- Do not make event evidence a second truth source.
+- Do not add `loom-build`; that belongs to #706.
+- Do not add deterministic review engine behavior; that belongs to #675.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,11 +11,11 @@
 - Review Entry: .loom/reviews/WI-576.json
 - Validation Entry: make check
 - Closing Condition: `structured-event-evidence.md` freezes the event evidence schema and truth boundary; `loom_check` rejects missing required event fields and forbidden authored truth fields; fake agent fixtures cover success/failure/tool failure; fake tracker fixtures cover active/closed/drift; generated skill surfaces are synchronized; `make check` passes cleanly; and the #576 batch PR absorbs #577-#580.
-- Current Checkpoint: build checkpoint
-- Current Stop: WI-576 structured event evidence contract, validator, fake orchestration fixtures, generated surfaces, and initial validation are being assembled on the batch branch.
-- Next Step: Complete review evidence, run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
+- Current Checkpoint: merge checkpoint
+- Current Stop: WI-576 structured event evidence implementation, generated surfaces, installer version, and review evidence are aligned on the batch branch.
+- Next Step: Run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
 - Recovery Boundary: Branch work/576-structured-event-evidence; active item WI-576; event evidence is evidence-only and must not replace Work Item, recovery, review, merge-ready, closeout, issue, tracker, or scheduler truth.
 - Current Lane: v0.8.0 / #531 / #576 structured event evidence and fake orchestration fixtures
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,22 +2,22 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-571
-- Goal: Deliver #571 approval and sandbox policy read surface for v0.8.0 / #531.
-- Scope: Define approval/sandbox policy read contracts, preserve the host-adapter boundary, expose policy and risk summary in status/flow output, and validate missing/conflict/unsafe policy fixtures.
-- Execution Path: phase/v0.8.0/fr/571
+- Item ID: WI-576
+- Goal: Deliver #576 structured event evidence and fake orchestration fixtures for v0.8.0 / #531.
+- Scope: Define evidence-only event contracts, add mechanical event evidence validation, and cover fake agent / fake tracker orchestration fixtures without calling real hosts.
+- Execution Path: phase/v0.8.0/fr/576
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-571.md
-- Review Entry: .loom/reviews/WI-571.json
+- Recovery Entry: .loom/progress/WI-576.md
+- Review Entry: .loom/reviews/WI-576.json
 - Validation Entry: make check
-- Closing Condition: `policy_readiness` exposes approval policy, sandbox policy, `declared | missing | conflict | unsafe`, and risk summary; required policy risk blocks the owning surface; optional/advisory policy risk remains advisory; status reads the latest derived summary; fixtures cover missing/conflict/unsafe policy; `make check` passes cleanly; and the #571 batch PR absorbs #572-#575.
-- Current Checkpoint: merge checkpoint
-- Current Stop: WI-571 approval/sandbox policy read surface implementation, generated carriers, demo bootstrap artifacts, reviews, and validation evidence are aligned on the batch branch.
-- Next Step: Push the #571 branch, open the batch PR, wait for host checks, merge to main, then run closeout for #572-#575.
+- Closing Condition: `structured-event-evidence.md` freezes the event evidence schema and truth boundary; `loom_check` rejects missing required event fields and forbidden authored truth fields; fake agent fixtures cover success/failure/tool failure; fake tracker fixtures cover active/closed/drift; generated skill surfaces are synchronized; `make check` passes cleanly; and the #576 batch PR absorbs #577-#580.
+- Current Checkpoint: build checkpoint
+- Current Stop: WI-576 structured event evidence contract, validator, fake orchestration fixtures, generated surfaces, and initial validation are being assembled on the batch branch.
+- Next Step: Complete review evidence, run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed shared scripts; python3 tools/skills_surface.py check passed; policy fixture smoke returned failures 0; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed; python3 tools/loom_check.py passed with 26 surfaces; make check passed twice, with the second demo-bootstrap run reporting write.touched: [].
-- Recovery Boundary: Branch work/571-approval-sandbox-read-surface; active item WI-571; policy readiness evidence is derived from companion locators and must not replace recovery truth, execution_attempt evidence, retained host action results, or host permission/sandbox systems.
-- Current Lane: v0.8.0 / #531 / #571 approval and sandbox policy read surface
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Recovery Boundary: Branch work/576-structured-event-evidence; active item WI-576; event evidence is evidence-only and must not replace Work Item, recovery, review, merge-ready, closeout, issue, tracker, or scheduler truth.
+- Current Lane: v0.8.0 / #531 / #576 structured event evidence and fake orchestration fixtures
 
 ## Runtime Evidence
 
@@ -29,7 +29,7 @@
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-571.md
-- Dynamic Truth: .loom/progress/WI-571.md
+- Static Truth: .loom/work-items/WI-576.md
+- Dynamic Truth: .loom/progress/WI-576.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-576.md
+++ b/.loom/work-items/WI-576.md
@@ -1,0 +1,27 @@
+# WI-576
+
+## Static Facts
+
+- Item ID: WI-576
+- Goal: Deliver #576 structured event evidence and fake orchestration fixtures for v0.8.0 / #531.
+- Scope: Define evidence-only event contracts, add mechanical event evidence validation, and cover fake agent / fake tracker orchestration fixtures without calling real hosts.
+- Execution Path: phase/v0.8.0/fr/576
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-576.md
+- Review Entry: .loom/reviews/WI-576.json
+- Validation Entry: make check
+- Closing Condition: `structured-event-evidence.md` freezes the event evidence schema and truth boundary; `loom_check` rejects missing required event fields and forbidden authored truth fields; fake agent fixtures cover success/failure/tool failure; fake tracker fixtures cover active/closed/drift; generated skill surfaces are synchronized; `make check` passes cleanly; and the #576 batch PR absorbs #577-#580.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-576.md`
+- `.loom/progress/WI-576.md`
+- `.loom/reviews/WI-576.json`
+- `.loom/status/current.md`
+- `.loom/specs/WI-576/spec.md`
+- `.loom/specs/WI-576/plan.md`
+- `.loom/specs/WI-576/implementation-contract.md`
+- `docs/methodology/harness/structured-event-evidence.md`
+- `docs/evidence/orchestration-conformance-profiles.md`
+- `src/skills/shared/scripts/loom_check.py`
+- `skills/`

--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -23,6 +23,7 @@
 - resume / handoff / merge-ready 消费同一 recovery / ledger contract
 - generated `skills/**`、`.loom-runtime/**`、`examples/new-project/.loom/**` 与 `src/skills/**` 同步
 - installer payload、version surface、runtime-state 和 `loom_check` 自检可运行
+- structured event evidence validator 和 fake agent / fake tracker fixtures 可证明 success、failure、tool failure、active、closed、drift 行为
 
 Core 缺口必须 fail closed，因为这些能力构成 Loom v0.7.0 的可恢复 harness 执行控制面。
 
@@ -34,6 +35,7 @@ Core 缺口必须 fail closed，因为这些能力构成 Loom v0.7.0 的可恢�
 
 - repo companion / repo interop locator-only 合同
 - host action / dynamic tool declaration-time locator contract
+- host-backed tracker state 只能作为 structured event evidence 或 retained host result 被消费
 - required locator missing / unreadable / invalid boundary 的 fail-closed 行为
 - optional / advisory missing in-repo locator 只进入 profile-local `missing_optional`
 - adapter drift、shadow parity、external runtime、repo-native carrier 只作为 retained evidence 或 advisory/profile-local gate 消费

--- a/docs/methodology/harness/README.md
+++ b/docs/methodology/harness/README.md
@@ -19,6 +19,8 @@
   - 定义 dynamic tool availability 的 `advertised` / `unavailable` / `unsupported` / `failed` 词表、companion / interop 边界与状态展示规则
 - [policy-read-surface.md](./policy-read-surface.md)
   - 定义 approval / sandbox policy 读面、missing / conflict / unsafe 词表、风险摘要与 host-adapter 边界
+- [structured-event-evidence.md](./structured-event-evidence.md)
+  - 定义 agent / tool / validation / failure / tracker event evidence 的字段、fake orchestration fixtures 与禁止承载 authored truth 的边界
 - [item-context-contract.md](./item-context-contract.md)
   - 定义当前活跃 `Work Item` 的最小 machine-readable 上下文字段与读取边界
 - [status-surface-contract.md](./status-surface-contract.md)

--- a/docs/methodology/harness/host-action-contract.md
+++ b/docs/methodology/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/docs/methodology/harness/status-surface-contract.md
+++ b/docs/methodology/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/docs/methodology/harness/structured-event-evidence.md
+++ b/docs/methodology/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a3f6fda7fe33a71ba7e8a298dc0a62cccbdd59ae2e1fc96825a9fca0f589ed0f"
+      "sha256": "2cf29801606ba3309f239460fa72223b7682056d42821d7c143b40d873c9854f"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a3f6fda7fe33a71ba7e8a298dc0a62cccbdd59ae2e1fc96825a9fca0f589ed0f"
+      "sha256": "2cf29801606ba3309f239460fa72223b7682056d42821d7c143b40d873c9854f"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.76",
+      "version": "0.1.77",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/structured-event-evidence.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/references/harness/host-action-contract.md
+++ b/skills/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/skills/shared/references/harness/status-surface-contract.md
+++ b/skills/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/skills/shared/references/harness/structured-event-evidence.md
+++ b/skills/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/references/harness/host-action-contract.md
+++ b/src/skills/shared/references/harness/host-action-contract.md
@@ -52,6 +52,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 - drift taxonomy 见 [reconciliation-audit.md](./reconciliation-audit.md)
 - closeout 检查与 sync 顺序见 [closeout-gate.md](./closeout-gate.md)
 - approval / sandbox policy 读面见 [policy-read-surface.md](./policy-read-surface.md)
+- structured event evidence 见 [structured-event-evidence.md](./structured-event-evidence.md)
 
 ## 2. 覆盖范围
 
@@ -152,6 +153,7 @@ v0.7 只冻结 declaration-time locator contract。
 - 不在 Loom core 中定义 host/platform 的调用协议
 - 不定义宿主 approval policy 名称、sandbox 配置项或权限提升动作
 - 不把 optional/advisory 缺口升级成普通 PR blocking gate
+- 不把 structured event evidence 提升为 issue、tracker、recovery 或 scheduler 的 authored truth
 
 ## 6. Ownership Boundary
 

--- a/src/skills/shared/references/harness/status-surface-contract.md
+++ b/src/skills/shared/references/harness/status-surface-contract.md
@@ -160,7 +160,23 @@
 - `drift`
 - `gate_failures`
 
-### 3.8 `github`
+### 3.9 `event_evidence`
+
+当 flow、fixture 或 host adapter 提供 structured event evidence 时，状态面可以展示最近事件摘要：
+
+- `schema_version`
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_type`
+- `result`
+- `source`
+- `subject`
+- `provenance`
+
+该字段组只消费 [structured-event-evidence.md](./structured-event-evidence.md) 定义的 evidence-only 事件，不得从事件中读取或生成 `next_step`、`blockers`、`latest_validation_summary`、issue closeout 或 scheduler 状态。
+
+### 3.10 `github`
 
 至少包含：
 
@@ -173,7 +189,7 @@
 - `branch_protection`
 - `project`
 
-### 3.8 `provenance`
+### 3.11 `provenance`
 
 每个会影响 `pass | block` 的字段组至少要能暴露：
 

--- a/src/skills/shared/references/harness/structured-event-evidence.md
+++ b/src/skills/shared/references/harness/structured-event-evidence.md
@@ -1,0 +1,115 @@
+# Structured Event Evidence
+
+本文件定义 Loom v0.8 的 structured event evidence 边界。
+
+Event evidence 是执行、工具、验证、失败和 host tracker 观察的证据面。它用于证明 orchestration 行为发生过、结果是什么、由哪个 fake 或 host adapter 观察到，但不得成为第二套 authored truth。
+
+## 1. 边界
+
+Event evidence 只允许表达：
+
+- `item_id`
+- `session_id`
+- `attempt_id`
+- `event_id`
+- `event_type`
+- `source`
+- `subject`
+- `result`
+- `summary`
+- `observed_at`
+- `provenance`
+
+Event evidence 不允许表达：
+
+- `next_step`
+- `blockers`
+- `latest_validation_summary`
+- `current_checkpoint`
+- `recovery`
+- `authored_truth`
+
+这些字段属于 Work Item、recovery entry、review record 或 closeout basis。事件只能引用这些载体的位置，不能复制或改写它们。
+
+## 2. Schema
+
+最小 schema 固定为 `loom-event-evidence/v1`。
+
+```json
+{
+  "schema_version": "loom-event-evidence/v1",
+  "item_id": "WI-576",
+  "session_id": "session-1",
+  "attempt_id": "attempt-1",
+  "event_id": "event-1",
+  "event_type": "agent.step",
+  "source": {
+    "kind": "fake_agent",
+    "locator": "loom_check.fixture.fake_agent"
+  },
+  "subject": {
+    "kind": "attempt",
+    "locator": ".loom/runtime/attempts/WI-576/latest.json"
+  },
+  "result": "pass",
+  "summary": "fake agent completed the step",
+  "observed_at": "fixture",
+  "provenance": {
+    "authority": "event_evidence",
+    "truth_boundary": "evidence_only"
+  }
+}
+```
+
+`event_type` 当前允许：
+
+- `agent.step`
+- `agent.tool`
+- `tracker.state`
+- `validation.result`
+- `failure.observed`
+
+`result` 当前允许：
+
+- `pass`
+- `fail`
+- `block`
+- `warn`
+- `unavailable`
+
+## 3. Fake Orchestration Fixtures
+
+Loom core fixtures must prove orchestration behavior without real model calls or real trackers.
+
+Fake agent fixtures cover:
+
+- success
+- failure
+- tool failure
+
+Fake tracker fixtures cover fake tracker state reads:
+
+- active
+- closed
+- drift
+
+Fixture events are blocking only for `orchestration-core` contract validity. They do not assert that a real external tracker is available.
+
+## 4. Consumption Rules
+
+Consumers may use event evidence to:
+
+- explain why a flow passed, failed, or blocked
+- connect attempt evidence to tool/validation/failure observations
+- prove fake orchestration behavior in `loom_check`
+- expose host tracker state as evidence
+
+Consumers must not use event evidence to:
+
+- author `next_step`
+- close an issue
+- replace recovery progress
+- bypass review, merge-ready, or closeout
+- invent scheduler state
+
+If event evidence is malformed, missing required fields, or carries forbidden authored truth fields, `loom_check` must fail closed.

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -74,6 +74,7 @@ CORE_DOCS = (
     "docs/methodology/harness/fact-chain-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -190,6 +191,7 @@ AUTOMATION_FRONTLOAD_EXECUTION_SUPPORT = (
     "docs/methodology/harness/work-item-contract.md",
     "docs/methodology/harness/execution-attempt.md",
     "docs/methodology/harness/dynamic-tool-handshake.md",
+    "docs/methodology/harness/structured-event-evidence.md",
     "docs/methodology/harness/execution-context.md",
     "docs/methodology/harness/execution-chain.md",
     "docs/methodology/harness/checkpoint-model.md",
@@ -264,6 +266,17 @@ REPO_INTEROP_AVAILABILITY = {"absent", "incomplete", "present"}
 DYNAMIC_TOOL_HANDSHAKE_STATUSES = {"advertised", "unavailable", "unsupported", "failed"}
 POLICY_READ_STATUSES = {"declared", "missing", "conflict", "unsafe"}
 POLICY_TYPES = {"approval", "sandbox"}
+EVENT_EVIDENCE_SCHEMA = "loom-event-evidence/v1"
+EVENT_EVIDENCE_TYPES = {"agent.step", "agent.tool", "tracker.state", "validation.result", "failure.observed"}
+EVENT_EVIDENCE_RESULTS = {"pass", "fail", "block", "warn", "unavailable"}
+EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "recovery",
+    "authored_truth",
+}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2273,6 +2286,57 @@ def require_execution_attempt_summary(
         for field in ("locator", "latest_locator"):
             if not isinstance(evidence.get(field), str) or not evidence.get(field):
                 failures.append(Failure(category, f"{context} execution_attempt evidence must include `{field}`"))
+
+
+def structured_event_evidence_errors(payload: object, *, context: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{context} event evidence must be an object"]
+    if payload.get("schema_version") != EVENT_EVIDENCE_SCHEMA:
+        errors.append(f"{context} schema_version must be `{EVENT_EVIDENCE_SCHEMA}`")
+    for field in ("item_id", "session_id", "attempt_id", "event_id", "summary", "observed_at"):
+        if not isinstance(payload.get(field), str) or not payload.get(field):
+            errors.append(f"{context} must include non-empty `{field}`")
+    if payload.get("event_type") not in EVENT_EVIDENCE_TYPES:
+        errors.append(f"{context} event_type is outside the stable vocabulary")
+    if payload.get("result") not in EVENT_EVIDENCE_RESULTS:
+        errors.append(f"{context} result is outside the stable vocabulary")
+    for field in ("source", "subject", "provenance"):
+        if not isinstance(payload.get(field), dict):
+            errors.append(f"{context} must include `{field}` as an object")
+    source = payload.get("source")
+    if isinstance(source, dict):
+        if not isinstance(source.get("kind"), str) or not source.get("kind"):
+            errors.append(f"{context} source.kind must be non-empty")
+        if not isinstance(source.get("locator"), str) or not source.get("locator"):
+            errors.append(f"{context} source.locator must be non-empty")
+    subject = payload.get("subject")
+    if isinstance(subject, dict):
+        if subject.get("kind") not in {"item", "session", "attempt", "tool", "validation", "failure", "tracker"}:
+            errors.append(f"{context} subject.kind is outside the stable vocabulary")
+        if not isinstance(subject.get("locator"), str) or not subject.get("locator"):
+            errors.append(f"{context} subject.locator must be non-empty")
+    provenance = payload.get("provenance")
+    if isinstance(provenance, dict):
+        if provenance.get("authority") != "event_evidence":
+            errors.append(f"{context} provenance.authority must be `event_evidence`")
+        if provenance.get("truth_boundary") != "evidence_only":
+            errors.append(f"{context} provenance.truth_boundary must be `evidence_only`")
+    forbidden = sorted(EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS.intersection(payload))
+    if forbidden:
+        errors.append(f"{context} event evidence must not carry authored truth fields: {', '.join(forbidden)}")
+    return errors
+
+
+def require_structured_event_evidence(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    for error in structured_event_evidence_errors(payload, context=context):
+        failures.append(Failure(category, error))
 
 
 def require_fact_chain_provenance(
@@ -9644,6 +9708,152 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def fake_event_evidence(
+    *,
+    event_id: str,
+    event_type: str,
+    source_kind: str,
+    subject_kind: str,
+    result: str,
+    summary: str,
+    subject_locator: str = ".loom/runtime/attempts/WI-576/latest.json",
+) -> dict[str, object]:
+    return {
+        "schema_version": EVENT_EVIDENCE_SCHEMA,
+        "item_id": "WI-576",
+        "session_id": "fixture-session",
+        "attempt_id": "fixture-attempt",
+        "event_id": event_id,
+        "event_type": event_type,
+        "source": {
+            "kind": source_kind,
+            "locator": f"loom_check.fixture.{source_kind}",
+        },
+        "subject": {
+            "kind": subject_kind,
+            "locator": subject_locator,
+        },
+        "result": result,
+        "summary": summary,
+        "observed_at": "fixture",
+        "provenance": {
+            "authority": "event_evidence",
+            "truth_boundary": "evidence_only",
+        },
+    }
+
+
+def check_structured_event_evidence_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/methodology/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "tool failure",
+            "drift",
+            "evidence_only",
+            "`next_step`",
+        ],
+        "skills/shared/references/harness/structured-event-evidence.md": [
+            "loom-event-evidence/v1",
+            "fake agent",
+            "fake tracker",
+            "evidence_only",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("structured-event-evidence", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("structured-event-evidence", f"`{relative}` must mention `{anchor}`"))
+
+    events = [
+        fake_event_evidence(
+            event_id="fake-agent-success",
+            event_type="agent.step",
+            source_kind="fake_agent",
+            subject_kind="attempt",
+            result="pass",
+            summary="fake agent completed the orchestration step",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-failure",
+            event_type="failure.observed",
+            source_kind="fake_agent",
+            subject_kind="failure",
+            result="fail",
+            summary="fake agent reported a controlled failure",
+            subject_locator=".loom/runtime/events/WI-576/failure.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-agent-tool-failure",
+            event_type="agent.tool",
+            source_kind="fake_agent",
+            subject_kind="tool",
+            result="block",
+            summary="fake agent reported a tool failure without calling a real tool",
+            subject_locator=".loom/runtime/events/WI-576/tool.json",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-active",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed active state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-closed",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="pass",
+            summary="fake tracker observed closed state",
+            subject_locator="fake-tracker://WI-576",
+        ),
+        fake_event_evidence(
+            event_id="fake-tracker-drift",
+            event_type="tracker.state",
+            source_kind="fake_tracker",
+            subject_kind="tracker",
+            result="block",
+            summary="fake tracker observed state drift",
+            subject_locator="fake-tracker://WI-576",
+        ),
+    ]
+    for event in events:
+        require_structured_event_evidence(
+            failures,
+            category="structured-event-evidence",
+            context=str(event.get("event_id")),
+            payload=event,
+        )
+
+    missing_required = dict(events[0])
+    missing_required.pop("attempt_id", None)
+    if not any("attempt_id" in error for error in structured_event_evidence_errors(missing_required, context="missing-required")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject missing required fields"))
+
+    truth_poisoned = dict(events[0])
+    truth_poisoned["next_step"] = "close the issue"
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(truth_poisoned, context="truth-poisoned")):
+        failures.append(Failure("structured-event-evidence", "event evidence must reject copied recovery truth"))
+
+    tracker_poisoned = dict(events[-1])
+    tracker_poisoned["recovery"] = {"next_step": "invented tracker recovery"}
+    if not any("authored truth fields" in error for error in structured_event_evidence_errors(tracker_poisoned, context="tracker-poisoned")):
+        failures.append(Failure("structured-event-evidence", "fake tracker drift must not carry scheduler or recovery truth"))
+
+    return failures
+
+
 def deferred_roadmap_inventory_section(body: str) -> str:
     match = re.search(r"(?ims)^## Roadmap Inventory\s*(.*?)(?=^## |\Z)", body)
     return match.group(1).strip() if match else ""
@@ -10101,6 +10311,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10108,7 +10319,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 26
+    categories_checked = 27
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")


### PR DESCRIPTION
## Summary

- Adds the `loom-event-evidence/v1` structured event evidence contract and evidence-only boundary for agent, tool, tracker, validation, and failure events.
- Adds `loom_check` validation fixtures for required event fields, allowed vocabularies, fake agent success/failure/tool-failure events, fake tracker active/closed/drift events, and forbidden authored truth fields.
- Syncs generated skill/reference/runtime surfaces, demo bootstrap payloads, root WI-576 carriers, review evidence, shadow evidence, and installer version `0.1.77`.

## Validation

- `python3 -m py_compile src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_check.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/loom_check.py` (`checked 27 surfaces`)
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `npm run check:payload --prefix packages/loom-installer`
- `python3 tools/loom_status.py --target . --item WI-576`
- `python3 tools/loom_flow.py flow merge-ready --target . --item WI-576`
- `python3 .loom/bin/loom_flow.py adopt verify --target .`
- `make check` (`loom_check: OK`, `checked 27 surfaces`; demo bootstrap `write.touched: []`)
- `git status --short --ignored=matching .loom/runtime/attempts` shows only ignored `.loom/runtime/attempts/`

## Review / Governance Evidence

- `.loom/work-items/WI-576.md`
- `.loom/progress/WI-576.md`
- `.loom/status/current.md`
- `.loom/reviews/WI-576.spec.json`
- `.loom/reviews/WI-576.json`
- `/tmp/loom-status-576-final3.json`
- `/tmp/loom-merge-ready-576-final3.json`
- `/tmp/loom-adopt-verify-576-final.json`

Parent FR: #576
v0.8.0 parent: #531

Closes #577
Closes #578
Closes #579
Closes #580
