### PR TITLE
feat: add review context pack evidence

### DIFF
--- a/.loom/bootstrap/init-result.json
+++ b/.loom/bootstrap/init-result.json
@@ -74,9 +74,9 @@
     "mode": "work-item + recovery-entry + derived status-surface",
     "read_entry": "python3 .loom/bin/loom_init.py fact-chain --target .",
     "entry_points": {
-      "current_item_id": "WI-675",
-      "work_item": ".loom/work-items/WI-675.md",
-      "recovery_entry": ".loom/progress/WI-675.md",
+      "current_item_id": "WI-679",
+      "work_item": ".loom/work-items/WI-679.md",
+      "recovery_entry": ".loom/progress/WI-679.md",
       "status_surface": ".loom/status/current.md"
     }
   },

--- a/.loom/progress/WI-675.md
+++ b/.loom/progress/WI-675.md
@@ -3,11 +3,11 @@
 ## Dynamic Facts
 
 - Item ID: WI-675
-- Current Checkpoint: merge checkpoint
-- Current Stop: WI-675 implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
-- Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
+- Current Checkpoint: retired
+- Current Stop: WI-675 merged through #718 and closed after post-merge verification and child closeout reconciliation.
+- Next Step: No WI-675 action; continue v0.8.0 execution at WI-679.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
+- Latest Validation Summary: #718 merged to main at 504099084c921d48ea0026609a10014c126f118b; post-merge make check passed with 27 surfaces and demo bootstrap write.touched [] ; closeout checks passed for #676-#678.
 - Recovery Boundary: Branch work/675-deterministic-review-engine-execution; active item WI-675; review engine profile evidence is execution evidence and must not replace authored review, Work Item, recovery, merge-ready, closeout, issue, or PR truth.
 - Current Lane: v0.8.0 / #531 / #675 deterministic review engine execution
 

--- a/.loom/progress/WI-679.md
+++ b/.loom/progress/WI-679.md
@@ -3,7 +3,7 @@
 ## Dynamic Facts
 
 - Item ID: WI-679
-- Current Checkpoint: build checkpoint
+- Current Checkpoint: merge checkpoint
 - Current Stop: WI-679 context pack implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open the #679 batch PR, merge to main, then close #680-#683.
 - Blockers: None recorded.

--- a/.loom/progress/WI-679.md
+++ b/.loom/progress/WI-679.md
@@ -1,0 +1,21 @@
+# WI-679 Progress
+
+## Dynamic Facts
+
+- Item ID: WI-679
+- Current Checkpoint: build checkpoint
+- Current Stop: WI-679 context pack implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open the #679 batch PR, merge to main, then close #680-#683.
+- Blockers: None recorded.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Recovery Boundary: Branch work/679-review-context-pack-repeated-blocker; active item WI-679; context pack and repeated blocker signal are input evidence only and must not replace review, recovery, merge-ready, closeout, issue, or PR truth.
+- Current Lane: v0.8.0 / #531 / #679 review context pack and repeated blocker signal
+
+## Execution Ledger
+
+- Ledger Binding: recovery_entry
+- Plan Locator: .loom/specs/WI-679/plan.md
+- Acceptance Locator: .loom/specs/WI-679/spec.md
+- Validation Evidence Locator: python3 tools/loom_check.py
+- Handoff Notes Locator: not_applicable
+- Evidence Freshness: current

--- a/.loom/progress/WI-679.md
+++ b/.loom/progress/WI-679.md
@@ -4,10 +4,10 @@
 
 - Item ID: WI-679
 - Current Checkpoint: build checkpoint
-- Current Stop: WI-679 context pack implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Current Stop: WI-679 context pack implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open the #679 batch PR, merge to main, then close #680-#683.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
 - Recovery Boundary: Branch work/679-review-context-pack-repeated-blocker; active item WI-679; context pack and repeated blocker signal are input evidence only and must not replace review, recovery, merge-ready, closeout, issue, or PR truth.
 - Current Lane: v0.8.0 / #531 / #679 review context pack and repeated blocker signal
 

--- a/.loom/reviews/WI-679.json
+++ b/.loom/reviews/WI-679.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#679 implementation writes review context pack input evidence, feeds recent findings and repeated blocker guidance into the default prompt, records context pack locators in engine evidence, and adds fixtures for repeated/root-cause candidates.",
   "reviewer": "codex",
-  "reviewed_head": "23ee00b27a3807b6edce5ebb37fb1d29938c7887",
+  "reviewed_head": "3a7cdd67dff04ea84593b4dcb2ccd56c8c4c0759",
   "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-679.json
