### PR TITLE
feat: make review engine profile deterministic

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -74,9 +74,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-576",
-      "work_item": ".loom/work-items/WI-576.md",
-      "recovery_entry": ".loom/progress/WI-576.md",
+      "current_item_id": "WI-675",
+      "work_item": ".loom/work-items/WI-675.md",
+      "recovery_entry": ".loom/progress/WI-675.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-576.md
+++ b/.loom/progress/WI-576.md
@@ -3,11 +3,11 @@
 ## Dynamic Facts
 
 - Item ID: WI-576
-- Current Checkpoint: merge checkpoint
-- Current Stop: WI-576 structured event evidence implementation, generated surfaces, installer version, and review evidence are aligned on the batch branch.
-- Next Step: Run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
+- Current Checkpoint: retired
+- Current Stop: WI-576 merged through #717 and closed after post-merge verification and child closeout reconciliation.
+- Next Step: No WI-576 action; continue v0.8.0 execution at WI-675.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
+- Latest Validation Summary: #717 merged to main at e46a8686cd6f049a5adfd3fff8833b796072f5e9; post-merge make check passed with 27 surfaces and demo bootstrap write.touched [] ; closeout checks passed for #577-#580.
 - Recovery Boundary: Branch work/576-structured-event-evidence; active item WI-576; event evidence is evidence-only and must not replace Work Item, recovery, review, merge-ready, closeout, issue, tracker, or scheduler truth.
 - Current Lane: v0.8.0 / #531 / #576 structured event evidence and fake orchestration fixtures
 

--- a/.loom/progress/WI-675.md
+++ b/.loom/progress/WI-675.md
@@ -3,7 +3,7 @@
 ## Dynamic Facts
 
 - Item ID: WI-675
-- Current Checkpoint: build checkpoint
+- Current Checkpoint: merge checkpoint
 - Current Stop: WI-675 implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
 - Blockers: None recorded.

--- a/.loom/progress/WI-675.md
+++ b/.loom/progress/WI-675.md
@@ -4,10 +4,10 @@
 
 - Item ID: WI-675
 - Current Checkpoint: build checkpoint
-- Current Stop: WI-675 implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Current Stop: WI-675 implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
 - Recovery Boundary: Branch work/675-deterministic-review-engine-execution; active item WI-675; review engine profile evidence is execution evidence and must not replace authored review, Work Item, recovery, merge-ready, closeout, issue, or PR truth.
 - Current Lane: v0.8.0 / #531 / #675 deterministic review engine execution
 

--- a/.loom/progress/WI-675.md
+++ b/.loom/progress/WI-675.md
@@ -1,0 +1,21 @@
+# WI-675 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-675
+- Current Checkpoint: build checkpoint
+- Current Stop: WI-675 implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
+- Blockers: None recorded.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Recovery Boundary: Branch work/675-deterministic-review-engine-execution; active item WI-675; review engine profile evidence is execution evidence and must not replace authored review, Work Item, recovery, merge-ready, closeout, issue, or PR truth.
+- Current Lane: v0.8.0 / #531 / #675 deterministic review engine execution
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-675/plan.md
+- Acceptance Locator: .loom/specs/WI-675/spec.md
+- Validation Evidence Locator: python3 tools/loom_check.py
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current

--- a/.loom/reviews/WI-675.json
+++ b/.loom/reviews/WI-675.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-675",
+  "decision": "fallback",
+  "kind": "general_review",
+  "summary": "Formal review has not been recorded yet.",
+  "reviewer": "not yet assigned",
+  "reviewed_head": "e46a8686cd6f049a5adfd3fff8833b796072f5e9",
+  "reviewed_validation_summary": "No validation recorded yet.",
+  "fallback_to": "admission",
+  "findings": [
+    {
+      "id": "scaffolded-block-1",
+      "summary": "Review artifact scaffolded but not yet concluded.",
+      "severity": "block",
+      "rebuttal": null,
+      "disposition": {
+        "status": "rejected",
+        "summary": "Scaffold placeholder must be replaced by a real formal review conclusion."
+      }
+    },
+    {
+      "id": "scaffolded-warn-1",
+      "summary": "Record a real review before asking merge checkpoint to consume it.",
+      "severity": "warn",
+      "rebuttal": null,
+      "disposition": {
+        "status": "deferred",
+        "summary": "This follow-up stays open until a real review is recorded."
+      }
+    }
+  ],
+  "blocking_issues": [
+    "Review artifact scaffolded but not yet concluded."
+  ],
+  "follow_ups": [
+    "Record a real review before asking merge checkpoint to consume it."
+  ]
+}

--- a/.loom/reviews/WI-675.json
+++ b/.loom/reviews/WI-675.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#675 implementation resolves a deterministic review engine profile before Codex execution, passes explicit model/reasoning settings, records profile evidence in metadata and review_record_input, and adds fixtures for override and missing-profile contract enforcement.",
   "reviewer": "codex",
-  "reviewed_head": "fd37609c35f8f3b54d18dd3797b02ca17bc6b255",
+  "reviewed_head": "c86a2f1207f444da103f65b23e3ec4db0f7c1bb6",
   "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-675.json
