### PR TITLE
feat(harness): add execution failure taxonomy

### DIFF
--- a/docs/evidence/fixtures/execution-failure-fixtures.json
+++ b/docs/evidence/fixtures/execution-failure-fixtures.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "loom-execution-failure-fixtures/v1",
+  "fixtures": [
+    {
+      "name": "timeout-inferred-from-engine-message",
+      "input": {
+        "result": "block",
+        "summary": "default review engine failed closed before a formal review record could be authored.",
+        "missing_inputs": [
+          "default review engine timed out after 900s"
+        ],
+        "fallback_to": "build"
+      },
+      "expect": {
+        "classification": "timeout",
+        "fallback_to": "build",
+        "summary_contains": "timed out"
+      }
+    },
+    {
+      "name": "stall-explicit",
+      "input": {
+        "result": "fallback",
+        "summary": "execution paused until host evidence can be refreshed.",
+        "missing_inputs": [
+          "host adapter stalled while waiting for refreshed state"
+        ],
+        "fallback_to": "admission",
+        "execution_failure": {
+          "classification": "stall",
+          "summary": "host adapter stalled while waiting for refreshed state",
+          "fallback_to": "admission"
+        }
+      },
+      "expect": {
+        "classification": "stall",
+        "fallback_to": "admission",
+        "summary_contains": "stalled"
+      }
+    },
+    {
+      "name": "retry-exhaustion-explicit",
+      "input": {
+        "result": "block",
+        "summary": "execution exhausted the declared retry budget.",
+        "missing_inputs": [
+          "retry exhaustion after three read attempts"
+        ],
+        "fallback_to": "build",
+        "execution_failure": {
+          "classification": "retry_exhaustion",
+          "summary": "retry exhaustion after three read attempts",
+          "fallback_to": "build"
+        }
+      },
+      "expect": {
+        "classification": "retry_exhaustion",
+        "fallback_to": "build",
+        "summary_contains": "retry exhaustion"
+      }
+    }
+  ]
+}

--- a/docs/methodology/harness/execution-attempt.md
+++ b/docs/methodology/harness/execution-attempt.md
@@ -16,7 +16,9 @@ Each envelope uses `schema_version: loom-execution-attempt/v1` and includes:
 - `created_at`: UTC timestamp for evidence ordering.
 - `head_sha`: git HEAD at the time the attempt was emitted, or `unknown-head`.
 - `workspace`: read-only binding summary with `entry` and resolved `path`.
-- `failure`: `{category, missing_inputs, fallback_to}`. `category` is `none`, `runtime_state`, `fact_chain`, `state_check`, `runtime_evidence`, `checkpoint`, `review`, `repo_specific`, `recovery_readiness`, or `unknown`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
+  `category` is `none`, `runtime_state`, `fact_chain`, `state_check`, `runtime_evidence`, `checkpoint`, `review`, `repo_specific`, `recovery_readiness`, or `unknown`.
+  `execution_classification` is `none`, `stall`, `timeout`, `retry_exhaustion`, or `unknown`.
 - `evidence`: `{locator, status}` pointing to the persisted attempt evidence. Missing or unreadable evidence must be reported as `missing`; it must not be treated as fresh.
 
 ## Persistence And Freshness
@@ -33,5 +35,6 @@ Stale attempts may be shown as stale evidence, but status must not present them 
 ## Provenance Rules
 
 - Attempts can summarize command results, steps, failures, fallback targets, and evidence locators.
+- Attempts may classify execution failures such as `stall`, `timeout`, or `retry_exhaustion`, but they do not create a scheduler state machine and do not authorize automatic retry.
 - Attempts can reference authored carriers by locator but must not duplicate their authored progress values.
 - Attempts are append-only runtime evidence for observability. They do not advance checkpoints, close Work Items, change review decisions, or satisfy merge-ready by themselves.

--- a/docs/methodology/harness/governance-failure-taxonomy.md
+++ b/docs/methodology/harness/governance-failure-taxonomy.md
@@ -190,7 +190,27 @@ closeout 阶段发现的控制面对齐漂移。
 
 状态面可以汇总，但不得把 taxonomy 压扁成单一字符串，例如“有点问题”或“需要处理”。
 
-## 8. 非目标
+## 8. Execution Failure Evidence
+
+除顶层 taxonomy 外，Loom 允许在 runtime evidence 中记录最近一次执行失败分类，用于 status、recovery 与 review 的风险输入。
+
+固定词表：
+
+- `stall`
+  - 执行面停滞、无进展或长时间等待外部宿主/工具返回
+- `timeout`
+  - 执行面在明确时间窗口内 fail closed
+- `retry_exhaustion`
+  - 尝试链已经耗尽，但 Loom 只记录证据，不接管 scheduler
+
+边界规则：
+
+- 这些分类不是新的顶层 gate taxonomy
+- 这些分类不替代 `stale` / `drift` / `gate_failure`
+- 这些分类可以携带 `fallback_to`，但 fallback target 只能指向 Loom 内部 checkpoint / flow / repair 入口
+- 这些分类不得声明 `Claimed`、`Running`、`RetryQueued` 或其他 scheduler state
+
+## 9. 非目标
 
 - 不把宿主 API 的原始错误码直接提升为 Loom taxonomy
 - 不为每个脚本单独维护失败枚举