+++ b/.loom/reviews/WI-679.json
@@ -1,39 +1,23 @@
 {
   "schema_version": "loom-review/v1",
   "item_id": "WI-679",
-  "decision": "fallback",
-  "kind": "general_review",
-  "summary": "Formal review has not been recorded yet.",
-  "reviewer": "not yet assigned",
-  "reviewed_head": "504099084c921d48ea0026609a10014c126f118b",
-  "reviewed_validation_summary": "No validation recorded yet.",
-  "fallback_to": "admission",
-  "findings": [
-    {
-      "id": "scaffolded-block-1",
-      "summary": "Review artifact scaffolded but not yet concluded.",
-      "severity": "block",
-      "rebuttal": null,
-      "disposition": {
-        "status": "rejected",
-        "summary": "Scaffold placeholder must be replaced by a real formal review conclusion."
-      }
-    },
-    {
-      "id": "scaffolded-warn-1",
-      "summary": "Record a real review before asking merge checkpoint to consume it.",
-      "severity": "warn",
-      "rebuttal": null,
-      "disposition": {
-        "status": "deferred",
-        "summary": "This follow-up stays open until a real review is recorded."
-      }
-    }
-  ],
-  "blocking_issues": [
-    "Review artifact scaffolded but not yet concluded."
-  ],
-  "follow_ups": [
-    "Record a real review before asking merge checkpoint to consume it."
-  ]
+  "decision": "allow",
+  "kind": "code_review",
+  "summary": "#679 implementation writes review context pack input evidence, feeds recent findings and repeated blocker guidance into the default prompt, records context pack locators in engine evidence, and adds fixtures for repeated/root-cause candidates.",
+  "reviewer": "codex",
+  "reviewed_head": "c82f5e84787a2a65fec105e63bfdda7091523511",
+  "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-679.md",
+    "recovery_entry": ".loom/progress/WI-679.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "engine_adapter": "loom/default-codex",
+    "engine_evidence": ".loom/runtime/review/WI-679/c82f5e84787a2a65fec105e63bfdda7091523511/engine-metadata.json",
+    "normalized_findings": "not_applicable"
+  }
 }

--- a/.loom/reviews/WI-679.json
+++ b/.loom/reviews/WI-679.json
@@ -5,7 +5,7 @@
   "kind": "code_review",
   "summary": "#679 implementation writes review context pack input evidence, feeds recent findings and repeated blocker guidance into the default prompt, records context pack locators in engine evidence, and adds fixtures for repeated/root-cause candidates.",
   "reviewer": "codex",
-  "reviewed_head": "c82f5e84787a2a65fec105e63bfdda7091523511",
+  "reviewed_head": "23ee00b27a3807b6edce5ebb37fb1d29938c7887",
   "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.",
   "fallback_to": null,
   "findings": [],

--- a/.loom/reviews/WI-679.json
+++ b/.loom/reviews/WI-679.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-679",
+  "decision": "fallback",
+  "kind": "general_review",
+  "summary": "Formal review has not been recorded yet.",
+  "reviewer": "not yet assigned",
+  "reviewed_head": "504099084c921d48ea0026609a10014c126f118b",
+  "reviewed_validation_summary": "No validation recorded yet.",
+  "fallback_to": "admission",
+  "findings": [
+    {
+      "id": "scaffolded-block-1",
+      "summary": "Review artifact scaffolded but not yet concluded.",
+      "severity": "block",
+      "rebuttal": null,
+      "disposition": {
+        "status": "rejected",
+        "summary": "Scaffold placeholder must be replaced by a real formal review conclusion."
+      }
+    },
+    {
+      "id": "scaffolded-warn-1",
+      "summary": "Record a real review before asking merge checkpoint to consume it.",
+      "severity": "warn",
+      "rebuttal": null,
+      "disposition": {
+        "status": "deferred",
+        "summary": "This follow-up stays open until a real review is recorded."
+      }
+    }
+  ],
+  "blocking_issues": [
+    "Review artifact scaffolded but not yet concluded."
+  ],
+  "follow_ups": [
+    "Record a real review before asking merge checkpoint to consume it."
+  ]
+}

--- a/.loom/reviews/WI-679.spec.json
+++ b/.loom/reviews/WI-679.spec.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "loom-review/v1",
+  "item_id": "WI-679",
+  "decision": "allow",
+  "kind": "spec_review",
+  "summary": "#679 spec defines context pack and repeated blocker evidence as input-only review evidence with advisory enforcement for v0.8.0.",
+  "reviewer": "codex",
+  "reviewed_head": "c82f5e84787a2a65fec105e63bfdda7091523511",
+  "reviewed_validation_summary": "python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; installer version and payload checks passed.",
+  "fallback_to": null,
+  "findings": [],
+  "blocking_issues": [],
+  "follow_ups": [],
+  "consumed_inputs": {
+    "work_item": ".loom/work-items/WI-679.md",
+    "recovery_entry": ".loom/progress/WI-679.md",
+    "status_surface": ".loom/status/current.md",
+    "build_checkpoint": "pass",
+    "engine_adapter": null,
+    "engine_evidence": null,
+    "normalized_findings": null
+  }
+}

--- a/.loom/shadow/closeout-loom.json
+++ b/.loom/shadow/closeout-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "fefcd76369987e6d8184b52a89609459fcb268a7498b8074eba573a7bf2af7e5"
+    ".loom/status/current.md": "f6bf7d2b8ba011e1897f6f29e7412465bb121b99185b075e4cc17a4df4ede26e"
   }
 }