+++ b/.loom/reviews/WI-675.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#675 implementation resolves a deterministic review engine profile before Codex execution, passes explicit model/reasoning settings, records profile evidence in metadata and review_record_input, and adds fixtures for override and missing-profile contract enforcement.",
   "reviewer": "codex",
-  "reviewed_head": "c86a2f1207f444da103f65b23e3ec4db0f7c1bb6",
+  "reviewed_head": "c86a2f1091ba405a2fc84c14bf96347fde4bbe62",
   "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-675.json
+++ b/.loom/reviews/WI-675.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#675 implementation resolves a deterministic review engine profile before Codex execution, passes explicit model/reasoning settings, records profile evidence in metadata and review_record_input, and adds fixtures for override and missing-profile contract enforcement.",
   "reviewer": "codex",
-  "reviewed_head": "7ab1c30edfea90ba4dd7fd34dffafcfe751d7f3a",
+  "reviewed_head": "fd37609c35f8f3b54d18dd3797b02ca17bc6b255",
   "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-675.json
+++ b/.loom/reviews/WI-675.json
@@ -1,39 +1,23 @@
 {
   "schema_version": "loom-review/v1",
   "item_id": "WI-675",
-  "decision": "fallback",
-  "kind": "general_review",
-  "summary": "Formal review has not been recorded yet.",
-  "reviewer": "not yet assigned",
-  "reviewed_head": "e46a8686cd6f049a5adfd3fff8833b796072f5e9",
-  "reviewed_validation_summary": "No validation recorded yet.",
-  "fallback_to": "admission",
-  "findings": [
-    {
-      "id": "scaffolded-block-1",
-      "summary": "Review artifact scaffolded but not yet concluded.",
-      "severity": "block",
-      "rebuttal": null,
-      "disposition": {
-        "status": "rejected",
-        "summary": "Scaffold placeholder must be replaced by a real formal review conclusion."
-      }
-    },
-    {
-      "id": "scaffolded-warn-1",
-      "summary": "Record a real review before asking merge checkpoint to consume it.",
-      "severity": "warn",
-      "rebuttal": null,
-      "disposition": {
-        "status": "deferred",
-        "summary": "This follow-up stays open until a real review is recorded."
-      }
-    }
-  ],
-  "blocking_issues": [
-    "Review artifact scaffolded but not yet concluded."
-  ],
-  "follow_ups": [
-    "Record a real review before asking merge checkpoint to consume it."
-  ]
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "#675 implementation resolves a deterministic review engine profile before Codex execution, passes explicit model/reasoning settings, records profile evidence in metadata and review_record_input, and adds fixtures for override and missing-profile contract enforcement.",
+  "reviewer": "codex",
+  "reviewed_head": "7ab1c30edfea90ba4dd7fd34dffafcfe751d7f3a",
+  "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-675.md",
+    "recovery_entry": ".loom/progress/WI-675.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "engine_adapter": "loom/default-codex",
+    "engine_evidence": ".loom/runtime/review/WI-675/7ab1c30edfea90ba4dd7fd34dffafcfe751d7f3a/engine-metadata.json",
+    "normalized_findings": "not_applicable"
+  }
 }

--- a/.loom/reviews/WI-675.spec.json
+++ b/.loom/reviews/WI-675.spec.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-675",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "#675 spec freezes deterministic review engine profile evidence and scopes implementation to explicit Codex model/reasoning resolution plus fixtures.",
+  "reviewer": "codex",
+  "reviewed_head": "7ab1c30edfea90ba4dd7fd34dffafcfe751d7f3a",
+  "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; installer version and payload checks passed.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-675.md",
+    "recovery_entry": ".loom/progress/WI-675.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "182741c84cd45fffaa0dfb310551942e3f02550df276c30c3a093d3eed3310c8"
+    ".loom/status/current.md": "fefcd76369987e6d8184b52a89609459fcb268a7498b8074eba573a7bf2af7e5"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "182741c84cd45fffaa0dfb310551942e3f02550df276c30c3a093d3eed3310c8"
+    ".loom/status/current.md": "fefcd76369987e6d8184b52a89609459fcb268a7498b8074eba573a7bf2af7e5"
   }
 }

--- a/.loom/specs/WI-675/implementation-contract.md
+++ b/.loom/specs/WI-675/implementation-contract.md
@@ -1,0 +1,20 @@
+# WI-675 Implementation Contract
+
+## In Scope
+
+- Review engine profile schema and deterministic profile selection.
+- Explicit Codex `--model` and reasoning configuration for `review run`.
+- Evidence fields under `engine.profile`, engine metadata, and `review_record_input.engine_profile`.
+- Fail-closed override semantics requiring an override reason.
+- Mechanical fixtures in `loom_check`.
+
+## Out Of Scope
+
+- Multiple review engines.
+- Repo-specific review instruction expansion.
+- Repeated blocker context-pack construction.
+- Release publication or v0.8.0 final closeout.
+
+## Truth Boundary
+
+The resolved profile is review execution evidence. It does not replace the authored review record, Work Item, recovery entry, merge-ready evidence, closeout evidence, GitHub issue state, or PR state.

