### PR TITLE
feat(harness): add retry evidence boundary

### DIFF
--- a/docs/evidence/fixtures/retry-evidence-fixtures.json
+++ b/docs/evidence/fixtures/retry-evidence-fixtures.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "loom-retry-evidence-fixtures/v1",
+  "fixtures": [
+    {
+      "name": "current-head-timeout-chain",
+      "freshness": "fresh",
+      "latest_index": 2,
+      "attempts": [
+        {
+          "result": "fallback",
+          "failure": {
+            "category": "review",
+            "execution_classification": "stall",
+            "execution_summary": "host adapter stalled while waiting for refreshed state",
+            "missing_inputs": [
+              "host adapter stalled while waiting for refreshed state"
+            ],
+            "fallback_to": "build"
+          }
+        },
+        {
+          "result": "block",
+          "failure": {
+            "category": "review",
+            "execution_classification": "timeout",
+            "execution_summary": "default review engine timed out after 900s",
+            "missing_inputs": [
+              "default review engine timed out after 900s"
+            ],
+            "fallback_to": "build"
+          }
+        }
+      ],
+      "expect": {
+        "status": "present",
+        "attempt_count": 2,
+        "retry_count": 1,
+        "latest_failure_classification": "timeout",
+        "exhausted": false,
+        "stale_attempt_count": 0
+      }
+    },
+    {
+      "name": "retry-exhaustion-chain",
+      "freshness": "fresh",
+      "latest_index": 3,
+      "attempts": [
+        {
+          "result": "fallback",
+          "failure": {
+            "category": "review",
+            "execution_classification": "stall",
+            "execution_summary": "host adapter stalled while waiting for refreshed state",
+            "missing_inputs": [
+              "host adapter stalled while waiting for refreshed state"
+            ],
+            "fallback_to": "build"
+          }
+        },
+        {
+          "result": "fallback",
+          "failure": {
+            "category": "review",
+            "execution_classification": "timeout",
+            "execution_summary": "default review engine timed out after 900s",
+            "missing_inputs": [
+              "default review engine timed out after 900s"
+            ],
+            "fallback_to": "build"
+          }
+        },
+        {
+          "result": "block",
+          "failure": {
+            "category": "review",
+            "execution_classification": "retry_exhaustion",
+            "execution_summary": "retry exhaustion after three read attempts",
+            "missing_inputs": [
+              "retry exhaustion after three read attempts"
+            ],
+            "fallback_to": "build"
+          }
+        }
+      ],
+      "expect": {
+        "status": "present",
+        "attempt_count": 3,
+        "retry_count": 2,
+        "latest_failure_classification": "retry_exhaustion",
+        "exhausted": true,
+        "stale_attempt_count": 0
+      }
+    },
+    {
+      "name": "stale-chain",
+      "freshness": "stale",
+      "latest_index": 1,
+      "attempts": [
+        {
+          "result": "block",
+          "failure": {
+            "category": "review",
+            "execution_classification": "timeout",
+            "execution_summary": "default review engine timed out after 900s",
+            "missing_inputs": [
+              "default review engine timed out after 900s"
+            ],
+            "fallback_to": "build"
+          }
+        }
+      ],
+      "expect": {
+        "status": "stale",
+        "attempt_count": 0,
+        "retry_count": 0,
+        "latest_failure_classification": "timeout",
+        "exhausted": false,
+        "stale_attempt_count": 1
+      }
+    }
+  ]
+}

--- a/docs/methodology/harness/execution-attempt.md
+++ b/docs/methodology/harness/execution-attempt.md
@@ -36,5 +36,6 @@ Stale attempts may be shown as stale evidence, but status must not present them 
 
 - Attempts can summarize command results, steps, failures, fallback targets, and evidence locators.
 - Attempts may classify execution failures such as `stall`, `timeout`, or `retry_exhaustion`, but they do not create a scheduler state machine and do not authorize automatic retry.
+- Attempts persist as append-only runtime evidence under `.loom/runtime/attempts/<item-id>/`, so retry evidence is derived from the attempt chain rather than from a separate scheduler-owned state record.
 - Attempts can reference authored carriers by locator but must not duplicate their authored progress values.
 - Attempts are append-only runtime evidence for observability. They do not advance checkpoints, close Work Items, change review decisions, or satisfy merge-ready by themselves.

--- a/docs/methodology/harness/governance-failure-taxonomy.md
+++ b/docs/methodology/harness/governance-failure-taxonomy.md
@@ -209,6 +209,7 @@ closeout 阶段发现的控制面对齐漂移。
 - 这些分类不替代 `stale` / `drift` / `gate_failure`
 - 这些分类可以携带 `fallback_to`，但 fallback target 只能指向 Loom 内部 checkpoint / flow / repair 入口
 - 这些分类不得声明 `Claimed`、`Running`、`RetryQueued` 或其他 scheduler state
+- retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行、由谁调度或是否会自动 backoff
 
 ## 9. 非目标
 

--- a/docs/methodology/harness/status-surface-contract.md
+++ b/docs/methodology/harness/status-surface-contract.md
@@ -179,6 +179,25 @@
 
 `execution_failure` 只作为 status / recovery / review 的风险输入，不声明 scheduler state，不触发自动 retry，也不单独决定 `pass | block`。
 