--- a/.loom/shadow/merge-ready-loom.json
+++ b/.loom/shadow/merge-ready-loom.json
@@ -4,6 +4,6 @@
     ".loom/status/current.md"
   ],
   "source_sha256": {
-    ".loom/status/current.md": "fefcd76369987e6d8184b52a89609459fcb268a7498b8074eba573a7bf2af7e5"
+    ".loom/status/current.md": "f6bf7d2b8ba011e1897f6f29e7412465bb121b99185b075e4cc17a4df4ede26e"
   }
 }

--- a/.loom/specs/WI-679/implementation-contract.md
+++ b/.loom/specs/WI-679/implementation-contract.md
@@ -1,0 +1,19 @@
+# WI-679 Implementation Contract
+
+## In Scope
+
+- `loom-review-context-pack/v1` evidence written by `review run`.
+- Recent finding and disposition projection into review prompt input.
+- Advisory `loom-repeated-blocker-signal/v1` evidence with source locators.
+- Fixtures that prove repeated blockers recommend root-cause handling.
+
+## Out Of Scope
+
+- Hard merge gate enforcement for repeated blockers.
+- New review truth carriers.
+- New review engine selection behavior.
+- Installed upgrade rehearsal or `loom-build`.
+
+## Truth Boundary
+
+The context pack and repeated blocker signal are input evidence. They must not replace the authored review record, Work Item, recovery entry, merge-ready evidence, closeout evidence, GitHub issue state, or PR state.

--- a/.loom/specs/WI-679/plan.md
+++ b/.loom/specs/WI-679/plan.md
@@ -1,0 +1,18 @@
+# WI-679 Plan
+
+## Steps
+
+- Document the context pack and repeated blocker signal contracts in `review-execution.md`.
+- Build context pack evidence from the current review record and prior normalized findings.
+- Add context pack locator to engine evidence, metadata, and `review_record_input`.
+- Include recent findings and repeated blocker guidance in the default review prompt.
+- Add fixtures for context pack presence and repeated blocker/root-cause candidate detection.
+- Refresh generated skill surfaces and demo bootstrap output.
+- Run targeted checks and full `make check`.
+
+## Validation
+
+- `python3 -m py_compile src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py`
+- `python3 tools/skills_surface.py check`
+- `python3 tools/loom_check.py`
+- `make check`

--- a/.loom/specs/WI-679/spec.md
+++ b/.loom/specs/WI-679/spec.md
@@ -1,0 +1,23 @@
+# WI-679 Spec
+
+## Goal
+
+Add an MVP review context pack so formal review consumes recent findings, dispositions, reviewed heads, validation summaries, and repeated blocker candidates before producing another verdict.
+
+## Acceptance Criteria
+
+- The context pack schema is `loom-review-context-pack/v1`.
+- The repeated blocker signal schema is `loom-repeated-blocker-signal/v1`.
+- `review run` writes context pack evidence before invoking the review engine.
+- The default review prompt includes recent finding summaries, disposition state, and repeated/root-cause classification guidance.
+- Engine metadata and review output expose the context pack locator.
+- Repeated block finding patterns are summarized with source locators and recommended root-cause handling.
+- Repeated blocker enforcement remains advisory in v0.8.0 and does not become a hard merge gate.
+- Fixtures prove repeated finding history produces a repeated blocker/root-cause candidate.
+- `make check` passes with no tracked verification drift.
+
+## Non-Goals
+
+- Do not create a second review truth source.
+- Do not make repeated blocker fallback blocking until v0.9 hardening.
+- Do not expand deterministic engine profile behavior; that belongs to #675.

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -2,22 +2,22 @@
 
 ## Derived Fact Chain View
 
-- Item ID: WI-675
-- Goal: Deliver #675 deterministic review engine execution for v0.8.0 / #531.
-- Scope: Define the review engine profile contract, resolve explicit Codex model and reasoning profile in review run, and require auditable profile evidence in review fixtures.
-- Execution Path: phase/v0.8.0/fr/675
+- Item ID: WI-679
+- Goal: Deliver #679 review context pack and repeated blocker signal for v0.8.0 / #531.
+- Scope: Define the review context pack MVP, feed recent findings/dispositions into review prompts and engine evidence, and emit advisory repeated blocker/root-cause signals with fixtures.
+- Execution Path: phase/v0.8.0/fr/679
 - Workspace Entry: .
-- Recovery Entry: .loom/progress/WI-675.md
-- Review Entry: .loom/reviews/WI-675.json
+- Recovery Entry: .loom/progress/WI-679.md
+- Review Entry: .loom/reviews/WI-679.json
 - Validation Entry: make check