--- a/.loom/specs/WI-675/plan.md
+++ b/.loom/specs/WI-675/plan.md
@@ -1,0 +1,18 @@
+# WI-675 Plan
+
+## Steps
+
+- Define the review engine profile contract in `docs/methodology/harness/review-execution.md` and synchronized skill references.
+- Add deterministic profile resolution to `loom_flow.py`.
+- Pass explicit model and reasoning flags to Codex in `review run`.
+- Record the resolved profile in engine metadata and `review_record_input`.
+- Add review-run fixtures for positive evidence, override evidence, missing override reason, and missing profile metadata.
+- Refresh generated skill surfaces.
+- Run targeted checks and full `make check`.
+
+## Validation
+
+- `python3 -m py_compile src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py`
+- `python3 tools/skills_surface.py check`
+- `python3 tools/loom_check.py`
+- `make check`

--- a/.loom/specs/WI-675/spec.md
+++ b/.loom/specs/WI-675/spec.md
@@ -1,0 +1,23 @@
+# WI-675 Spec
+
+## Goal
+
+Make formal review execution deterministic by resolving and recording a stable review engine profile before `review run` invokes the Codex-backed reviewer.
+
+## Acceptance Criteria
+
+- The stable profile schema is `loom-review-engine-profile/v1`.
+- The profile records adapter, engine, profile id, model, reasoning effort, timeout, context policy, selection reason, and override reason.
+- `review run` passes explicit model and reasoning arguments to Codex instead of inheriting host defaults.
+- Default, high-risk, spec-review, and repeated-blocker profile selection rules are documented.
+- Manual profile, model, or reasoning overrides fail closed unless an override reason is recorded.
+- Engine metadata includes the resolved profile for pass and fail-closed paths.
+- `review_record_input` includes the resolved profile when engine review passes.
+- Regression fixtures prove positive profile evidence, override evidence, missing-reason blocking, and missing profile contract failure.
+- `make check` passes with no tracked verification drift.
+
+## Non-Goals
+
+- Do not turn Loom into a multi-engine marketplace.
+- Do not add the review context pack or repeated blocker loop handling; that belongs to #679.
+- Do not change authored review record truth semantics beyond evidence locators.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,7 +11,7 @@
 - Review Entry: .loom/reviews/WI-675.json
 - Validation Entry: make check
 - Closing Condition: Review execution has a stable profile contract; review run passes explicit model and reasoning parameters instead of inheriting host defaults; engine metadata and review_record_input expose the resolved profile, selection reason, and override reason; override without reason fails closed; review fixtures require profile evidence; generated skill surfaces are synchronized; make check passes cleanly; and the #675 batch PR absorbs #676-#678.
-- Current Checkpoint: build checkpoint
+- Current Checkpoint: merge checkpoint
 - Current Stop: WI-675 implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
 - Blockers: None recorded.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -12,10 +12,10 @@
 - Validation Entry: make check
 - Closing Condition: Review execution has a stable profile contract; review run passes explicit model and reasoning parameters instead of inheriting host defaults; engine metadata and review_record_input expose the resolved profile, selection reason, and override reason; override without reason fails closed; review fixtures require profile evidence; generated skill surfaces are synchronized; make check passes cleanly; and the #675 batch PR absorbs #676-#678.
 - Current Checkpoint: build checkpoint
-- Current Stop: WI-675 implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Current Stop: WI-675 implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
 - Recovery Boundary: Branch work/675-deterministic-review-engine-execution; active item WI-675; review engine profile evidence is execution evidence and must not replace authored review, Work Item, recovery, merge-ready, closeout, issue, or PR truth.
 - Current Lane: v0.8.0 / #531 / #675 deterministic review engine execution
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,22 +2,22 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-576
-- Goal: Deliver #576 structured event evidence and fake orchestration fixtures for v0.8.0 / #531.
-- Scope: Define evidence-only event contracts, add mechanical event evidence validation, and cover fake agent / fake tracker orchestration fixtures without calling real hosts.
-- Execution Path: phase/v0.8.0/fr/576
+- Item ID: WI-675
+- Goal: Deliver #675 deterministic review engine execution for v0.8.0 / #531.
+- Scope: Define the review engine profile contract, resolve explicit Codex model and reasoning profile in review run, and require auditable profile evidence in review fixtures.
+- Execution Path: phase/v0.8.0/fr/675
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-576.md
-- Review Entry: .loom/reviews/WI-576.json
+- Recovery Entry: .loom/progress/WI-675.md
+- Review Entry: .loom/reviews/WI-675.json
 - Validation Entry: make check