--- a/docs/methodology/harness/status-surface-contract.md
+++ b/docs/methodology/harness/status-surface-contract.md
@@ -166,6 +166,19 @@
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留
 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+状态面可以展示最近一次 `execution_attempt` 的执行失败分类，但该字段组只读 runtime evidence，不得把执行失败直接升级成 merge gate。
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`: 最近失败分类或 freshness 说明
+- `fallback_to`: 若最近 attempt 已给出 fallback target，则原样暴露
+- `provenance`: 指向 `latest_execution_attempt` locator 与 freshness
+
+`execution_failure` 只作为 status / recovery / review 的风险输入，不声明 scheduler state，不触发自动 retry，也不单独决定 `pass | block`。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/docs/methodology/harness/status-surface.md
+++ b/docs/methodology/harness/status-surface.md
@@ -108,6 +108,7 @@ Approval / sandbox policy 也只能派生读取：
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 - execution budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（`stall` / `timeout` / `retry_exhaustion` 只作为风险输入）
 
 ## 4. `Runtime Evidence`
 
@@ -181,6 +182,19 @@ Approval / sandbox policy 也只能派生读取：
 - stale attempt 可以展示 `attempt_id`、`result` 与 locator，但必须标为 `freshness: stale`
 - missing 或 unreadable attempt evidence 必须标为 `missing` 或 `invalid`，不得用 flow 输出里的摘要补写第二真相
 - attempt 的 `result` 不等于当前 gate 通过；gate 仍消费 Work Item、recovery、review、merge-ready 与 closeout 主载体
+
+## 6.1 Execution Failure
+
+状态面可以从最近一次 fresh `execution_attempt` 派生 `execution_failure`：
+
+- `stall`
+  - 表示执行面停滞、无进展或等待外部宿主响应超出预期
+- `timeout`
+  - 表示执行面在明确时间窗口内失败关闭
+- `retry_exhaustion`
+  - 表示尝试链已经耗尽，但 Loom 只记录证据，不接管调度
+
+若最近 attempt 已 stale，`execution_failure.status` 必须显示 `stale`；若没有可读 attempt evidence，则显示 `missing` 或 `invalid`。该字段组不创建 scheduler state，不单独决定 merge gate。
 
 ## 7. gate 可消费判定
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.83",
+      "version": "0.1.84",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-build/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-build/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-init/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-init/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-review/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/shared/references/harness/execution-attempt.md
+++ b/skills/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/skills/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/skills/shared/references/harness/status-surface-contract.md
+++ b/skills/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/shared/references/harness/status-surface.md
+++ b/skills/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/src/skills/shared/references/harness/execution-attempt.md
+++ b/src/skills/shared/references/harness/execution-attempt.md
@@ -15,7 +15,9 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 - `created_at`: UTC timestamp.
 - `head_sha`: current git HEAD, or `unknown-head`.
 - `workspace`: read-only `{entry, path}`.
-- `failure`: `{category, missing_inputs, fallback_to}`.
+- `failure`: `{category, execution_classification, execution_summary, missing_inputs, fallback_to}`.
 - `evidence`: `{locator, status}`.
 
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
+
+`failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.

--- a/src/skills/shared/references/harness/governance-failure-taxonomy.md
+++ b/src/skills/shared/references/harness/governance-failure-taxonomy.md
@@ -119,6 +119,16 @@ closeout 阶段发现的控制面对齐漂移。
 
 宿主 merge 控制面未达线。
 
+## 6. Execution Failure Evidence
+
+Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为 status / recovery / review 风险输入。
+
+- `stall`
+- `timeout`
+- `retry_exhaustion`
+
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+
 典型例子：
 
 - PR 仍是 draft

--- a/src/skills/shared/references/harness/status-surface-contract.md
+++ b/src/skills/shared/references/harness/status-surface-contract.md
@@ -165,6 +165,17 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
+### 3.7.2 `execution_failure`
+
+- `schema_version`: `loom-execution-failure/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `classification`: `none` / `stall` / `timeout` / `retry_exhaustion` / `unknown`
+- `summary`
+- `fallback_to`
+- `provenance`
+
+该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/src/skills/shared/references/harness/status-surface.md
+++ b/src/skills/shared/references/harness/status-surface.md
@@ -103,6 +103,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- 最近 execution failure 分类（只作风险输入）
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -121,6 +122,10 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+## 4.1 execution_failure
+
+状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
 
 ## 4. `Runtime Evidence`
 

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -282,6 +282,7 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2313,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3816,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3848,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10593,71 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10725,40 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10818,6 +10932,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -155,6 +155,15 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1762,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1852,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1896,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1927,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2019,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2105,77 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
     }
 
 

--- a/src/skills/shared/scripts/loom_status.py
+++ b/src/skills/shared/scripts/loom_status.py
@@ -16,6 +16,7 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
     load_context,
     report_blocking_failures,
@@ -490,6 +491,7 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +526,7 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,


### PR DESCRIPTION
## Summary
Freeze the execution failure taxonomy and expose it through the shared execution-attempt and status surfaces for the `#585` batch.

This PR covers:
- #586 docs contract for execution failure evidence and fallback boundaries
- #587 execution-attempt/status runtime support for `stall`, `timeout`, and `retry_exhaustion`
- #588 fixtures and loom_check regression coverage

## Scope
- Harness docs + installed references
- `execution_attempt` envelope execution failure classification
- `loom_status` top-level `execution_failure` summary path
- Failure fixtures and `loom_check` contract assertions
- Regenerated shared runtime/install surfaces and installer package version bump to `0.1.84`

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py check`
- `npm test` (in `packages/loom-installer`)
- `npm pack --dry-run` (in `packages/loom-installer`)
- `python3 tools/loom_status.py --target examples/new-project --item INIT-0001`

## Binding
- Work Items: #586, #587, #588
- FR: #585
- Phase: #532