+### 3.7.3 `retry_evidence`
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 retry evidence，但该字段组只读 runtime evidence，不得替代 scheduler。
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`: 当前 `HEAD` 绑定的 attempt 数量
+- `retry_count`: `attempt_count - 1`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`: 仅当最近分类为 `retry_exhaustion` 时为 `true`
+- `scheduler_ownership`: 固定 `external`
+- `stale_attempt_count`: 不再绑定当前 `HEAD` 的旧 attempt 数量
+- `provenance`
+
+该字段组只说明“已经发生过什么尝试”，不声明 `Claimed`、`Running`、`RetryQueued` 或自动 backoff 计划。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/docs/methodology/harness/status-surface.md
+++ b/docs/methodology/harness/status-surface.md
@@ -109,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - approval / sandbox policy 与 risk summary
 - execution budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（`stall` / `timeout` / `retry_exhaustion` 只作为风险输入）
+- retry evidence 摘要（attempt chain、stale retry evidence、是否 exhausted）
 
 ## 4. `Runtime Evidence`
 
@@ -195,6 +196,23 @@ Approval / sandbox policy 也只能派生读取：
   - 表示尝试链已经耗尽，但 Loom 只记录证据，不接管调度
 
 若最近 attempt 已 stale，`execution_failure.status` 必须显示 `stale`；若没有可读 attempt evidence，则显示 `missing` 或 `invalid`。该字段组不创建 scheduler state，不单独决定 merge gate。