-- Closing Condition: `structured-event-evidence.md` freezes the event evidence schema and truth boundary; `loom_check` rejects missing required event fields and forbidden authored truth fields; fake agent fixtures cover success/failure/tool failure; fake tracker fixtures cover active/closed/drift; generated skill surfaces are synchronized; `make check` passes cleanly; and the #576 batch PR absorbs #577-#580.
-- Current Checkpoint: merge checkpoint
-- Current Stop: WI-576 structured event evidence implementation, generated surfaces, installer version, and review evidence are aligned on the batch branch.
-- Next Step: Run full `make check`, open the #576 batch PR, merge to main, then close #577-#580.
+- Closing Condition: Review execution has a stable profile contract; review run passes explicit model and reasoning parameters instead of inheriting host defaults; engine metadata and review_record_input expose the resolved profile, selection reason, and override reason; override without reason fails closed; review fixtures require profile evidence; generated skill surfaces are synchronized; make check passes cleanly; and the #675 batch PR absorbs #676-#678.
+- Current Checkpoint: build checkpoint
+- Current Stop: WI-675 implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
-- Recovery Boundary: Branch work/576-structured-event-evidence; active item WI-576; event evidence is evidence-only and must not replace Work Item, recovery, review, merge-ready, closeout, issue, tracker, or scheduler truth.
-- Current Lane: v0.8.0 / #531 / #576 structured event evidence and fake orchestration fixtures
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Recovery Boundary: Branch work/675-deterministic-review-engine-execution; active item WI-675; review engine profile evidence is execution evidence and must not replace authored review, Work Item, recovery, merge-ready, closeout, issue, or PR truth.
+- Current Lane: v0.8.0 / #531 / #675 deterministic review engine execution
 
 ## Runtime Evidence
 
@@ -29,7 +29,7 @@
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-576.md
-- Dynamic Truth: .loom/progress/WI-576.md
+- Static Truth: .loom/work-items/WI-675.md
+- Dynamic Truth: .loom/progress/WI-675.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/work-items/WI-675.md
+++ b/.loom/work-items/WI-675.md
@@ -1,0 +1,27 @@
+# WI-675
+
+## Static Facts
+
+- Item ID: WI-675
+- Goal: Deliver #675 deterministic review engine execution for v0.8.0 / #531.
+- Scope: Define the review engine profile contract, resolve explicit Codex model and reasoning profile in review run, and require auditable profile evidence in review fixtures.
+- Execution Path: phase/v0.8.0/fr/675
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-675.md
+- Review Entry: .loom/reviews/WI-675.json
+- Validation Entry: make check
+- Closing Condition: Review execution has a stable profile contract; review run passes explicit model and reasoning parameters instead of inheriting host defaults; engine metadata and review_record_input expose the resolved profile, selection reason, and override reason; override without reason fails closed; review fixtures require profile evidence; generated skill surfaces are synchronized; make check passes cleanly; and the #675 batch PR absorbs #676-#678.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-675.md`
+- `.loom/progress/WI-675.md`
+- `.loom/reviews/WI-675.json`
+- `.loom/status/current.md`
+- `.loom/specs/WI-675/spec.md`
+- `.loom/specs/WI-675/plan.md`
+- `.loom/specs/WI-675/implementation-contract.md`
+- `docs/methodology/harness/review-execution.md`
+- `src/skills/shared/scripts/loom_flow.py`
+- `src/skills/shared/scripts/loom_check.py`
+- `skills/`

--- a/docs/methodology/harness/review-execution.md
+++ b/docs/methodology/harness/review-execution.md
@@ -55,6 +55,37 @@ Loom 把 review 分成三层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "847128c31b5cdb3d72887ba4932ed58de9f4e2ef729d4d51855d37364d3a3555"
+      "sha256": "08035cff99ba0ba1875653344e60801148bde1c2c99ebff0e1d0eed7a57696d2"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "2cf29801606ba3309f239460fa72223b7682056d42821d7c143b40d873c9854f"
+      "sha256": "e2a0d80f3b095780cf8a17a4fff5c61287ef2bfe737345b48016a54245d31de8"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "847128c31b5cdb3d72887ba4932ed58de9f4e2ef729d4d51855d37364d3a3555"
+      "sha256": "08035cff99ba0ba1875653344e60801148bde1c2c99ebff0e1d0eed7a57696d2"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "2cf29801606ba3309f239460fa72223b7682056d42821d7c143b40d873c9854f"
+      "sha256": "e2a0d80f3b095780cf8a17a4fff5c61287ef2bfe737345b48016a54245d31de8"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.77",
+      "version": "0.1.78",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/skills/shared/references/harness/review-execution.md
+++ b/skills/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")

--- a/src/skills/shared/references/harness/review-execution.md
+++ b/src/skills/shared/references/harness/review-execution.md
@@ -57,6 +57,37 @@ Loom 把 review 分成四层：
 
 成熟既有仓库可以通过 repo companion 的 `review_instruction_locators` 声明 spec review 与 implementation review 的 repo-owned instruction 入口。正式 review 必须先消费这些 locator；缺失、不可读或越界时 fail closed，不得猜测 `spec_review.md`、`code_review.md` 或任何 repo-specific review instruction 路径。
 
