### PR TITLE
feat(harness): provider-neutral execution budget for status surface

### DIFF
--- a/docs/evidence/fixtures/execution-budget-fixtures.json
+++ b/docs/evidence/fixtures/execution-budget-fixtures.json
@@ -1,0 +1,105 @@
+{
+  "schema_version": "loom-execution-budget-fixtures/v1",
+  "fixtures": [
+    {
+      "name": "host-header-budget-present",
+      "description": "Budget from host header extraction remains provider-neutral. Unknown raw header fields are dropped.",
+      "input": {
+        "status": "present",
+        "enforcement": "advisory",
+        "summary": "read x-ratelimit-* headers from recent repository request",
+        "dimensions": [
+          {
+            "id": "requests",
+            "unit": "request",
+            "used": 142,
+            "limit": 5000,
+            "remaining": 4858,
+            "risk": "low",
+            "source": "github_host_headers",
+            "x-ratelimit-remaining": 4858,
+            "x-ratelimit-reset": 1736440000
+          },
+          {
+            "id": "tokens",
+            "unit": "token",
+            "used": 1200,
+            "limit": 12000,
+            "remaining": 10800,
+            "risk": "low",
+            "source": "github_host_headers",
+            "rateLimit": 12000
+          }
+        ],
+        "provenance": {
+          "source": "github_host",
+          "read_mode": "cached_non_merge"
+        },
+        "adapter_evidence_locator": "loom.checks.host.github.api.headers",
+        "x-ratelimit-limit": 12000
+      },
+      "expect": {
+        "status": "present",
+        "dimension_ids": ["requests", "tokens"],
+        "dimension_fields": ["id", "unit", "used", "limit", "remaining", "risk", "source"],
+        "forbidden_fields": [
+          "x-ratelimit-remaining",
+          "x-ratelimit-reset",
+          "rateLimit",
+          "x-ratelimit-limit"
+        ],
+        "enforcement": "advisory"
+      }
+    },
+    {
+      "name": "budget-missing-not-applicable",
+      "description": "Missing budget is allowed as advisory not_applicable.",
+      "input": null,
+      "expect": {
+        "status": "not_applicable",
+        "enforcement": "advisory",
+        "dimensions_count": 0,
+        "dimension_ids": []
+      }
+    },
+    {
+      "name": "vendor-dimensions-filtered",
+      "description": "Unknown vendor-specific dimension IDs and fields cannot enter Loom core budget output.",
+      "input": {
+        "status": "present",
+        "enforcement": "advisory",
+        "summary": "adapters should expose normalised dimensions only",
+        "dimensions": [
+          {
+            "id": "x-ratelimit-resource",
+            "limit": "core",
+            "used": 99,
+            "remaining": 1
+          },
+          {
+            "id": "time_window",
+            "unit": "minute",
+            "used": 60,
+            "limit": 60,
+            "remaining": 0,
+            "risk": "high",
+            "source": "github_host"
+          }
+        ],
+        "provenance": {
+          "source": "github_host",
+          "read_mode": "cached_non_merge"
+        },
+        "adapter_evidence_locator": "loom.adapter.github.rate-limit"
+      },
+      "expect": {
+        "status": "present",
+        "dimension_ids": ["time_window"],
+        "dimension_fields": ["id", "unit", "used", "limit", "remaining", "risk", "source"],
+        "forbidden_fields": [
+          "x-ratelimit-resource"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/methodology/harness/host-api-budget.md
+++ b/docs/methodology/harness/host-api-budget.md
@@ -2,7 +2,35 @@
 
 Loom 的宿主读取必须有明确预算、快照与降级语义。
 
-默认规则：
+`github_control_plane.api_snapshot` 的 `budget` 字段必须使用 `loom-execution-budget/v1`，且不得直接暴露供应商专属字段名。
+
+## execution budget Contract
+
+固定字段：
+
+- `schema_version: loom-execution-budget/v1`
+- `status`
+- `enforcement`
+- `summary`
+- `dimensions`
+- `provenance`
+- `adapter_evidence_locator`
+
+其中：
+
+- `status` 为以下之一：
+  - `present`
+  - `not_applicable`
+  - `unavailable`
+- `enforcement` 固定为 `advisory`
+- `summary` 必须说明预算输出是否来自 host header、adapter evidence，或说明不可用原因
+- `dimensions` 每项是标准化维度 `unit/used/limit/remaining/risk/source` 集合中的元素
+  - `id` 只允许：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 不允许出现供应商原始字段名（例如 `x-ratelimit-...`、`rateLimit` 等）
+- `provenance` 记录读取来源（host header 或 adapter evidence）
+- `adapter_evidence_locator` 只保留适配器 evidence locator，不承载原始供应商字段
+
+读取规则（与 `github_control_plane.api_snapshot` 一致）：
 
 - 非合并展示、status、upgrade-plan、precheck 使用 `cached_non_merge`。
 - merge-ready / controlled merge 所需宿主事实使用 `uncached_live_gate`。
@@ -11,27 +39,7 @@ Loom 的宿主读取必须有明确预算、快照与降级语义。
 - 合并前 live recheck 失败必须 fail-closed。
 - REST 优先；GraphQL 只在 REST 无法表达对象关系时使用，并且必须声明 scope、cost 与 fallback。
 - 不在热路径使用 search endpoint 或 polling。
-- 不为了查看额度额外调用 `/rate_limit`；只消费自然响应中的 `x-ratelimit-*` header。
+- 不为了查看额度额外调用 `/rate_limit`；只消费自然响应中的 header 信息（当可读到时）。
 - GitHub Actions 默认按 `GITHUB_TOKEN` 每 repo 每小时 1,000 requests 级别预算设计。
 
-## Snapshot Contract
-
-`github_control_plane.api_snapshot` 使用：
-
-- `schema_version: loom-host-api-snapshot/v1`
-- `read_mode: cached_non_merge | uncached_live_gate`
-- `verification_status: verified | unverified | stale | host_unavailable`
-- `fallback_status`
-- `cache_scope`
-- `requests`
-- `errors`
-- `budget`
-
-读取失败不得投影为：
-
-- empty required checks
-- disabled branch protection
-- empty rulesets
-- host enforcement pass
-
-缺失或失败必须留在 `errors` / `missing_inputs` / `host_enforcement.verification_status` 中，由调用路径决定 advisory 降级或 merge fail-closed。
+读取失败必须留在 `errors` / `missing_inputs` / `host_enforcement.verification_status` 中，由调用路径决定 advisory 降级或 merge fail-closed。

--- a/docs/methodology/harness/status-surface-contract.md
+++ b/docs/methodology/harness/status-surface-contract.md
@@ -151,6 +151,21 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留
+`unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/docs/methodology/harness/status-surface.md
+++ b/docs/methodology/harness/status-surface.md
@@ -41,6 +41,9 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -104,6 +107,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+- execution budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 
 ## 4. `Runtime Evidence`
 

--- a/examples/new-project/.loom/bin/governance_surface.py
+++ b/examples/new-project/.loom/bin/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/examples/new-project/.loom/bin/loom_status.py
+++ b/examples/new-project/.loom/bin/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -125,7 +125,7 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "15eebdff23b1e670b131252f7271b5bd23f57a729a0c8e155c2018e76fe19ceb"
+      "sha256": "c407fa9574560bfa01e8c14bab57f16f025d9f6d5a53b2b136bb52b229481ed3"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -137,7 +137,7 @@
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "fea8f59d4d0934ce60b7c5bf8592528c457093df98f30ceab278790188fbae02"
+      "sha256": "4dabb17354fd66b4eef13093dae231fb461b3bc51e30ba4bbf44397b07337331"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a4fd2deb84f08c5698e1608bb03c2b64a435a4a098cc4442bd0b4a281e5c0f55"
+      "sha256": "360aa049c3549928ba96f50ac37bc29de190eca157fa214c68bdafd71474e957"
     },
     {
       "path": "AGENTS.md",
@@ -416,16 +416,15 @@
         ],
         "errors": [],
         "budget": {
-          "schema_version": "loom-host-api-budget/v1",
-          "default_non_merge_read_mode": "cached_non_merge",
-          "merge_gate_read_mode": "uncached_live_gate",
-          "cache_scope": "process",
-          "rest_first": true,
-          "graphql_allowed_when": "REST cannot express the required relationship",
-          "search_endpoint": "not_in_hot_path",
-          "polling": "not_in_hot_path",
-          "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-          "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits"
+          "schema_version": "loom-execution-budget/v1",
+          "status": "not_applicable",
+          "enforcement": "advisory",
+          "summary": "execution budget is not collected for this invocation.",
+          "dimensions": [],
+          "provenance": {
+            "source": "github_host"
+          },
+          "adapter_evidence_locator": ""
         }
       }
     },

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -47,7 +47,7 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "15eebdff23b1e670b131252f7271b5bd23f57a729a0c8e155c2018e76fe19ceb"
+      "sha256": "c407fa9574560bfa01e8c14bab57f16f025d9f6d5a53b2b136bb52b229481ed3"
     },
     {
       "path": ".loom/bin/loom_flow.py",
@@ -59,7 +59,7 @@
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "fea8f59d4d0934ce60b7c5bf8592528c457093df98f30ceab278790188fbae02"
+      "sha256": "4dabb17354fd66b4eef13093dae231fb461b3bc51e30ba4bbf44397b07337331"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "a4fd2deb84f08c5698e1608bb03c2b64a435a4a098cc4442bd0b4a281e5c0f55"
+      "sha256": "360aa049c3549928ba96f50ac37bc29de190eca157fa214c68bdafd71474e957"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.82",
+      "version": "0.1.83",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.82",
+  "version": "0.1.83",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-build/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-init/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-review/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-api-budget.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/shared/references/harness/host-api-budget.md
+++ b/skills/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/skills/shared/references/harness/status-surface-contract.md
+++ b/skills/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/shared/references/harness/status-surface.md
+++ b/skills/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/src/skills/shared/references/harness/host-api-budget.md
+++ b/src/skills/shared/references/harness/host-api-budget.md
@@ -4,8 +4,11 @@ Canonical contract: `docs/methodology/harness/host-api-budget.md`.
 
 Installed summary:
 
-- Non-merge reads use `cached_non_merge`.
-- Merge gate reads use `uncached_live_gate` and fail closed on missing live host facts.
+- `github_control_plane.api_snapshot.budget` uses `loom-execution-budget/v1`.
+- Required budget fields: `schema_version` / `status` / `enforcement` / `summary` / `dimensions` / `provenance` / `adapter_evidence_locator`.
+- `dimensions` must use the fixed IDs `turns` / `tokens` / `requests` / `retries` / `time_window`; provider-specific field names must not be carried into Loom core schema.
+- Missing budget output is allowed as `status: not_applicable` or `status: unavailable` and must remain `enforcement: advisory`.
+- Non-merge reads use `cached_non_merge`; merge reads use `uncached_live_gate`.
 - REST is preferred; GraphQL requires explicit scope, cost, and fallback.
 - Search endpoint and polling are not hot-path mechanisms.
 - Remote read failures must surface as `unverified`, `stale`, or `host_unavailable`.

--- a/src/skills/shared/references/harness/status-surface-contract.md
+++ b/src/skills/shared/references/harness/status-surface-contract.md
@@ -151,6 +151,20 @@
 
 该字段组只消费 `.loom/companion/repo-interface.json` 的 `policy_locators` 与只读 policy declaration，不申请权限、不修改 sandbox、不写 host result。
 
+### 3.7.1 `execution_budget`
+
+状态面必须展示 provider-neutral 的执行预算消费路径，不得把预算字段作为阻断 gate。
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`: 预算可读性与来源说明
+- `dimensions`: 标准化 budget dimensions
+- `provenance`: 来源说明
+- `adapter_evidence_locator`: 适配器 evidence locator
+
+`dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/src/skills/shared/references/harness/status-surface.md
+++ b/src/skills/shared/references/harness/status-surface.md
@@ -102,8 +102,25 @@ Approval / sandbox policy 也只能派生读取：
 - BDD 外环场景的证据覆盖状态
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
+- execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
+
+## 4. execution_budget
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
 
 ## 4. `Runtime Evidence`
 

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -109,18 +109,91 @@ GATE_STARTER_ALIASES = {
         "summary": "Audit closeout drift without mutating host state.",
     },
 }
-HOST_API_BUDGET_CONTRACT = {
-    "schema_version": "loom-host-api-budget/v1",
-    "default_non_merge_read_mode": "cached_non_merge",
-    "merge_gate_read_mode": "uncached_live_gate",
-    "cache_scope": "process",
-    "rest_first": True,
-    "graphql_allowed_when": "REST cannot express the required relationship",
-    "search_endpoint": "not_in_hot_path",
-    "polling": "not_in_hot_path",
-    "rate_limit_policy": "consume x-ratelimit-* headers from natural responses when available; do not call /rate_limit just to inspect budget",
-    "github_actions_budget": "design for GITHUB_TOKEN per-repository hourly request limits",
-}
+LOOM_EXECUTION_BUDGET_SCHEMA = "loom-execution-budget/v1"
+LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
+LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
+LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+
+
+def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
+    if not isinstance(raw_dimensions, list):
+        return []
+    dimensions: list[dict[str, Any]] = []
+    for candidate in raw_dimensions:
+        if not isinstance(candidate, dict):
+            continue
+        budget_id = candidate.get("id")
+        if not isinstance(budget_id, str) or budget_id not in LOOM_EXECUTION_BUDGET_DIMENSION_IDS:
+            continue
+        dimension: dict[str, Any] = {"id": budget_id}
+        for field in LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS:
+            if field == "id":
+                continue
+            if field in candidate:
+                dimension[field] = candidate[field]
+        dimensions.append(dimension)
+    return dimensions
+
+
+def execution_budget_payload(
+    *,
+    status: str,
+    summary: str,
+    dimensions: list[dict[str, Any]] | None = None,
+    provenance: dict[str, Any] | None = None,
+    adapter_evidence_locator: str | None = None,
+    enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+) -> dict[str, Any]:
+    normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
+        "status": normalized_status,
+        "enforcement": enforcement,
+        "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
+        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "provenance": provenance or {"source": "github_host"},
+        "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
+    }
+
+
+def normalize_execution_budget_payload(
+    raw: object,
+    *,
+    fallback_status: str = "not_applicable",
+    fallback_summary: str = "execution budget is not currently available",
+    fallback_locator: str = "",
+    fallback_provenance: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return execution_budget_payload(
+            status=fallback_status,
+            summary=fallback_summary,
+            dimensions=[],
+            provenance=fallback_provenance or {"source": "github_host"},
+            adapter_evidence_locator=fallback_locator,
+        )
+
+    status = raw.get("status")
+    if not isinstance(status, str):
+        status = fallback_status
+    summary = raw.get("summary")
+    dimensions = normalize_execution_budget_dimensions(raw.get("dimensions"))
+    provenance = raw.get("provenance")
+    adapter_evidence_locator = raw.get("adapter_evidence_locator")
+
+    return execution_budget_payload(
+        status=status,
+        summary=summary if isinstance(summary, str) else fallback_summary,
+        dimensions=dimensions,
+        provenance=provenance if isinstance(provenance, dict) else fallback_provenance or {"source": "github_host"},
+        adapter_evidence_locator=str(adapter_evidence_locator) if isinstance(adapter_evidence_locator, str) else fallback_locator,
+        enforcement=(
+            raw.get("enforcement")
+            if isinstance(raw.get("enforcement"), str) and raw.get("enforcement") == LOOM_EXECUTION_BUDGET_ENFORCEMENT
+            else LOOM_EXECUTION_BUDGET_ENFORCEMENT
+        ),
+    )
 
 
 def local_worker_backend_contract() -> dict[str, object]:
@@ -2065,8 +2138,24 @@ def host_api_snapshot(
     requests: list[dict[str, Any]],
     errors: list[str],
     required_live: bool = False,
+    budget: object | None = None,
 ) -> dict[str, Any]:
     verification_status = "verified" if not errors else "unverified"
+    if errors:
+        budget_payload = execution_budget_payload(
+            status="unavailable",
+            summary="; ".join(errors),
+            provenance={"source": "github_control_plane", "error_count": len(errors)},
+            adapter_evidence_locator="",
+            enforcement=LOOM_EXECUTION_BUDGET_ENFORCEMENT,
+        )
+    else:
+        budget_payload = normalize_execution_budget_payload(
+            budget,
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not collected for this invocation.",
+            fallback_locator="",
+        )
     return {
         "schema_version": "loom-host-api-snapshot/v1",
         "read_mode": "uncached_live_gate" if required_live else "cached_non_merge",
@@ -2075,7 +2164,7 @@ def host_api_snapshot(
         "cache_scope": "none" if required_live else "process",
         "requests": requests,
         "errors": errors,
-        "budget": HOST_API_BUDGET_CONTRACT,
+        "budget": budget_payload,
     }
 
 

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -277,6 +277,11 @@ EVENT_EVIDENCE_FORBIDDEN_AUTHORED_FIELDS = {
     "recovery",
     "authored_truth",
 }
+EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
+EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
+EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
+EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3805,6 +3810,38 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             if payload.get("command") != "status":
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
+            execution_budget = payload.get("execution_budget")
+            if not isinstance(execution_budget, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
+            else:
+                missing_inputs = payload.get("missing_inputs")
+                if "execution_budget" in missing_inputs if isinstance(missing_inputs, list) else False:
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` must not surface `execution_budget` as missing input",
+                        )
+                    )
+                budget_missing = execution_budget.get("status") in {"not_applicable", "unavailable"}
+                if budget_missing and execution_budget.get("enforcement") != "advisory":
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` missing budget must remain advisory",
+                        )
+                    )
+                governance_missing = governance_status.get("missing_inputs") if isinstance(governance_status, dict) else []
+                if (
+                    budget_missing
+                    and isinstance(governance_missing, list)
+                    and any(str(item).startswith("execution_budget") for item in governance_missing)
+                ):
+                    failures.append(
+                        Failure(
+                            "daily-execution-cli",
+                            "`loom_status` should not block merge-ready gate on advisory execution budget status",
+                        )
+                    )
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10370,6 +10407,177 @@ def check_deferred_roadmap_tree_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-budget-fixtures.json"
+    category = "execution-budget"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-budget-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must be an object"))
+        return failures
+
+    schema_version = fixture_payload.get("schema_version")
+    if schema_version != EXECUTION_BUDGET_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-budget-fixtures.json` schema_version must be `{EXECUTION_BUDGET_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-budget-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-budget-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` must expose fixture `expect` as an object"))
+            continue
+
+        payload = governance_surface_module.normalize_execution_budget_payload(
+            fixture.get("input"),
+            fallback_status="not_applicable",
+            fallback_summary="execution budget is not currently available",
+            fallback_locator="",
+        )
+
+        if not isinstance(payload, dict):
+            failures.append(Failure(category, f"`{context}` budget payload must normalize to object"))
+            continue
+
+        if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_SCHEMA}`",
+                )
+            )
+        if set(payload.keys()) - EXECUTION_BUDGET_STABLE_FIELDS:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` normalized budget payload must stay in stable field vocabulary",
+                )
+            )
+
+        status = payload.get("status")
+        if status not in EXECUTION_BUDGET_STATUS:
+            failures.append(Failure(category, f"`{context}` normalized budget status must be stable"))
+        expected_status = expect.get("status")
+        if expected_status is not None and status != expected_status:
+            failures.append(Failure(category, f"`{context}` normalized budget status `{status}` != expected `{expected_status}`"))
+
+        expected_enforcement = expect.get("enforcement", "advisory")
+        if payload.get("enforcement") != expected_enforcement:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` budget enforcement `{payload.get('enforcement')}` != expected `{expected_enforcement}`",
+                )
+            )
+
+        dimensions = payload.get("dimensions")
+        if not isinstance(dimensions, list):
+            failures.append(Failure(category, f"`{context}` budget dimensions must stay a list"))
+            dimensions = []
+
+        expected_dimension_ids = expect.get("dimension_ids")
+        if isinstance(expected_dimension_ids, list):
+            actual_ids = [dimension.get("id") for dimension in dimensions if isinstance(dimension, dict)]
+            if actual_ids != expected_dimension_ids:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` budget dimension ids {actual_ids} != expected {expected_dimension_ids}",
+                    )
+                )
+
+        expected_dimension_fields = expect.get("dimension_fields")
+        if isinstance(expected_dimension_fields, list):
+            field_set = set(str(field) for field in expected_dimension_fields)
+            if not field_set.issubset(EXECUTION_BUDGET_DIMENSION_FIELDS):
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` expect `dimension_fields` contains non-stable budget dimension fields",
+                    )
+                )
+            for position, dimension in enumerate(dimensions):
+                if not isinstance(dimension, dict):
+                    failures.append(Failure(category, f"`{context}` budget dimension #{position} must be an object"))
+                    continue
+                budget_id = dimension.get("id")
+                if not isinstance(budget_id, str) or budget_id not in EXECUTION_BUDGET_DIMENSION_IDS:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension #{position} id `{budget_id}` must stay in stable vocabulary",
+                        )
+                    )
+                extra_fields = set(dimension.keys()) - set(expected_dimension_fields)
+                if extra_fields:
+                    failures.append(
+                        Failure(
+                            category,
+                            f"`{context}` budget dimension {budget_id} has unsupported fields: {sorted(extra_fields)}",
+                        )
+                    )
+
+        expected_forbidden_fields = expect.get("forbidden_fields")
+        if isinstance(expected_forbidden_fields, list):
+            forbidden = {str(field) for field in expected_forbidden_fields}
+            for field in forbidden:
+                for key in payload.keys():
+                    if key == field:
+                        failures.append(Failure(category, f"`{context}` budget payload must not contain forbidden field `{field}`"))
+                for dimension in dimensions:
+                    if isinstance(dimension, dict) and field in dimension:
+                        failures.append(
+                            Failure(
+                                category,
+                                f"`{context}` budget dimension `{dimension.get('id')}` must not contain forbidden field `{field}`",
+                            )
+                        )
+
+        expected_count = expect.get("dimensions_count")
+        if isinstance(expected_count, int) and isinstance(dimensions, list) and len(dimensions) != expected_count:
+            failures.append(Failure(category, f"`{context}` budget dimensions count {len(dimensions)} != expected {expected_count}"))
+
+        if status in {"not_applicable", "unavailable"} and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` missing budget should keep advisory enforcement"))
+
+        if status in {"not_applicable", "unavailable"} and isinstance(payload.get("dimensions"), list):
+            if payload["dimensions"]:
+                failures.append(
+                    Failure(
+                        category,
+                        f"`{context}` missing budget should not expose dimensions",
+                    )
+                )
+
+        provenance = payload.get("provenance")
+        if not isinstance(provenance, dict):
+            failures.append(Failure(category, f"`{context}` budget provenance must be an object"))
+
+        locator = payload.get("adapter_evidence_locator")
+        if locator is not None and not isinstance(locator, str):
+            failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10609,6 +10817,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
+    failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))
@@ -10616,7 +10825,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 28
+    categories_checked = 29
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/scripts/loom_status.py
+++ b/src/skills/shared/scripts/loom_status.py
@@ -433,6 +433,21 @@ def main(argv: list[str]) -> int:
     )
     ci_check_presence = github_control_plane.get("ci_check_presence") if isinstance(github_control_plane, dict) else None
     host_enforcement = github_control_plane.get("host_enforcement") if isinstance(github_control_plane, dict) else None
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    if not isinstance(execution_budget, dict):
+        execution_budget = {
+            "schema_version": "loom-execution-budget/v1",
+            "status": "not_applicable",
+            "enforcement": "advisory",
+            "summary": "execution budget is not available for this execution path",
+            "dimensions": [],
+            "provenance": {"source": "github_control_plane"},
+            "adapter_evidence_locator": "",
+        }
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -511,6 +526,7 @@ def main(argv: list[str]) -> int:
             "latest_execution_attempt": latest_execution_attempt,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
+            "execution_budget": execution_budget,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],


### PR DESCRIPTION
## Summary
Freeze the provider-neutral execution budget contract and wire it into Loom status consumption for the first #581 execution batch.

This PR covers:
- #582 docs contract for `loom-execution-budget/v1`
- #583 status surface integration (`execution_budget` summary path)
- #584 fixtures + loom_check regression coverage

## Scope
- Contract docs in harness methodology + mirrored references
- Budget normalization helpers in governance surface
- `loom_status` top-level `execution_budget` output (advisory, non-blocking)
- Budget fixtures and contract assertions in `loom_check`
- Regenerated shared runtime/install surfaces and example bootstrap artifacts

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_check.py`
- `python3 tools/loom_status.py --target examples/new-project --item INIT-0001`
- `make check`

## Binding
- FR: #581
- Phase: #532