+
+## 6.2 Retry Evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`：
+
+- `attempt_count`
+  - 绑定当前 `HEAD` 的 attempt 总数
+- `retry_count`
+  - `attempt_count - 1`
+- `latest_failure_classification` / `latest_failure_summary`
+  - 最近 attempt 的失败分类与摘要
+- `stale_attempt_count`
+  - 仍可读但已不再绑定当前 `HEAD` 的旧 attempts
+- `scheduler_ownership`
+  - 固定为 `external`
+
+若当前只有旧 head 的 attempt chain，`retry_evidence.status` 必须为 `stale`。若最近分类为 `retry_exhaustion`，状态面可以暴露 `exhausted: true`，但不得生成自动 retry 计划或 scheduler state。
 
 ## 7. gate 可消费判定
 

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -282,6 +282,8 @@ EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "su
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
+EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -2312,6 +2314,10 @@ def require_execution_attempt_summary(
         failures.append(Failure(category, f"{context} execution_attempt result must stay within the stable contract"))
     if payload.get("failure_category") not in loom_flow_module.EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failures.append(Failure(category, f"{context} execution_attempt failure_category is outside the stable vocabulary"))
+    if payload.get("execution_classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+        failures.append(Failure(category, f"{context} execution_attempt execution_classification is outside the stable vocabulary"))
+    if not isinstance(payload.get("execution_summary"), str) or not str(payload.get("execution_summary")).strip():
+        failures.append(Failure(category, f"{context} execution_attempt must include a non-empty execution_summary"))
     evidence = payload.get("evidence")
     if not isinstance(evidence, dict):
         failures.append(Failure(category, f"{context} execution_attempt must include evidence"))
@@ -3811,6 +3817,8 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3842,6 +3850,24 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            if not isinstance(execution_failure, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
+            else:
+                if execution_failure.get("schema_version") != loom_flow_module.EXECUTION_FAILURE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure must report schema v1"))
+                if execution_failure.get("status") not in loom_flow_module.EXECUTION_FAILURE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
+                if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10578,6 +10604,180 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/execution-failure-fixtures.json"
+    category = "execution-failure"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/execution-failure-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != EXECUTION_FAILURE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/execution-failure-fixtures.json` schema_version must be `{EXECUTION_FAILURE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`execution-failure-fixtures.json` must expose fixtures list"))
+        return failures
+
+    for index, fixture in enumerate(fixtures, start=1):
+        if not isinstance(fixture, dict):
+            failures.append(Failure(category, f"`execution-failure-fixtures.json` fixture #{index} must be an object"))
+            continue
+        name = str(fixture.get("name") or f"fixture-{index}")
+        context = f"{name} (#{index})"
+        input_payload = fixture.get("input")
+        if not isinstance(input_payload, dict):
+            failures.append(Failure(category, f"`{context}` input must be an object"))
+            continue
+        expect = fixture.get("expect")
+        if not isinstance(expect, dict):
+            failures.append(Failure(category, f"`{context}` expect must be an object"))
+            continue
+
+        details = loom_flow_module.execution_failure_details(input_payload)
+        expected_classification = expect.get("classification")
+        if expected_classification is not None and details.get("classification") != expected_classification:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure classification `{details.get('classification')}` != expected `{expected_classification}`",
+                )
+            )
+        expected_fallback = expect.get("fallback_to")
+        if expected_fallback is not None and details.get("fallback_to") != expected_fallback:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` execution failure fallback_to `{details.get('fallback_to')}` != expected `{expected_fallback}`",
+                )
+            )
+        summary_contains = expect.get("summary_contains")
+        if isinstance(summary_contains, str) and summary_contains not in str(details.get("summary")):
+            failures.append(Failure(category, f"`{context}` execution failure summary must contain `{summary_contains}`"))
+
+    return failures
+
+
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10645,6 +10845,47 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         if not isinstance(envelope, dict):
             failures.append(Failure("execution-attempt", "latest attempt must expose the persisted envelope"))
             return failures
+        failure = envelope.get("failure")
+        if not isinstance(failure, dict) or failure.get("execution_classification") != "none":
+            failures.append(Failure("execution-attempt", "pass attempt must classify execution failure as `none`"))
+
+        timeout_summary = loom_flow_module.persist_execution_attempt(
+            context,
+            command="flow",
+            operation="review",
+            payload={
+                "command": "flow",
+                "operation": "review",
+                "result": "block",
+                "summary": "default review engine failed closed before a formal review record could be authored.",
+                "missing_inputs": ["default review engine timed out after 900s"],
+                "fallback_to": "build",
+                "steps": [
+                    {
+                        "name": "review-engine",
+                        "result": "block",
+                        "summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    }
+                ],
+            },
+        )
+        if timeout_summary.get("execution_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "timed-out attempt must classify execution failure as `timeout`"))
+        latest_timeout = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
+        execution_failure = loom_flow_module.latest_execution_failure_payload(latest_timeout)
+        if execution_failure.get("status") != "present":
+            failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
+        if execution_failure.get("classification") != "timeout":
+            failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10670,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10818,6 +11062,8 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
+    failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -155,6 +155,17 @@ GUIDED_ADOPTION_PLAN_SCHEMA = "loom-guided-adoption-plan/v1"
 COMPANION_GENERATION_SCHEMA = "loom-companion-generation/v1"
 EXECUTION_ATTEMPT_SCHEMA = "loom-execution-attempt/v1"
 EXECUTION_ATTEMPT_RESULTS = {"pass", "block", "fallback"}
+EXECUTION_FAILURE_SCHEMA = "loom-execution-failure/v1"
+EXECUTION_FAILURE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
+EXECUTION_FAILURE_CLASSIFICATIONS = {
+    "none",
+    "stall",
+    "timeout",
+    "retry_exhaustion",
+    "unknown",
+}
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -1753,6 +1764,85 @@ def execution_attempt_failure_category(payload: dict[str, Any]) -> str:
     return "unknown"
 
 
+def classify_execution_failure_text(text: str) -> str:
+    lowered = text.strip().lower()
+    if not lowered:
+        return "unknown"
+    if "retry_exhaustion" in lowered or "retry exhaustion" in lowered or "retries exhausted" in lowered:
+        return "retry_exhaustion"
+    if "timed out" in lowered or re.search(r"\btimeout\b", lowered):
+        return "timeout"
+    if "stall" in lowered or "stalled" in lowered:
+        return "stall"
+    return "unknown"
+
+
+def execution_failure_details(payload: dict[str, Any]) -> dict[str, Any]:
+    if payload.get("result") == "pass":
+        return {
+            "classification": "none",
+            "summary": "latest execution attempt completed without an execution failure classification.",
+            "fallback_to": None,
+        }
+
+    explicit = payload.get("execution_failure")
+    if isinstance(explicit, dict):
+        classification = explicit.get("classification") or explicit.get("kind")
+        summary = explicit.get("summary")
+        fallback_to = explicit.get("fallback_to")
+        if isinstance(classification, str) and classification in EXECUTION_FAILURE_CLASSIFICATIONS:
+            normalized_summary = (
+                str(summary).strip()
+                if isinstance(summary, str) and str(summary).strip()
+                else f"execution failure classified as `{classification}`."
+            )
+            return {
+                "classification": classification,
+                "summary": normalized_summary,
+                "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else payload.get("fallback_to"),
+            }
+
+    texts: list[str] = []
+    summary = payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        texts.append(summary.strip())
+    missing_inputs = payload.get("missing_inputs")
+    if isinstance(missing_inputs, list):
+        texts.extend(str(item).strip() for item in missing_inputs if str(item).strip())
+    steps = payload.get("steps")
+    if isinstance(steps, list):
+        for step in steps:
+            if not isinstance(step, dict):
+                continue
+            for field in ("summary", "name"):
+                value = step.get(field)
+                if isinstance(value, str) and value.strip():
+                    texts.append(value.strip())
+            step_missing = step.get("missing_inputs")
+            if isinstance(step_missing, list):
+                texts.extend(str(item).strip() for item in step_missing if str(item).strip())
+    engine = payload.get("engine")
+    if isinstance(engine, dict):
+        failure_reason = engine.get("failure_reason")
+        if isinstance(failure_reason, str) and failure_reason.strip():
+            texts.append(failure_reason.strip())
+
+    classification = "unknown"
+    matched_summary: str | None = None
+    for candidate in texts:
+        classification = classify_execution_failure_text(candidate)
+        if classification != "unknown":
+            matched_summary = candidate
+            break
+
+    summary_text = next((candidate for candidate in texts if candidate), None)
+    return {
+        "classification": classification,
+        "summary": matched_summary or summary_text or "execution attempt blocked without a classified execution failure.",
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
 def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     evidence = envelope.get("evidence") if isinstance(envelope.get("evidence"), dict) else {}
     failure = envelope.get("failure") if isinstance(envelope.get("failure"), dict) else {}
@@ -1764,6 +1854,8 @@ def execution_attempt_summary_from_envelope(envelope: dict[str, Any]) -> dict[st
         "operation": envelope.get("operation"),
         "result": envelope.get("result"),
         "failure_category": failure.get("category"),
+        "execution_classification": failure.get("execution_classification"),
+        "execution_summary": failure.get("execution_summary"),
         "fallback_to": failure.get("fallback_to"),
         "evidence": {
             "status": evidence.get("status"),
@@ -1806,6 +1898,7 @@ def build_execution_attempt_envelope(
     failure_category = execution_attempt_failure_category(payload)
     if failure_category not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
         failure_category = "unknown"
+    execution_failure = execution_failure_details(payload)
     steps = payload.get("steps")
     step_summary = []
     if isinstance(steps, list):
@@ -1836,8 +1929,10 @@ def build_execution_attempt_envelope(
         },
         "failure": {
             "category": failure_category,
+            "execution_classification": execution_failure["classification"],
+            "execution_summary": execution_failure["summary"],
             "missing_inputs": missing_inputs,
-            "fallback_to": payload.get("fallback_to"),
+            "fallback_to": execution_failure["fallback_to"],
         },
         "steps": step_summary,
         "evidence": {
@@ -1926,6 +2021,10 @@ def validate_execution_attempt_envelope(
     else:
         if failure.get("category") not in EXECUTION_ATTEMPT_FAILURE_CATEGORIES:
             errors.append("execution_attempt failure.category is outside the stable vocabulary")
+        if failure.get("execution_classification") not in EXECUTION_FAILURE_CLASSIFICATIONS:
+            errors.append("execution_attempt failure.execution_classification is outside the stable vocabulary")
+        if not isinstance(failure.get("execution_summary"), str) or not str(failure.get("execution_summary")).strip():
+            errors.append("execution_attempt failure.execution_summary must be a non-empty string")
         if not isinstance(failure.get("missing_inputs"), list):
             errors.append("execution_attempt failure.missing_inputs must be a list")
     evidence = payload.get("evidence")
@@ -2008,6 +2107,181 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
         "evidence": {"locator": locator, "status": "present" if freshness in {"fresh", "stale"} else "invalid"},
         "missing_inputs": errors,
         "attempt": envelope,
+    }
+
+
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
+def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    status = latest_attempt.get("status") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "latest_execution_attempt",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if status == "missing":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "missing",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is missing.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    if status == "invalid":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "invalid",
+            "classification": "unknown",
+            "summary": latest_attempt.get("summary") if isinstance(latest_attempt.get("summary"), str) else "latest execution attempt evidence is invalid.",
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+
+    attempt = latest_attempt.get("attempt") if isinstance(latest_attempt, dict) else None
+    failure = attempt.get("failure") if isinstance(attempt, dict) else None
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else None
+    fallback_to = failure.get("fallback_to") if isinstance(failure, dict) else None
+    normalized_summary = (
+        str(summary).strip()
+        if isinstance(summary, str) and str(summary).strip()
+        else "latest execution attempt did not record a readable execution failure summary."
+    )
+    if freshness == "stale":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "stale",
+            "classification": classification,
+            "summary": "latest execution failure evidence exists but is stale for the current HEAD.",
+            "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+            "provenance": provenance,
+        }
+    if classification == "none":
+        return {
+            "schema_version": EXECUTION_FAILURE_SCHEMA,
+            "status": "not_applicable",
+            "classification": "none",
+            "summary": normalized_summary,
+            "fallback_to": None,
+            "provenance": provenance,
+        }
+    return {
+        "schema_version": EXECUTION_FAILURE_SCHEMA,
+        "status": "present",
+        "classification": classification,
+        "summary": normalized_summary,
+        "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
+        "provenance": provenance,
     }
 
 

--- a/examples/new-project/.loom/bin/loom_status.py
+++ b/examples/new-project/.loom/bin/loom_status.py
@@ -16,7 +16,9 @@ from loom_flow import (
     github_issue_payload,
     github_pr_payload,
     implementation_review_status_payload,
+    latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -490,6 +492,8 @@ def main(argv: list[str]) -> int:
         github_errors=github_errors,
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
+    execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -524,6 +528,8 @@ def main(argv: list[str]) -> int:
             "recovery_readiness": report_recovery_readiness(context["report"]),
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
+            "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,13 +131,13 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "7bad6734ccaebb8422c9746f1c1aaaa936fb751f8797b18dba2eec456ecdfec8"
+      "sha256": "8516698ec56df6c7d3ed8fdb61aedf84e502e87fd261895a5a17e6c53667e9ca"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "4dabb17354fd66b4eef13093dae231fb461b3bc51e30ba4bbf44397b07337331"
+      "sha256": "5ae0bd604f67b35cc11053b07bd3e2d69e57d8378aa939bded0ab6d1378efafe"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "360aa049c3549928ba96f50ac37bc29de190eca157fa214c68bdafd71474e957"
+      "sha256": "4e6fa51a03d6f35be0634e243102bb02de86e3486c75c4b37c5b1032ba1bbc50"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,13 +53,13 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "7bad6734ccaebb8422c9746f1c1aaaa936fb751f8797b18dba2eec456ecdfec8"
+      "sha256": "8516698ec56df6c7d3ed8fdb61aedf84e502e87fd261895a5a17e6c53667e9ca"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "4dabb17354fd66b4eef13093dae231fb461b3bc51e30ba4bbf44397b07337331"
+      "sha256": "5ae0bd604f67b35cc11053b07bd3e2d69e57d8378aa939bded0ab6d1378efafe"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "360aa049c3549928ba96f50ac37bc29de190eca157fa214c68bdafd71474e957"
+      "sha256": "4e6fa51a03d6f35be0634e243102bb02de86e3486c75c4b37c5b1032ba1bbc50"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.84",
+      "version": "0.1.85",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-build/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-build/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-init/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-init/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-review/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/execution-attempt.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/skills/shared/references/harness/execution-attempt.md
+++ b/skills/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/skills/shared/references/harness/governance-failure-taxonomy.md
+++ b/skills/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/skills/shared/references/harness/status-surface-contract.md
+++ b/skills/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/skills/shared/references/harness/status-surface.md
+++ b/skills/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,

--- a/src/skills/shared/references/harness/execution-attempt.md
+++ b/src/skills/shared/references/harness/execution-attempt.md
@@ -21,3 +21,4 @@ It is not authored progress. Envelopes must not carry `current_stop`, `next_step
 Status may display a latest attempt only as fresh when the envelope is valid, item-bound, HEAD-bound, and free of authored progress fields. Missing or stale evidence must be reported as missing or stale instead of becoming execution truth.
 
 `failure.execution_classification` is reserved for runtime evidence such as `stall`, `timeout`, or `retry_exhaustion`. It stays provider-neutral and does not create scheduler ownership.
+Retry evidence comes from the persisted attempt chain under `.loom/runtime/attempts/<item-id>/`, not from a separate scheduler state record.

--- a/src/skills/shared/references/harness/governance-failure-taxonomy.md
+++ b/src/skills/shared/references/harness/governance-failure-taxonomy.md
@@ -127,7 +127,7 @@ Loom 允许在 runtime evidence 中记录最近一次执行失败分类，作为
 - `timeout`
 - `retry_exhaustion`
 
-这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。
+这些分类不是新的顶层 taxonomy，不替代 `stale` / `drift` / `gate_failure`，也不得声明 scheduler state。retry evidence 只说明 attempt chain 已发生什么，不说明下一次何时执行。
 
 典型例子：
 

--- a/src/skills/shared/references/harness/status-surface-contract.md
+++ b/src/skills/shared/references/harness/status-surface-contract.md
@@ -176,6 +176,23 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
+### 3.7.3 `retry_evidence`
+
+- `schema_version`: `loom-retry-evidence/v1`
+- `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
+- `attempt_count`
+- `retry_count`
+- `latest_attempt_id`
+- `latest_attempt_result`
+- `latest_failure_classification`
+- `latest_failure_summary`
+- `exhausted`
+- `scheduler_ownership`
+- `stale_attempt_count`
+- `provenance`
+
+该字段组从 attempt chain 派生 retry evidence，不声明 scheduler state。
+
 ### 3.8 `taxonomy`
 
 至少包含：

--- a/src/skills/shared/references/harness/status-surface.md
+++ b/src/skills/shared/references/harness/status-surface.md
@@ -104,6 +104,7 @@ Approval / sandbox policy 也只能派生读取：
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
 - 最近 execution failure 分类（只作风险输入）
+- retry evidence 摘要
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 
@@ -126,6 +127,10 @@ Approval / sandbox policy 也只能派生读取：
 ## 4.1 execution_failure
 
 状态面可以从最近一次 `execution_attempt` 派生 `execution_failure`，用于暴露 `stall`、`timeout`、`retry_exhaustion` 等执行风险。该字段只读 runtime evidence，不创建 scheduler state，也不单独阻断 merge。
+
+## 4.2 retry_evidence
+
+状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 `retry_evidence`，用于暴露 attempt_count、retry_count、stale_attempt_count 与 exhausted 信号。该字段只读 runtime evidence，不声明 scheduler state。
 
 ## 4. `Runtime Evidence`
 

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -283,6 +283,7 @@ EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining",
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
+RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
 
 
 def repo_root_from_argv(argv: list[str]) -> Path:
@@ -3817,6 +3818,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
             execution_failure = payload.get("execution_failure")
+            retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_budget`"))
             else:
@@ -3857,6 +3859,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure status must stay within the stable set"))
                 if execution_failure.get("classification") not in loom_flow_module.EXECUTION_FAILURE_CLASSIFICATIONS:
                     failures.append(Failure("daily-execution-cli", "`loom_status` execution_failure classification must stay within the stable vocabulary"))
+            if not isinstance(retry_evidence, dict):
+                failures.append(Failure("daily-execution-cli", "`loom_status` must include `retry_evidence`"))
+            else:
+                if retry_evidence.get("schema_version") != loom_flow_module.RETRY_EVIDENCE_SCHEMA:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must report schema v1"))
+                if retry_evidence.get("status") not in loom_flow_module.RETRY_EVIDENCE_STATUSES:
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence status must stay within the stable set"))
+                if retry_evidence.get("scheduler_ownership") != "external":
+                    failures.append(Failure("daily-execution-cli", "`loom_status` retry_evidence must keep scheduler_ownership external"))
             if not isinstance(governance_status, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `governance_status`"))
             else:
@@ -10658,6 +10669,115 @@ def check_execution_failure_fixture_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_retry_evidence_fixture_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    fixture_path = root / "docs/evidence/fixtures/retry-evidence-fixtures.json"
+    category = "retry-evidence"
+    try:
+        fixture_payload = load_json_file(fixture_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        failures.append(Failure(category, f"`docs/evidence/fixtures/retry-evidence-fixtures.json` is unreadable: {exc}"))
+        return failures
+
+    if not isinstance(fixture_payload, dict):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must be an object"))
+        return failures
+    if fixture_payload.get("schema_version") != RETRY_EVIDENCE_FIXTURE_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"`docs/evidence/fixtures/retry-evidence-fixtures.json` schema_version must be `{RETRY_EVIDENCE_FIXTURE_SCHEMA}`",
+            )
+        )
+
+    fixtures = fixture_payload.get("fixtures")
+    if not isinstance(fixtures, list):
+        failures.append(Failure(category, "`retry-evidence-fixtures.json` must expose fixtures list"))
+        return failures
+
+    with tempfile.TemporaryDirectory(prefix="loom-check-retry-evidence-") as tmp:
+        root_dir = Path(tmp)
+        current_head = "1" * 40
+        stale_head = "0" * 40
+        for index, fixture in enumerate(fixtures, start=1):
+            if not isinstance(fixture, dict):
+                failures.append(Failure(category, f"`retry-evidence-fixtures.json` fixture #{index} must be an object"))
+                continue
+            name = str(fixture.get("name") or f"fixture-{index}")
+            context = f"{name} (#{index})"
+            fixture_target = root_dir / name
+            attempts_dir = fixture_target / ".loom/runtime/attempts/INIT-0001"
+            attempts_dir.mkdir(parents=True, exist_ok=True)
+            envelopes = fixture.get("attempts")
+            if not isinstance(envelopes, list):
+                failures.append(Failure(category, f"`{context}` attempts must be a list"))
+                continue
+            latest_index = fixture.get("latest_index", len(envelopes))
+            for attempt_index, envelope in enumerate(envelopes, start=1):
+                if not isinstance(envelope, dict):
+                    continue
+                payload = dict(envelope)
+                payload.setdefault("schema_version", loom_flow_module.EXECUTION_ATTEMPT_SCHEMA)
+                payload.setdefault("item_id", "INIT-0001")
+                payload.setdefault("command", "flow")
+                payload.setdefault("operation", "review")
+                payload.setdefault("result", "block")
+                payload.setdefault("created_at", f"2026-05-09T06:00:{attempt_index:02d}Z")
+                payload.setdefault("head_sha", current_head if fixture.get("freshness") != "stale" else stale_head)
+                payload.setdefault("attempt_id", f"INIT-0001-review-{attempt_index}")
+                payload.setdefault("branch", "work/594-retry-evidence-boundary")
+                payload.setdefault("workspace", {"entry": ".", "path": "."})
+                payload.setdefault(
+                    "failure",
+                    {
+                        "category": "review",
+                        "execution_classification": "timeout",
+                        "execution_summary": "default review engine timed out after 900s",
+                        "missing_inputs": ["default review engine timed out after 900s"],
+                        "fallback_to": "build",
+                    },
+                )
+                payload.setdefault(
+                    "evidence",
+                    {
+                        "status": "present",
+                        "locator": f".loom/runtime/attempts/INIT-0001/{payload['attempt_id']}.json",
+                        "latest_locator": ".loom/runtime/attempts/INIT-0001/latest.json",
+                    },
+                )
+                attempt_path = attempts_dir / f"{payload['attempt_id']}.json"
+                attempt_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+                if attempt_index == latest_index:
+                    (attempts_dir / "latest.json").write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            head_result = run_command(root, ["git", "init"], cwd=fixture_target, timeout_seconds=30)
+            if head_result.returncode != 0:
+                failures.append(Failure(category, f"`{context}` git init failed"))
+                continue
+            run_command(root, ["git", "config", "user.email", "loom-check@example.com"], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "config", "user.name", "loom-check"], cwd=fixture_target, timeout_seconds=30)
+            (fixture_target / "README.md").write_text("retry fixture\n", encoding="utf-8")
+            run_command(root, ["git", "add", "."], cwd=fixture_target, timeout_seconds=30)
+            run_command(root, ["git", "commit", "-m", "baseline"], cwd=fixture_target, timeout_seconds=30)
+            if fixture.get("freshness") != "stale":
+                actual_head = run_command(root, ["git", "rev-parse", "HEAD"], cwd=fixture_target, timeout_seconds=30).stdout.strip()
+                for attempt_file in attempts_dir.glob("*.json"):
+                    payload = json.loads(attempt_file.read_text(encoding="utf-8"))
+                    payload["head_sha"] = actual_head
+                    attempt_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+            payload = loom_flow_module.latest_retry_evidence_payload(fixture_target, "INIT-0001")
+            expect = fixture.get("expect")
+            if not isinstance(expect, dict):
+                failures.append(Failure(category, f"`{context}` expect must be an object"))
+                continue
+            for field in ("status", "attempt_count", "retry_count", "latest_failure_classification", "exhausted", "stale_attempt_count"):
+                if field in expect and payload.get(field) != expect.get(field):
+                    failures.append(Failure(category, f"`{context}` retry evidence `{field}` {payload.get(field)!r} != expected {expect.get(field)!r}"))
+
+    return failures
+
+
 def check_execution_attempt_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
     example_target = root / "examples/new-project"
@@ -10759,6 +10879,13 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
             failures.append(Failure("execution-attempt", "fresh classified execution failure must surface as present"))
         if execution_failure.get("classification") != "timeout":
             failures.append(Failure("execution-attempt", "latest execution failure surface must preserve timeout classification"))
+        retry_evidence = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if retry_evidence.get("status") != "present":
+            failures.append(Failure("execution-attempt", "multiple current-head attempts must surface retry evidence as present"))
+        if retry_evidence.get("attempt_count") != 2 or retry_evidence.get("retry_count") != 1:
+            failures.append(Failure("execution-attempt", "retry evidence must count current-head attempt history"))
+        if retry_evidence.get("latest_failure_classification") != "timeout":
+            failures.append(Failure("execution-attempt", "retry evidence must preserve latest failure classification"))
 
         poisoned = dict(envelope)
         poisoned["next_step"] = "forbidden duplicate recovery progress"
@@ -10784,6 +10911,9 @@ def check_execution_attempt_contract(root: Path) -> list[Failure]:
         stale_payload = loom_flow_module.latest_execution_attempt_payload(target, "INIT-0001")
         if stale_payload.get("freshness") != "stale":
             failures.append(Failure("execution-attempt", "status must not display a stale attempt as fresh"))
+        stale_retry = loom_flow_module.latest_retry_evidence_payload(target, "INIT-0001")
+        if stale_retry.get("status") != "stale":
+            failures.append(Failure("execution-attempt", "retry evidence must not display a stale attempt chain as fresh"))
 
     return failures
 
@@ -10933,6 +11063,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
     failures.extend(check_execution_failure_fixture_contract(root))
+    failures.extend(check_retry_evidence_fixture_contract(root))
     failures.extend(check_execution_attempt_contract(root))
     failures.extend(check_build_execution_contract(root))
     failures.extend(check_markdown_links(root))

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -164,6 +164,8 @@ EXECUTION_FAILURE_CLASSIFICATIONS = {
     "retry_exhaustion",
     "unknown",
 }
+RETRY_EVIDENCE_SCHEMA = "loom-retry-evidence/v1"
+RETRY_EVIDENCE_STATUSES = {"present", "not_applicable", "stale", "missing", "invalid"}
 EXECUTION_ATTEMPT_FAILURE_CATEGORIES = {
     "none",
     "runtime_state",
@@ -2108,6 +2110,31 @@ def latest_execution_attempt_payload(target_root: Path, item_id: str) -> dict[st
     }
 
 
+def execution_attempt_history_payload(target_root: Path, item_id: str) -> list[dict[str, Any]]:
+    directory = execution_attempt_directory(target_root, item_id)
+    if not directory.exists():
+        return []
+    attempts: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.name == "latest.json":
+            continue
+        try:
+            payload = load_json_file(path)
+        except Exception:
+            continue
+        envelope, errors, _ = validate_execution_attempt_envelope(
+            payload,
+            target_root=target_root,
+            expected_item=item_id,
+            expected_head=None,
+        )
+        if errors or envelope is None:
+            continue
+        attempts.append(envelope)
+    attempts.sort(key=lambda entry: (str(entry.get("created_at") or ""), str(entry.get("attempt_id") or "")))
+    return attempts
+
+
 def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str, Any]:
     evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
     locator = evidence.get("locator") if isinstance(evidence, dict) else None
@@ -2175,6 +2202,85 @@ def latest_execution_failure_payload(latest_attempt: dict[str, Any]) -> dict[str
         "classification": classification,
         "summary": normalized_summary,
         "fallback_to": str(fallback_to) if isinstance(fallback_to, str) and fallback_to.strip() else None,
+        "provenance": provenance,
+    }
+
+
+def latest_retry_evidence_payload(target_root: Path, item_id: str) -> dict[str, Any]:
+    latest_attempt = latest_execution_attempt_payload(target_root, item_id)
+    history = execution_attempt_history_payload(target_root, item_id)
+    evidence = latest_attempt.get("evidence") if isinstance(latest_attempt, dict) else {}
+    locator = evidence.get("locator") if isinstance(evidence, dict) else None
+    freshness = latest_attempt.get("freshness") if isinstance(latest_attempt, dict) else None
+    provenance = {
+        "source_layer": "derived_surface",
+        "source_locator": locator,
+        "source_binding": "execution_attempt_history",
+        "freshness": freshness if isinstance(freshness, str) else "missing",
+        "conflict": "none",
+    }
+    if latest_attempt.get("status") == "missing":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "missing",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+    if latest_attempt.get("status") == "invalid":
+        return {
+            "schema_version": RETRY_EVIDENCE_SCHEMA,
+            "status": "invalid",
+            "attempt_count": 0,
+            "retry_count": 0,
+            "latest_attempt_id": None,
+            "latest_attempt_result": None,
+            "latest_failure_classification": "unknown",
+            "latest_failure_summary": latest_attempt.get("summary"),
+            "exhausted": False,
+            "scheduler_ownership": "external",
+            "stale_attempt_count": 0,
+            "provenance": provenance,
+        }
+
+    latest_envelope = latest_attempt.get("attempt") if isinstance(latest_attempt.get("attempt"), dict) else {}
+    current_head = git_head_sha(target_root) or "unknown-head"
+    current_attempts = [entry for entry in history if entry.get("head_sha") == current_head]
+    stale_attempts = [entry for entry in history if entry.get("head_sha") != current_head]
+    failure = latest_envelope.get("failure") if isinstance(latest_envelope, dict) else {}
+    classification = failure.get("execution_classification") if isinstance(failure, dict) else None
+    if not isinstance(classification, str) or classification not in EXECUTION_FAILURE_CLASSIFICATIONS:
+        classification = "unknown"
+    summary = failure.get("execution_summary") if isinstance(failure, dict) else latest_attempt.get("summary")
+    latest_attempt_id = latest_envelope.get("attempt_id") if isinstance(latest_envelope, dict) else None
+    latest_attempt_result = latest_envelope.get("result") if isinstance(latest_envelope, dict) else None
+    attempt_count = len(current_attempts)
+    retry_count = max(0, attempt_count - 1)
+    if latest_attempt.get("freshness") == "stale":
+        status = "stale"
+    elif attempt_count <= 1 and classification == "none":
+        status = "not_applicable"
+    else:
+        status = "present"
+    return {
+        "schema_version": RETRY_EVIDENCE_SCHEMA,
+        "status": status,
+        "attempt_count": attempt_count,
+        "retry_count": retry_count,
+        "latest_attempt_id": latest_attempt_id if isinstance(latest_attempt_id, str) and latest_attempt_id else None,
+        "latest_attempt_result": latest_attempt_result if isinstance(latest_attempt_result, str) else None,
+        "latest_failure_classification": classification,
+        "latest_failure_summary": str(summary).strip() if isinstance(summary, str) and str(summary).strip() else None,
+        "exhausted": classification == "retry_exhaustion",
+        "scheduler_ownership": "external",
+        "stale_attempt_count": len(stale_attempts),
         "provenance": provenance,
     }
 

--- a/src/skills/shared/scripts/loom_status.py
+++ b/src/skills/shared/scripts/loom_status.py
@@ -18,6 +18,7 @@ from loom_flow import (
     implementation_review_status_payload,
     latest_execution_failure_payload,
     latest_execution_attempt_payload,
+    latest_retry_evidence_payload,
     load_context,
     report_blocking_failures,
     report_blocking_messages,
@@ -492,6 +493,7 @@ def main(argv: list[str]) -> int:
     )
     latest_execution_attempt = latest_execution_attempt_payload(target_root, context["item_id"])
     execution_failure = latest_execution_failure_payload(latest_execution_attempt)
+    retry_evidence = latest_retry_evidence_payload(target_root, context["item_id"])
 
     missing_inputs: list[str] = []
     for section in (spec_review, review, merge_ready):
@@ -527,6 +529,7 @@ def main(argv: list[str]) -> int:
             "execution_ledger": report_execution_ledger(context["report"]),
             "latest_execution_attempt": latest_execution_attempt,
             "execution_failure": execution_failure,
+            "retry_evidence": retry_evidence,
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,


### PR DESCRIPTION
## Summary
Derive provider-neutral retry evidence from the persisted execution-attempt history and expose it through the status surface for the `#593` batch.

This PR covers:
- #594 docs contract for retry evidence and scheduler boundary
- #595 runtime/status support for attempt-chain-derived retry evidence
- #596 fixtures and loom_check regression coverage

## Scope
- Harness docs + installed references
- `execution_attempt` history-derived retry evidence
- `loom_status` top-level `retry_evidence` summary path
- Retry fixtures and `loom_check` contract assertions
- Refreshed `examples/new-project` bootstrap carriers after runtime hash changes
- Regenerated shared runtime/install surfaces and installer package version bump to `0.1.85`

## Validation
- `python3 -m py_compile tools/loom_init.py tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/loom_init.py bootstrap --target examples/new-project --write --force --verify --install-pr-template --portable-output`

## Binding
- Work Items: #594, #595, #596
- FR: #593
- Phase: #532