+### 2.1 Review engine profile contract
+
+`review run` 在调用 Codex-backed reviewer 前必须解析稳定 profile，不得继承本机 `~/.codex/config.toml` 的默认 model 或 reasoning effort。
+
+Resolved profile 的 schema 为 `loom-review-engine-profile/v1`，至少包含：
+
+- `adapter`: 当前固定为 `loom/default-codex`
+- `engine`: 当前固定为 `codex`
+- `profile_id`: `default`、`high-risk`、`spec-review` 或 `repeated-blocker`
+- `model`: 显式传给 engine 的 model
+- `reasoning_effort`: `low`、`medium`、`high` 或 `xhigh`
+- `timeout_seconds`: engine 执行超时
+- `context_policy`: 本次 review 允许消费的上下文策略
+- `selection_reason`: 选择该 profile 的原因
+- `override_reason`: 若发生人工或 repo override，必须为非空；无 override 时为 `null`
+
+默认选择规则：
+
+- `spec-review`: `kind = spec_review` 时使用，reasoning 至少为 `high`
+- `high-risk`: active item 涉及 shared contract、security、permission、approval、sandbox、host adapter、runtime 或 release 边界时使用
+- `repeated-blocker`: active item 已标记重复 blocker / root-cause review 时使用
+- `default`: 普通 implementation review 使用
+
+允许通过 `review run --engine-profile`、`--engine-model` 或 `--engine-reasoning` override，但必须同时提供 `--engine-override-reason`。override evidence 必须记录 previous profile、selected profile 和 reason。
+
+Resolved profile 必须同时出现在：
+
+- `engine.profile`
+- `.loom/runtime/review/<item>/<head>/engine-metadata.json`
+- `review_record_input.engine_profile`
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -2178,6 +2178,35 @@ def require_review_run_payload(
         failures.append(Failure(category, f"{context} engine must stay `codex` for the default path"))
     if engine.get("adapter") != "loom/default-codex":
         failures.append(Failure(category, f"{context} adapter must stay `loom/default-codex`"))
+    profile = engine.get("profile")
+    if engine.get("result") == "not_run" and profile is None and engine.get("failure_reason") == "runtime_conflict":
+        pass
+    elif not isinstance(profile, dict):
+        failures.append(Failure(category, f"{context} engine profile must include the resolved review engine profile"))
+    else:
+        if profile.get("schema_version") != "loom-review-engine-profile/v1":
+            failures.append(Failure(category, f"{context} engine profile schema must stay `loom-review-engine-profile/v1`"))
+        if profile.get("adapter") != "loom/default-codex" or profile.get("engine") != "codex":
+            failures.append(Failure(category, f"{context} engine profile must bind the Codex adapter explicitly"))
+        if profile.get("profile_id") not in {"default", "high-risk", "spec-review", "repeated-blocker"}:
+            failures.append(Failure(category, f"{context} engine profile id must stay within the stable vocabulary"))
+        for key in ("model", "reasoning_effort", "context_policy", "selection_reason"):
+            if not isinstance(profile.get(key), str) or not profile.get(key):
+                failures.append(Failure(category, f"{context} engine profile must include non-empty `{key}`"))
+        if profile.get("reasoning_effort") not in {"low", "medium", "high", "xhigh"}:
+            failures.append(Failure(category, f"{context} engine profile reasoning effort must stay within the stable vocabulary"))
+        if not isinstance(profile.get("timeout_seconds"), int) or profile.get("timeout_seconds") <= 0:
+            failures.append(Failure(category, f"{context} engine profile must include a positive `timeout_seconds`"))
+        if "override" in profile:
+            override = profile.get("override")
+            if not isinstance(override, dict):
+                failures.append(Failure(category, f"{context} engine profile override must be an object"))
+            else:
+                for key in ("previous_profile", "selected_profile"):
+                    if not isinstance(override.get(key), dict):
+                        failures.append(Failure(category, f"{context} engine profile override must include `{key}`"))
+                if not isinstance(override.get("reason"), str) or not override.get("reason"):
+                    failures.append(Failure(category, f"{context} engine profile override must include a non-empty reason"))
     if engine.get("result") not in {"pass", "block", "not_run"}:
         failures.append(Failure(category, f"{context} engine result must stay within the stable contract"))
     if engine.get("failure_reason") not in {None, "engine_unavailable", "schema_drift", "runtime_conflict", "repo_diff_detected"}:
@@ -2213,6 +2242,8 @@ def require_review_run_payload(
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
+            if not isinstance(review_record_input.get("engine_profile"), dict):
+                failures.append(Failure(category, f"{context} review_record_input must include resolved `engine_profile`"))
             if review_record_input.get("decision") not in {"allow", "block", "fallback"}:
                 failures.append(Failure(category, f"{context} review_record_input decision must stay within the stable contract"))
             if review_record_input.get("reviewer") != "loom/default-codex":
@@ -4712,6 +4743,89 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 payload=payload,
                 expected_result={"pass"},
             )
+            if isinstance(payload, dict):
+                profile_probe = json.loads(json.dumps(payload))
+                if isinstance(profile_probe.get("engine"), dict):
+                    profile_probe["engine"].pop("profile", None)
+                profile_probe_failures: list[Failure] = []
+                require_review_run_payload(
+                    profile_probe_failures,
+                    category="daily-execution-cli",
+                    context="`review run` missing profile probe",
+                    payload=profile_probe,
+                    expected_result={"pass"},
+                )
+                if not any("engine profile" in failure.detail for failure in profile_probe_failures):
+                    failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        override_target = Path(tmp) / "profile-override"
+        prepare_review_target(override_target, "review run profile override")
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(override_target),
+                "--item",
+                "INIT-0001",
+                "--engine-model",
+                "gpt-5.2",
+                "--engine-reasoning",
+                "high",
+                "--engine-override-reason",
+                "fixture requires explicit high-reasoning review profile evidence",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` profile override",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            engine = payload.get("engine") if isinstance(payload, dict) else None
+            profile = engine.get("profile") if isinstance(engine, dict) else None
+            if not isinstance(profile, dict) or not isinstance(profile.get("override"), dict):
+                failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile evidence"))
+            else:
+                override = profile["override"]
+                if not isinstance(override.get("previous_profile"), dict) or not isinstance(override.get("selected_profile"), dict):
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must record previous and selected profile"))
+                if override.get("reason") != "fixture requires explicit high-reasoning review profile evidence":
+                    failures.append(Failure("daily-execution-cli", "`review run` profile override must preserve the override reason"))
+
+        missing_reason_target = Path(tmp) / "profile-override-missing-reason"
+        prepare_review_target(missing_reason_target, "review run profile override missing reason")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(missing_reason_target),
+                "--item",
+                "INIT-0001",
+                "--engine-reasoning",
+                "high",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` profile override missing reason failed: {error}"))
+        elif payload.get("result") != "block":
+            failures.append(Failure("daily-execution-cli", "`review run` profile override must block without an override reason"))
+        elif "override requires" not in json.dumps(payload.get("missing_inputs"), ensure_ascii=False):
+            failures.append(Failure("daily-execution-cli", "`review run` profile override missing reason must expose the missing reason"))
 
         engine_missing_target = Path(tmp) / "engine-missing"
         prepare_review_target(engine_missing_target, "review run engine unavailable")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -106,6 +106,43 @@ REVIEW_FINDING_DISPOSITION_STATUSES = {"accepted", "rejected", "deferred"}
 DEFAULT_REVIEW_ENGINE = "codex"
 DEFAULT_REVIEW_ADAPTER = "loom/default-codex"
 DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
+REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
+REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
+REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "profile_id": "default",
+        "model": "gpt-5.2",
+        "reasoning_effort": "medium",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "minimal-review-baseline",
+        "selection_reason": "default implementation review profile for normal-risk changes",
+    },
+    "high-risk": {
+        "profile_id": "high-risk",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "expanded-risk-baseline",
+        "selection_reason": "high-risk review profile for shared contracts, security, permissions, sandbox, or host-boundary changes",
+    },
+    "spec-review": {
+        "profile_id": "spec-review",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "formal-spec-suite-baseline",
+        "selection_reason": "formal spec review profile",
+    },
+    "repeated-blocker": {
+        "profile_id": "repeated-blocker",
+        "model": "gpt-5.2",
+        "reasoning_effort": "high",
+        "timeout_seconds": DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+        "context_policy": "recent-findings-and-dispositions",
+        "selection_reason": "repeated blocker review profile",
+    },
+}
 ENGINE_FAILURE_REASONS = {
     "engine_unavailable",
     "schema_drift",
@@ -299,6 +336,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     review.add_argument("--engine-adapter", help="Optional review engine adapter identifier consumed by this record")
     review.add_argument("--engine-evidence", help="Optional review engine evidence path relative to the target root")
     review.add_argument("--normalized-findings", help="Optional normalized findings path relative to the target root")
+    review.add_argument("--engine-profile", choices=tuple(sorted(REVIEW_ENGINE_PROFILE_IDS)), help="Optional deterministic review engine profile override for review run")
+    review.add_argument("--engine-model", help="Optional review engine model override for review run")
+    review.add_argument("--engine-reasoning", choices=tuple(sorted(REVIEW_ENGINE_REASONING_EFFORTS)), help="Optional review engine reasoning effort override for review run")
+    review.add_argument("--engine-override-reason", help="Required reason when overriding review engine profile, model, or reasoning")
     review.add_argument("--blocking-issue", action="append", default=[], help="Blocking review finding")
     review.add_argument("--follow-up", action="append", default=[], help="Follow-up item recorded by the review")
 
@@ -3234,6 +3275,7 @@ def run_default_review_engine(
     context: dict[str, Any],
     build_payload: dict[str, Any],
     review_path: str,
+    engine_profile: dict[str, Any],
     *,
     review_kind: str | None = None,
 ) -> dict[str, Any]:
@@ -3254,6 +3296,7 @@ def run_default_review_engine(
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
+    timeout_seconds = int(engine_profile["timeout_seconds"])
 
     before_fingerprint, fingerprint_errors = git_tracked_diff_fingerprint(context["target_root"])
     if fingerprint_errors:
@@ -3266,6 +3309,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "runtime_conflict",
                 "reviewed_head": reviewed_head,
@@ -3294,8 +3338,13 @@ def run_default_review_engine(
             [
                 DEFAULT_REVIEW_ENGINE,
                 "exec",
+                "--ignore-user-config",
                 "-C",
                 str(context["target_root"]),
+                "-m",
+                str(engine_profile["model"]),
+                "-c",
+                f"model_reasoning_effort={json.dumps(engine_profile['reasoning_effort'])}",
                 "-s",
                 "workspace-write",
                 "--output-schema",
@@ -3310,7 +3359,7 @@ def run_default_review_engine(
             text=True,
             capture_output=True,
             check=False,
-            timeout=DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
         )
     except FileNotFoundError:
         failure_reason = "engine_unavailable"
@@ -3318,7 +3367,7 @@ def run_default_review_engine(
     except subprocess.TimeoutExpired:
         failure_reason = "runtime_conflict"
         failure_detail = (
-            f"default review engine timed out after {DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS}s"
+            f"default review engine timed out after {timeout_seconds}s"
         )
     else:
         if completed.returncode != 0:
@@ -3363,6 +3412,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3377,6 +3427,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": failure_reason,
                 "reviewed_head": reviewed_head,
@@ -3397,6 +3448,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3412,6 +3464,7 @@ def run_default_review_engine(
             "engine": {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "block",
                 "failure_reason": "schema_drift",
                 "reviewed_head": reviewed_head,
@@ -3425,6 +3478,7 @@ def run_default_review_engine(
             {
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
+                "profile": engine_profile,
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
@@ -3441,6 +3495,7 @@ def run_default_review_engine(
         "engine": {
             "engine": DEFAULT_REVIEW_ENGINE,
             "adapter": DEFAULT_REVIEW_ADAPTER,
+            "profile": engine_profile,
             "result": "pass",
             "failure_reason": None,
             "reviewed_head": reviewed_head,
@@ -3454,6 +3509,7 @@ def run_default_review_engine(
             "findings_file": relative_to_root(findings_path, context["target_root"]),
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
+            "engine_profile": engine_profile,
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4019,6 +4075,95 @@ def implementation_review_kind(context: dict[str, Any]) -> str:
     if scope_paths and all(path.endswith(".md") or path.startswith(".loom/") for path in scope_paths):
         return "general_review"
     return "code_review"
+
+
+def review_engine_profile_selection(context: dict[str, Any], review_kind: str) -> tuple[str, str]:
+    if review_kind == "spec_review":
+        return "spec-review", "spec review requires the formal spec profile instead of inheriting host defaults"
+    haystack = " ".join(
+        str(context.get(key, ""))
+        for key in (
+            "goal",
+            "scope",
+            "execution_path",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+        )
+    ).lower()
+    high_risk_terms = (
+        "security",
+        "permission",
+        "approval",
+        "sandbox",
+        "host",
+        "adapter",
+        "shared contract",
+        "contract",
+        "runtime",
+        "release",
+    )
+    if any(term in haystack for term in high_risk_terms):
+        return "high-risk", "risk terms in the active item require the high-risk formal review profile"
+    if "repeated blocker" in haystack or "repeated-blocker" in haystack:
+        return "repeated-blocker", "active item references repeated blocker review handling"
+    return "default", "default implementation review profile for normal-risk changes"
+
+
+def resolve_review_engine_profile(
+    context: dict[str, Any],
+    review_kind: str,
+    *,
+    requested_profile: str | None = None,
+    requested_model: str | None = None,
+    requested_reasoning: str | None = None,
+    override_reason: str | None = None,
+) -> tuple[dict[str, Any] | None, list[str]]:
+    selected_profile, selection_reason = review_engine_profile_selection(context, review_kind)
+    if requested_profile:
+        selected_profile = requested_profile
+        selection_reason = f"profile override requested `{requested_profile}`"
+    base_profile = dict(REVIEW_ENGINE_PROFILES[selected_profile])
+    base_profile["selection_reason"] = selection_reason
+    previous_profile = dict(base_profile)
+    override_requested = any(value for value in (requested_profile, requested_model, requested_reasoning))
+    reason = override_reason.strip() if isinstance(override_reason, str) else ""
+    if override_requested and not reason:
+        return None, ["review engine profile override requires --engine-override-reason"]
+    if requested_model:
+        base_profile["model"] = requested_model.strip()
+    if requested_reasoning:
+        base_profile["reasoning_effort"] = requested_reasoning
+    if not isinstance(base_profile.get("model"), str) or not base_profile["model"].strip():
+        return None, ["review engine profile model must be non-empty"]
+    if base_profile.get("reasoning_effort") not in REVIEW_ENGINE_REASONING_EFFORTS:
+        return None, ["review engine profile reasoning effort is outside the stable vocabulary"]
+    resolved = {
+        "schema_version": REVIEW_ENGINE_PROFILE_SCHEMA,
+        "profile_id": base_profile["profile_id"],
+        "adapter": DEFAULT_REVIEW_ADAPTER,
+        "engine": DEFAULT_REVIEW_ENGINE,
+        "model": base_profile["model"],
+        "reasoning_effort": base_profile["reasoning_effort"],
+        "timeout_seconds": int(base_profile["timeout_seconds"]),
+        "context_policy": base_profile["context_policy"],
+        "selection_reason": base_profile["selection_reason"],
+        "override_reason": reason or None,
+    }
+    if override_requested:
+        resolved["override"] = {
+            "previous_profile": previous_profile,
+            "selected_profile": {
+                "profile_id": resolved["profile_id"],
+                "model": resolved["model"],
+                "reasoning_effort": resolved["reasoning_effort"],
+                "timeout_seconds": resolved["timeout_seconds"],
+                "context_policy": resolved["context_policy"],
+            },
+            "reason": reason,
+        }
+    return resolved, []
 
 
 def review_focus_paths(context: dict[str, Any]) -> list[str]:
@@ -8097,6 +8242,42 @@ def handle_review(args: argparse.Namespace) -> int:
     if args.operation == "run":
         flow_operation = "spec-review" if inferred_spec_review else "review"
         review_kind = "spec_review" if inferred_spec_review else implementation_review_kind(context)
+        engine_profile, engine_profile_errors = resolve_review_engine_profile(
+            context,
+            review_kind,
+            requested_profile=args.engine_profile,
+            requested_model=args.engine_model,
+            requested_reasoning=args.engine_reasoning,
+            override_reason=args.engine_override_reason,
+        )
+        if engine_profile_errors or engine_profile is None:
+            manual_review = manual_review_payload(
+                context=context,
+                findings_file=None,
+                kind=review_kind,
+                review_record_path=review_path,
+            )
+            return emit(
+                {
+                    "command": "review",
+                    "operation": "run",
+                    "item": {"id": context["item_id"]},
+                    "result": "block",
+                    "summary": "default review engine profile could not be resolved safely.",
+                    "missing_inputs": engine_profile_errors,
+                    "fallback_to": None,
+                    "engine": {
+                        "engine": DEFAULT_REVIEW_ENGINE,
+                        "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": None,
+                        "result": "not_run",
+                        "failure_reason": "runtime_conflict",
+                        "reviewed_head": git_head_sha(target_root) or "unknown-head",
+                        "evidence": None,
+                    },
+                    "manual_review": manual_review,
+                }
+            )
         flow_payload = build_review_flow_payload(target_root, args.output, args.item, operation=flow_operation)
         review_surface = flow_payload.get("review") or (flow_payload.get("spec_review") if inferred_spec_review else None)
         if flow_payload["result"] != "pass":
@@ -8127,6 +8308,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "engine": {
                         "engine": DEFAULT_REVIEW_ENGINE,
                         "adapter": DEFAULT_REVIEW_ADAPTER,
+                        "profile": engine_profile,
                         "result": "not_run",
                         "failure_reason": None,
                         "reviewed_head": git_head_sha(target_root) or "unknown-head",
@@ -8137,7 +8319,13 @@ def handle_review(args: argparse.Namespace) -> int:
             )
 
         build_payload = flow_payload["build_checkpoint"]
-        engine_payload = run_default_review_engine(context, build_payload, review_path, review_kind=review_kind)
+        engine_payload = run_default_review_engine(
+            context,
+            build_payload,
+            review_path,
+            engine_profile,
+            review_kind=review_kind,
+        )
         review_record_input = engine_payload.get("review_record_input")
         findings_file = (
             review_record_input.get("findings_file")


### PR DESCRIPTION
## Summary

- Defines the `loom-review-engine-profile/v1` contract for deterministic formal review execution.
- Resolves explicit Codex adapter/model/reasoning/timeout/context-policy profile before `review run` invokes the engine, including default, high-risk, spec-review, and repeated-blocker profile paths.
- Passes explicit Codex model and reasoning config instead of inheriting host defaults.
- Records resolved profile evidence in `engine.profile`, engine metadata, and `review_record_input.engine_profile`.
- Adds fixtures for positive profile evidence, override previous/selected/reason evidence, missing override reason fail-closed behavior, and missing profile metadata contract failure.
- Syncs generated skill/runtime surfaces, demo bootstrap generated files, shadow evidence, root WI-675 carriers, and installer version `0.1.78`.

## Validation

- `python3 -m py_compile src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/loom_check.py` (`checked 27 surfaces`)
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `npm run check:payload --prefix packages/loom-installer`
- `python3 tools/loom_status.py --target . --item WI-675`
- `python3 tools/loom_flow.py flow merge-ready --target . --item WI-675`
- `python3 .loom/bin/loom_flow.py adopt verify --target .`
- `make check` (`loom_check: OK`, `checked 27 surfaces`; demo bootstrap `write.touched: []`)
- `git status --short --ignored=matching .loom/runtime/attempts` shows only ignored `.loom/runtime/attempts/`

## Review / Governance Evidence

- `.loom/work-items/WI-675.md`
- `.loom/progress/WI-675.md`
- `.loom/status/current.md`
- `.loom/reviews/WI-675.spec.json`
- `.loom/reviews/WI-675.json`
- `/tmp/loom-status-675-final4.json`
- `/tmp/loom-merge-ready-675-final4.json`
- `/tmp/loom-adopt-verify-675-final.json`

Parent FR: #675
v0.8.0 parent: #531

Closes #676
Closes #677
Closes #678