-- Closing Condition: Review execution has a stable profile contract; review run passes explicit model and reasoning parameters instead of inheriting host defaults; engine metadata and review_record_input expose the resolved profile, selection reason, and override reason; override without reason fails closed; review fixtures require profile evidence; generated skill surfaces are synchronized; make check passes cleanly; and the #675 batch PR absorbs #676-#678.
-- Current Checkpoint: merge checkpoint
-- Current Stop: WI-675 implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
-- Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open #675 batch PR, merge to main, then close #676-#678.
+- Closing Condition: Review context pack schema is documented; review run writes context pack evidence; prompt consumes recent findings and dispositions; repeated blocker signal is advisory evidence with source locators; fixtures prove repeated blockers recommend root-cause handling; generated skill surfaces are synchronized; make check passes cleanly; and the #679 batch PR absorbs #680-#683.
+- Current Checkpoint: build checkpoint
+- Current Stop: WI-679 context pack implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open the #679 batch PR, merge to main, then close #680-#683.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
-- Recovery Boundary: Branch work/675-deterministic-review-engine-execution; active item WI-675; review engine profile evidence is execution evidence and must not replace authored review, Work Item, recovery, merge-ready, closeout, issue, or PR truth.
-- Current Lane: v0.8.0 / #531 / #675 deterministic review engine execution
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Recovery Boundary: Branch work/679-review-context-pack-repeated-blocker; active item WI-679; context pack and repeated blocker signal are input evidence only and must not replace review, recovery, merge-ready, closeout, issue, or PR truth.
+- Current Lane: v0.8.0 / #531 / #679 review context pack and repeated blocker signal
 
 ## Runtime Evidence
 
@@ -29,7 +29,7 @@
 
 ## Sources
 
-- Static Truth: .loom/work-items/WI-675.md
-- Dynamic Truth: .loom/progress/WI-675.md
+- Static Truth: .loom/work-items/WI-679.md
+- Dynamic Truth: .loom/progress/WI-679.md
 - Locator Truth: .loom/bootstrap/init-result.json
 - Fact Chain CLI: python3 .loom/bin/loom_init.py fact-chain --target .

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -12,10 +12,10 @@
 - Validation Entry: make check
 - Closing Condition: Review context pack schema is documented; review run writes context pack evidence; prompt consumes recent findings and dispositions; repeated blocker signal is advisory evidence with source locators; fixtures prove repeated blockers recommend root-cause handling; generated skill surfaces are synchronized; make check passes cleanly; and the #679 batch PR absorbs #680-#683.
 - Current Checkpoint: build checkpoint
-- Current Stop: WI-679 context pack implementation and fixtures are drafted on the batch branch; generated skill surfaces are synchronized.
+- Current Stop: WI-679 context pack implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open the #679 batch PR, merge to main, then close #680-#683.
 - Blockers: None recorded.
-- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces.
+- Latest Validation Summary: python3 -m py_compile passed for changed loom_flow and loom_check scripts; python3 tools/skills_surface.py check passed; python3 tools/loom_check.py passed with 27 surfaces; node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main passed; npm run check:payload --prefix packages/loom-installer passed.
 - Recovery Boundary: Branch work/679-review-context-pack-repeated-blocker; active item WI-679; context pack and repeated blocker signal are input evidence only and must not replace review, recovery, merge-ready, closeout, issue, or PR truth.
 - Current Lane: v0.8.0 / #531 / #679 review context pack and repeated blocker signal
 

--- a/.loom/status/current.md
+++ b/.loom/status/current.md
@@ -11,7 +11,7 @@
 - Review Entry: .loom/reviews/WI-679.json
 - Validation Entry: make check
 - Closing Condition: Review context pack schema is documented; review run writes context pack evidence; prompt consumes recent findings and dispositions; repeated blocker signal is advisory evidence with source locators; fixtures prove repeated blockers recommend root-cause handling; generated skill surfaces are synchronized; make check passes cleanly; and the #679 batch PR absorbs #680-#683.
-- Current Checkpoint: build checkpoint
+- Current Checkpoint: merge checkpoint
 - Current Stop: WI-679 context pack implementation, fixtures, generated surfaces, installer version, and review evidence are aligned on the batch branch.
 - Next Step: Run installer/version checks, refresh review evidence, run merge-ready, open the #679 batch PR, merge to main, then close #680-#683.
 - Blockers: None recorded.

--- a/.loom/work-items/WI-679.md
+++ b/.loom/work-items/WI-679.md
@@ -1,0 +1,27 @@
+# WI-679
+
+## Static Facts
+
+- Item ID: WI-679
+- Goal: Deliver #679 review context pack and repeated blocker signal for v0.8.0 / #531.
+- Scope: Define the review context pack MVP, feed recent findings/dispositions into review prompts and engine evidence, and emit advisory repeated blocker/root-cause signals with fixtures.
+- Execution Path: phase/v0.8.0/fr/679
+- Workspace Entry: .
+- Recovery Entry: .loom/progress/WI-679.md
+- Review Entry: .loom/reviews/WI-679.json
+- Validation Entry: make check
+- Closing Condition: Review context pack schema is documented; review run writes context pack evidence; prompt consumes recent findings and dispositions; repeated blocker signal is advisory evidence with source locators; fixtures prove repeated blockers recommend root-cause handling; generated skill surfaces are synchronized; make check passes cleanly; and the #679 batch PR absorbs #680-#683.
+
+## Associated Artifacts
+
+- `.loom/work-items/WI-679.md`
+- `.loom/progress/WI-679.md`
+- `.loom/reviews/WI-679.json`
+- `.loom/status/current.md`
+- `.loom/specs/WI-679/spec.md`
+- `.loom/specs/WI-679/plan.md`
+- `.loom/specs/WI-679/implementation-contract.md`
+- `docs/methodology/harness/review-execution.md`
+- `src/skills/shared/scripts/loom_flow.py`
+- `src/skills/shared/scripts/loom_check.py`
+- `skills/`

--- a/docs/methodology/harness/review-execution.md
+++ b/docs/methodology/harness/review-execution.md
@@ -86,6 +86,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "08035cff99ba0ba1875653344e60801148bde1c2c99ebff0e1d0eed7a57696d2"
+      "sha256": "cc7dfa79b7ba0c573b9441ba08928129e8210ffe07337a8bf5239fb39fdf47ff"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "e2a0d80f3b095780cf8a17a4fff5c61287ef2bfe737345b48016a54245d31de8"
+      "sha256": "f761cf04db50733f4193355de05d1de523093bb236d6e24c20e59e5562a8ad75"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "08035cff99ba0ba1875653344e60801148bde1c2c99ebff0e1d0eed7a57696d2"
+      "sha256": "cc7dfa79b7ba0c573b9441ba08928129e8210ffe07337a8bf5239fb39fdf47ff"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "e2a0d80f3b095780cf8a17a4fff5c61287ef2bfe737345b48016a54245d31de8"
+      "sha256": "f761cf04db50733f4193355de05d1de523093bb236d6e24c20e59e5562a8ad75"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.78",
+      "version": "0.1.79",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/skills/shared/references/harness/review-execution.md
+++ b/skills/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",

--- a/src/skills/shared/references/harness/review-execution.md
+++ b/src/skills/shared/references/harness/review-execution.md
@@ -88,6 +88,31 @@ Resolved profile 必须同时出现在：
 - `.loom/runtime/review/<item>/<head>/engine-metadata.json`
 - `review_record_input.engine_profile`
 
+### 2.2 Review context pack
+
+`review run` 必须在调用 engine 前写入 MVP context pack，schema 为 `loom-review-context-pack/v1`。context pack 是输入证据，不是第二份 review truth。
+
+Context pack 至少包含：
+
+- `item_id`
+- `review_path`
+- `current_head`
+- `validation_summary`
+- `history_available`
+- `recent_findings`
+- `repeated_blocker_signal`
+
+`recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
+
+- `result = present` 表示至少两个 block finding 共享 repeat key
+- `result = absent` 表示当前可用历史中未发现重复 blocker
+- `enforcement = advisory` 表示本批不把重复 blocker 自动升级成 merge gate blocker
+- `candidates[]` 必须列出 repeat key、count、source locators、summary 和 recommended action
+
+Prompt 必须消费 context pack，并要求 reviewer 将 finding 分类为 `new`、`unresolved` 或 `repeated/root-cause candidate`。历史不可用时，context pack 仍必须存在并标明 `history_available = false`，不得猜测历史结论。
+
 ## 3. review record 最小字段
 
 review record 至少应包含：

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -2219,7 +2219,7 @@ def require_review_run_payload(
         if not isinstance(evidence, dict):
             failures.append(Failure(category, f"{context} engine must include `evidence` when it runs"))
         else:
-            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata"):
+            for key in ("runtime_root", "prompt", "raw_result", "normalized_findings", "metadata", "context_pack"):
                 value = evidence.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} engine evidence must include non-empty `{key}`"))
@@ -2238,7 +2238,7 @@ def require_review_run_payload(
         if not isinstance(review_record_input, dict):
             failures.append(Failure(category, f"{context} must include `review_record_input` when engine review passes"))
         else:
-            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings"):
+            for key in ("decision", "summary", "reviewer", "kind", "findings_file", "engine_adapter", "engine_evidence", "normalized_findings", "context_pack"):
                 value = review_record_input.get(key)
                 if not isinstance(value, str) or not value:
                     failures.append(Failure(category, f"{context} review_record_input must include non-empty `{key}`"))
@@ -4744,6 +4744,20 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 expected_result={"pass"},
             )
             if isinstance(payload, dict):
+                evidence = payload.get("engine", {}).get("evidence") if isinstance(payload.get("engine"), dict) else None
+                context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+                prompt_path = evidence.get("prompt") if isinstance(evidence, dict) else None
+                if not isinstance(context_pack_path, str) or not (review_target / context_pack_path).exists():
+                    failures.append(Failure("daily-execution-cli", "`review run` positive chain must write context pack evidence"))
+                else:
+                    context_pack = json.loads((review_target / context_pack_path).read_text(encoding="utf-8"))
+                    if context_pack.get("schema_version") != "loom-review-context-pack/v1":
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must use the stable schema"))
+                    if not isinstance(context_pack.get("repeated_blocker_signal"), dict):
+                        failures.append(Failure("daily-execution-cli", "`review run` context pack must include repeated blocker signal"))
+                prompt_file = (review_target / prompt_path) if isinstance(prompt_path, str) else None
+                if prompt_file is None or not prompt_file.exists() or "Recent Review Context Pack" not in prompt_file.read_text(encoding="utf-8"):
+                    failures.append(Failure("daily-execution-cli", "`review run` prompt must include recent review context pack guidance"))
                 profile_probe = json.loads(json.dumps(payload))
                 if isinstance(profile_probe.get("engine"), dict):
                     profile_probe["engine"].pop("profile", None)
@@ -4757,6 +4771,76 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 )
                 if not any("engine profile" in failure.detail for failure in profile_probe_failures):
                     failures.append(Failure("daily-execution-cli", "`review run` contract check must fail when resolved profile metadata is missing"))
+
+        repeated_target = Path(tmp) / "repeated-blocker-context"
+        prepare_review_target(repeated_target, "review run repeated blocker context")
+        history_root = repeated_target / ".loom/runtime/review/INIT-0001"
+        for attempt in ("attempt-a", "attempt-b"):
+            attempt_root = history_root / attempt
+            attempt_root.mkdir(parents=True, exist_ok=True)
+            (attempt_root / "normalized-findings.json").write_text(
+                json.dumps(
+                    {
+                        "findings": [
+                            {
+                                "id": "block-context-drift",
+                                "summary": "Context drift keeps reappearing after local patch attempts.",
+                                "severity": "block",
+                                "rebuttal": None,
+                                "disposition": {
+                                    "status": "accepted",
+                                    "summary": "Fixture marks this as a real repeated blocker candidate.",
+                                },
+                            }
+                        ]
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (attempt_root / "engine-metadata.json").write_text(
+                json.dumps({"reviewed_head": attempt, "validation_summary": f"{attempt} validation"}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        write_fake_codex(fake_bin / "codex", mode="success")
+        payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "review",
+                "run",
+                "--target",
+                str(repeated_target),
+                "--item",
+                "INIT-0001",
+            ],
+            env=success_env,
+        )
+        if error:
+            failures.append(Failure("daily-execution-cli", f"`review run` repeated blocker context failed: {error}"))
+        else:
+            require_review_run_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`review run` repeated blocker context",
+                payload=payload,
+                expected_result={"pass"},
+            )
+            evidence = payload.get("engine", {}).get("evidence") if isinstance(payload, dict) and isinstance(payload.get("engine"), dict) else None
+            context_pack_path = evidence.get("context_pack") if isinstance(evidence, dict) else None
+            if not isinstance(context_pack_path, str):
+                failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must expose context pack evidence"))
+            else:
+                context_pack = json.loads((repeated_target / context_pack_path).read_text(encoding="utf-8"))
+                signal = context_pack.get("repeated_blocker_signal")
+                if not isinstance(signal, dict) or signal.get("result") != "present":
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must identify repeated blocker candidates"))
+                candidates = signal.get("candidates") if isinstance(signal, dict) else None
+                if not isinstance(candidates, list) or not candidates:
+                    failures.append(Failure("daily-execution-cli", "`review run` repeated blocker context must include candidate details"))
 
         override_target = Path(tmp) / "profile-override"
         prepare_review_target(override_target, "review run profile override")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -177,6 +177,8 @@ EXECUTION_ATTEMPT_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery_boundary",
     "closing_condition",
 }
+REVIEW_CONTEXT_PACK_SCHEMA = "loom-review-context-pack/v1"
+REPEATED_BLOCKER_SIGNAL_SCHEMA = "loom-repeated-blocker-signal/v1"
 
 ADOPTION_DECISION_QUESTIONS: dict[str, str] = {
     "fr_work_item_layer": "Which host planning object owns the FR layer, and how does each FR point to its Work Item?",
@@ -2935,6 +2937,127 @@ def load_findings_file(target_root: Path, findings_file: str) -> tuple[list[dict
     return findings, []
 
 
+def repeated_blocker_key(finding: dict[str, Any]) -> str:
+    finding_id = finding.get("id")
+    if isinstance(finding_id, str) and finding_id.strip():
+        return re.sub(r"[^a-z0-9]+", "-", finding_id.lower()).strip("-")
+    summary = str(finding.get("summary", "")).lower()
+    words = re.findall(r"[a-z0-9]+", summary)
+    return "-".join(words[:10]) or "unknown"
+
+
+def review_context_finding_entry(
+    *,
+    source: str,
+    source_kind: str,
+    reviewed_head: str | None,
+    validation_summary: str | None,
+    finding: dict[str, Any],
+) -> dict[str, Any]:
+    disposition = finding.get("disposition")
+    disposition_status = disposition.get("status") if isinstance(disposition, dict) else None
+    disposition_summary = disposition.get("summary") if isinstance(disposition, dict) else None
+    return {
+        "source": source,
+        "source_kind": source_kind,
+        "reviewed_head": reviewed_head,
+        "validation_summary": validation_summary,
+        "id": finding.get("id"),
+        "summary": finding.get("summary"),
+        "severity": finding.get("severity"),
+        "disposition": {
+            "status": disposition_status,
+            "summary": disposition_summary,
+        } if disposition_status or disposition_summary else None,
+        "repeat_key": repeated_blocker_key(finding),
+    }
+
+
+def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    recent_findings: list[dict[str, Any]] = []
+    review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
+    if review_record and not review_errors:
+        for finding in review_record.get("findings", []):
+            if isinstance(finding, dict):
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=review_path,
+                        source_kind="review_record",
+                        reviewed_head=review_record.get("reviewed_head"),
+                        validation_summary=review_record.get("reviewed_validation_summary"),
+                        finding=finding,
+                    )
+                )
+
+    runtime_history_root = context["target_root"] / ".loom/runtime/review" / context["item_id"]
+    if runtime_history_root.exists():
+        for findings_path in sorted(runtime_history_root.glob("*/normalized-findings.json")):
+            try:
+                payload = load_json_file(findings_path)
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+            raw_findings = payload.get("findings") if isinstance(payload, dict) else None
+            findings, errors = normalize_review_findings(raw_findings, relative=relative_to_root(findings_path, context["target_root"]))
+            if errors:
+                continue
+            metadata_path = findings_path.parent / "engine-metadata.json"
+            metadata: dict[str, Any] = {}
+            if metadata_path.exists():
+                try:
+                    loaded = load_json_file(metadata_path)
+                    if isinstance(loaded, dict):
+                        metadata = loaded
+                except (OSError, ValueError, json.JSONDecodeError):
+                    metadata = {}
+            for finding in findings:
+                recent_findings.append(
+                    review_context_finding_entry(
+                        source=relative_to_root(findings_path, context["target_root"]),
+                        source_kind="normalized_findings",
+                        reviewed_head=metadata.get("reviewed_head") if isinstance(metadata.get("reviewed_head"), str) else None,
+                        validation_summary=metadata.get("validation_summary") if isinstance(metadata.get("validation_summary"), str) else None,
+                        finding=finding,
+                    )
+                )
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for finding in recent_findings:
+        if finding.get("severity") == "block":
+            groups.setdefault(str(finding.get("repeat_key") or "unknown"), []).append(finding)
+    candidates = [
+        {
+            "repeat_key": key,
+            "count": len(entries),
+            "sources": [entry["source"] for entry in entries],
+            "summaries": [entry["summary"] for entry in entries if entry.get("summary")],
+            "recommended_action": "treat as a root-cause candidate before repeating another local patch",
+        }
+        for key, entries in sorted(groups.items())
+        if len(entries) >= 2
+    ]
+    return {
+        "schema_version": REVIEW_CONTEXT_PACK_SCHEMA,
+        "item_id": context["item_id"],
+        "review_path": review_path,
+        "current_head": git_head_sha(context["target_root"]) or "unknown-head",
+        "validation_summary": context["latest_validation_summary"],
+        "history_available": bool(recent_findings),
+        "history_policy": "not_applicable when no prior review record or normalized findings are available",
+        "recent_findings": recent_findings[-20:],
+        "repeated_blocker_signal": {
+            "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
+            "result": "present" if candidates else "absent",
+            "enforcement": "advisory",
+            "summary": (
+                "Repeated blocker candidates are present; reviewer should classify root-cause risk."
+                if candidates
+                else "No repeated blocker candidates detected in available review history."
+            ),
+            "candidates": candidates,
+        },
+    }
+
+
 def load_review_record(
     target_root: Path,
     item_id: str,
@@ -3285,14 +3408,18 @@ def run_default_review_engine(
     result_path = runtime_root / "engine-result.json"
     findings_path = runtime_root / "normalized-findings.json"
     metadata_path = runtime_root / "engine-metadata.json"
+    context_pack_path = runtime_root / "context-pack.json"
     scratch_dir = context["target_root"] / ".loom/runtime/tmp" / "review-engine" / context["item_id"]
+    context_pack = build_review_context_pack(context, review_path)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    write_json_file(context_pack_path, context_pack)
     prompt_text = build_default_review_prompt(
         context=context,
         build_payload=build_payload,
         runtime_fields=runtime_evidence_from_report(context["report"])[0],
         review_path=review_path,
+        context_pack=context_pack,
     )
-    runtime_root.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text, encoding="utf-8")
 
     effective_kind = review_kind or default_review_kind(context)
@@ -3319,6 +3446,7 @@ def run_default_review_engine(
                     "raw_result": relative_to_root(result_path, context["target_root"]),
                     "normalized_findings": relative_to_root(findings_path, context["target_root"]),
                     "metadata": relative_to_root(metadata_path, context["target_root"]),
+                    "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 },
             },
         }
@@ -3404,6 +3532,7 @@ def run_default_review_engine(
         "raw_result": relative_to_root(result_path, context["target_root"]),
         "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         "metadata": relative_to_root(metadata_path, context["target_root"]),
+        "context_pack": relative_to_root(context_pack_path, context["target_root"]),
     }
 
     if failure_reason is not None:
@@ -3413,6 +3542,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": failure_reason,
                 "summary": failure_detail,
                 "reviewed_head": reviewed_head,
@@ -3449,6 +3579,7 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "failure_reason": "schema_drift",
                 "summary": "normalized engine output did not satisfy Loom review schema",
                 "errors": normalization_errors,
@@ -3479,11 +3610,13 @@ def run_default_review_engine(
                 "engine": DEFAULT_REVIEW_ENGINE,
                 "adapter": DEFAULT_REVIEW_ADAPTER,
                 "profile": engine_profile,
+                "context_pack": relative_to_root(context_pack_path, context["target_root"]),
                 "result": "pass",
                 "reviewed_head": reviewed_head,
                 "decision": normalized_payload["decision"],
                 "summary": normalized_payload["summary"],
                 "kind": effective_kind,
+                "validation_summary": context["latest_validation_summary"],
             },
         )
     cleanup_scratch_tree(context["target_root"], scratch_dir)
@@ -3510,6 +3643,7 @@ def run_default_review_engine(
             "engine_adapter": DEFAULT_REVIEW_ADAPTER,
             "engine_evidence": relative_to_root(result_path, context["target_root"]),
             "engine_profile": engine_profile,
+            "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
         },
     }
@@ -4249,6 +4383,7 @@ def build_default_review_prompt(
     build_payload: dict[str, Any],
     runtime_fields: dict[str, dict[str, Any]],
     review_path: str,
+    context_pack: dict[str, Any],
 ) -> str:
     focus_paths = review_focus_paths(context)
     is_spec_review = review_path == default_spec_review_path(context["item_id"])
@@ -4263,6 +4398,23 @@ def build_default_review_prompt(
     path_lines = [f"- `{path}`" for path in focus_paths[:20]]
     if len(focus_paths) > 20:
         path_lines.append(f"- ... ({len(focus_paths) - 20} more paths omitted)")
+    recent_findings = context_pack.get("recent_findings") if isinstance(context_pack.get("recent_findings"), list) else []
+    recent_lines = [
+        f"- {entry.get('severity')}: {entry.get('summary')} (disposition={((entry.get('disposition') or {}).get('status') if isinstance(entry.get('disposition'), dict) else None) or 'none'}, source={entry.get('source')})"
+        for entry in recent_findings[:10]
+        if isinstance(entry, dict)
+    ]
+    if not recent_lines:
+        recent_lines = ["- not_applicable: no prior review findings were available."]
+    repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
+    repeated_lines = [
+        f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
+        for candidate in repeated_candidates[:10]
+        if isinstance(candidate, dict)
+    ]
+    if not repeated_lines:
+        repeated_lines = ["- absent: no repeated blocker candidate detected."]
     return "\n".join(
         [
             "你是 Loom 默认 formal reviewer。",
@@ -4302,6 +4454,16 @@ def build_default_review_prompt(
             "",
             "优先审查这些路径：",
             *path_lines,
+            "",
+            "Recent Review Context Pack：",
+            f"- Schema: {context_pack.get('schema_version')}",
+            f"- History Available: {context_pack.get('history_available')}",
+            f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
+            "Recent Findings:",
+            *recent_lines,
+            "Repeated Blocker Candidates:",
+            *repeated_lines,
+            "- 请将发现分类为 new、unresolved 或 repeated/root-cause candidate；不要在没有证据时把 repeat 自动升级成 hard gate。",
             "",
             "Findings 写作要求：",
             "- 每条 finding 必须包含 `id`、`summary`、`severity`、`rebuttal`、`disposition`。",


### PR DESCRIPTION
## Summary

- Adds `loom-review-context-pack/v1` review input evidence for `review run`.
- Projects recent findings, dispositions, reviewed heads, validation summaries, and source locators from review records and prior normalized findings.
- Adds advisory `loom-repeated-blocker-signal/v1` evidence for repeated block finding/root-cause candidates.
- Feeds context pack and repeated blocker guidance into the default review prompt.
- Exposes context pack evidence through engine evidence, engine metadata, and `review_record_input.context_pack`.
- Adds fixtures proving context pack presence and repeated blocker/root-cause candidate detection.
- Syncs generated skill/runtime surfaces, demo bootstrap generated files, shadow evidence, root WI-679 carriers, and installer version `0.1.79`.

## Validation

- `python3 -m py_compile src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py skills/shared/scripts/loom_flow.py skills/shared/scripts/loom_check.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/loom_check.py` (`checked 27 surfaces`)
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `npm run check:payload --prefix packages/loom-installer`
- `python3 tools/loom_status.py --target . --item WI-679`
- `python3 tools/loom_flow.py flow merge-ready --target . --item WI-679`
- `python3 .loom/bin/loom_flow.py adopt verify --target .`
- `make check` (`loom_check: OK`, `checked 27 surfaces`; demo bootstrap `write.touched: []`)
- `git status --short --ignored=matching .loom/runtime/attempts` shows only ignored `.loom/runtime/attempts/`

## Review / Governance Evidence

- `.loom/work-items/WI-679.md`
- `.loom/progress/WI-679.md`
- `.loom/status/current.md`
- `.loom/reviews/WI-679.spec.json`
- `.loom/reviews/WI-679.json`
- `/tmp/loom-status-679-final.json`
- `/tmp/loom-merge-ready-679-final.json`
- `/tmp/loom-adopt-verify-679-final.json`

Parent FR: #679
v0.8.0 parent: #531

Closes #680
Closes #681
Closes #682
Closes #683
