### PR TITLE
feat(harness): consume advisory budget risk in review and merge gate

### DIFF
--- a/docs/evidence/fixtures/execution-budget-fixtures.json
+++ b/docs/evidence/fixtures/execution-budget-fixtures.json
@@ -42,6 +42,8 @@
         "status": "present",
         "dimension_ids": ["requests", "tokens"],
         "dimension_fields": ["id", "unit", "used", "limit", "remaining", "risk", "source"],
+        "highest_risk": "low",
+        "risk_dimensions": ["requests", "tokens"],
         "forbidden_fields": [
           "x-ratelimit-remaining",
           "x-ratelimit-reset",
@@ -59,7 +61,9 @@
         "status": "not_applicable",
         "enforcement": "advisory",
         "dimensions_count": 0,
-        "dimension_ids": []
+        "dimension_ids": [],
+        "highest_risk": "none",
+        "risk_dimensions": []
       }
     },
     {
@@ -96,9 +100,119 @@
         "status": "present",
         "dimension_ids": ["time_window"],
         "dimension_fields": ["id", "unit", "used", "limit", "remaining", "risk", "source"],
+        "highest_risk": "high",
+        "risk_dimensions": ["time_window"],
         "forbidden_fields": [
           "x-ratelimit-resource"
         ]
+      }
+    },
+    {
+      "name": "high-risk-advisory-remains-non-blocking",
+      "description": "High-risk budget dimensions are exposed as advisory risk evidence only.",
+      "input": {
+        "status": "present",
+        "enforcement": "advisory",
+        "summary": "host budget indicates retry and request pressure",
+        "dimensions": [
+          {
+            "id": "requests",
+            "unit": "request",
+            "used": 4950,
+            "limit": 5000,
+            "remaining": 50,
+            "risk": "high",
+            "source": "github_host_headers"
+          },
+          {
+            "id": "retries",
+            "unit": "attempt",
+            "used": 4,
+            "limit": 5,
+            "remaining": 1,
+            "risk": "medium",
+            "source": "loom_runtime"
+          }
+        ],
+        "provenance": {
+          "source": "github_host",
+          "read_mode": "cached_non_merge"
+        },
+        "adapter_evidence_locator": "loom.adapter.github.rate-limit"
+      },
+      "expect": {
+        "status": "present",
+        "enforcement": "advisory",
+        "dimension_ids": ["requests", "retries"],
+        "dimension_fields": ["id", "unit", "used", "limit", "remaining", "risk", "source"],
+        "highest_risk": "high",
+        "risk_dimensions": ["requests", "retries"]
+      }
+    },
+    {
+      "name": "budget-unavailable-remains-advisory",
+      "description": "Unavailable budget stays advisory and yields no risk dimensions.",
+      "input": {
+        "status": "unavailable",
+        "enforcement": "advisory",
+        "summary": "host budget mirror could not be refreshed",
+        "dimensions": [
+          {
+            "id": "requests",
+            "unit": "request",
+            "used": 1,
+            "limit": 2,
+            "remaining": 1,
+            "risk": "high",
+            "source": "stale_host"
+          }
+        ],
+        "provenance": {
+          "source": "github_host",
+          "read_mode": "cached_non_merge"
+        },
+        "adapter_evidence_locator": "loom.adapter.github.rate-limit"
+      },
+      "expect": {
+        "status": "unavailable",
+        "enforcement": "advisory",
+        "dimensions_count": 0,
+        "dimension_ids": [],
+        "highest_risk": "none",
+        "risk_dimensions": []
+      }
+    },
+    {
+      "name": "invalid-blocking-enforcement-is-normalized-away",
+      "description": "Adapters cannot promote execution budget into a budget-only blocking channel.",
+      "input": {
+        "status": "present",
+        "enforcement": "blocking",
+        "summary": "invalid adapter tried to publish blocking budget enforcement",
+        "dimensions": [
+          {
+            "id": "time_window",
+            "unit": "minute",
+            "used": 59,
+            "limit": 60,
+            "remaining": 1,
+            "risk": "high",
+            "source": "invalid_adapter"
+          }
+        ],
+        "provenance": {
+          "source": "github_host",
+          "read_mode": "uncached_live_gate"
+        },
+        "adapter_evidence_locator": "loom.adapter.invalid.blocking"
+      },
+      "expect": {
+        "status": "present",
+        "enforcement": "advisory",
+        "dimension_ids": ["time_window"],
+        "dimension_fields": ["id", "unit", "used", "limit", "remaining", "risk", "source"],
+        "highest_risk": "high",
+        "risk_dimensions": ["time_window"]
       }
     }
   ]

--- a/docs/methodology/harness/merge-checkpoint.md
+++ b/docs/methodology/harness/merge-checkpoint.md
@@ -32,6 +32,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable`
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 
@@ -96,6 +97,12 @@
 - 缺少 fresh verification evidence
 - 证据只存在于未整合的 subagent 输出中
 - review disposition 指向的补救、拒绝理由或延期事项缺少可消费证据
+
+`budget_risk` 在 `merge-ready` 中只作为 advisory evidence：
+
+- `high` 风险必须进入 merge-ready 输出摘要，提醒 reviewer / recovery / host merge 消费方
+- 不得把 advisory budget 加入 `missing_inputs`
+- 不得因为 budget-only 风险把 `result` 从 `pass` 改成 `block` 或 `fallback`
 
 ## 6. 与 `controlled merge` 的边界
 

--- a/docs/methodology/harness/review-execution.md
+++ b/docs/methodology/harness/review-execution.md
@@ -96,11 +96,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -142,6 +157,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/docs/methodology/harness/status-surface-contract.md
+++ b/docs/methodology/harness/status-surface-contract.md
@@ -166,7 +166,22 @@
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留
 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 状态面可以展示最近一次 `execution_attempt` 的执行失败分类，但该字段组只读 runtime evidence，不得把执行失败直接升级成 merge gate。
 
@@ -179,7 +194,7 @@
 
 `execution_failure` 只作为 status / recovery / review 的风险输入，不声明 scheduler state，不触发自动 retry，也不单独决定 `pass | block`。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 状态面可以从 `.loom/runtime/attempts/<item-id>/` 的 attempt chain 派生 retry evidence，但该字段组只读 runtime evidence，不得替代 scheduler。
 

--- a/docs/methodology/harness/status-surface.md
+++ b/docs/methodology/harness/status-surface.md
@@ -44,6 +44,9 @@
 - `execution_budget`
   - 从 `github_control_plane.api_snapshot.budget` 派生
   - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -108,10 +111,40 @@ Approval / sandbox policy 也只能派生读取：
 - dynamic tool availability 与 failure summary
 - approval / sandbox policy 与 risk summary
 - execution budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（`stall` / `timeout` / `retry_exhaustion` 只作为风险输入）
 - retry evidence 摘要（attempt chain、stale retry evidence、是否 exhausted）
 
-## 4. `Runtime Evidence`
+## 4. execution budget / execution budget risk
+
+状态面在 `execution_budget` 字段组里展示 provider-neutral 预算快照：
+
+- `schema_version`: `loom-execution-budget/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `summary`
+- `dimensions`
+  - 每项允许的 `id`：`turns`、`tokens`、`requests`、`retries`、`time_window`
+  - 每项固定字段：`unit`、`used`、`limit`、`remaining`、`risk`、`source`
+- `provenance`
+- `adapter_evidence_locator`
+
+`status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
+
+## 4.1 `Runtime Evidence`
 
 若事项涉及运行面，状态面必须继续提供固定区块 `Runtime Evidence`：
 

--- a/examples/new-project/.loom/bin/governance_surface.py
+++ b/examples/new-project/.loom/bin/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/examples/new-project/.loom/bin/loom_status.py
+++ b/examples/new-project/.loom/bin/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -125,19 +125,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "c407fa9574560bfa01e8c14bab57f16f025d9f6d5a53b2b136bb52b229481ed3"
+      "sha256": "9555b98122705fab5d79c3d7af381ced0d0135ebe9a2c7720eb45d08786f0e7e"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "8516698ec56df6c7d3ed8fdb61aedf84e502e87fd261895a5a17e6c53667e9ca"
+      "sha256": "78c5d1e85a1d49046b015d0addb0eb35310d607fc486b576f2c76fca880f8558"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "5ae0bd604f67b35cc11053b07bd3e2d69e57d8378aa939bded0ab6d1378efafe"
+      "sha256": "f2f48d4489a0f6c0567030a5b732aeeca72a9c3c2098a182bcdb44dbd549b5f8"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "4e6fa51a03d6f35be0634e243102bb02de86e3486c75c4b37c5b1032ba1bbc50"
+      "sha256": "703503e23265e0c63c89f53bb9ed2e060dd9c63614fe67d2aed809ac3056fd16"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -47,19 +47,19 @@
       "path": ".loom/bin/governance_surface.py",
       "kind": "loom-tool-support",
       "source": "skills/shared/scripts/governance_surface.py",
-      "sha256": "c407fa9574560bfa01e8c14bab57f16f025d9f6d5a53b2b136bb52b229481ed3"
+      "sha256": "9555b98122705fab5d79c3d7af381ced0d0135ebe9a2c7720eb45d08786f0e7e"
     },
     {
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "8516698ec56df6c7d3ed8fdb61aedf84e502e87fd261895a5a17e6c53667e9ca"
+      "sha256": "78c5d1e85a1d49046b015d0addb0eb35310d607fc486b576f2c76fca880f8558"
     },
     {
       "path": ".loom/bin/loom_status.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_status.py",
-      "sha256": "5ae0bd604f67b35cc11053b07bd3e2d69e57d8378aa939bded0ab6d1378efafe"
+      "sha256": "f2f48d4489a0f6c0567030a5b732aeeca72a9c3c2098a182bcdb44dbd549b5f8"
     },
     {
       "path": ".loom/bin/runtime_paths.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "4e6fa51a03d6f35be0634e243102bb02de86e3486c75c4b37c5b1032ba1bbc50"
+      "sha256": "703503e23265e0c63c89f53bb9ed2e060dd9c63614fe67d2aed809ac3056fd16"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.85",
+      "version": "0.1.86",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.85",
+  "version": "0.1.86",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-build/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-init/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-review/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/merge-checkpoint.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/skills/shared/references/harness/merge-checkpoint.md
+++ b/skills/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/skills/shared/references/harness/review-execution.md
+++ b/skills/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/skills/shared/references/harness/status-surface-contract.md
+++ b/skills/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/skills/shared/references/harness/status-surface.md
+++ b/skills/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/skills/shared/scripts/loom_status.py
+++ b/skills/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],

--- a/src/skills/shared/references/harness/merge-checkpoint.md
+++ b/src/skills/shared/references/harness/merge-checkpoint.md
@@ -34,6 +34,7 @@
 - test evidence
 - fresh verification evidence 的 `head_sha` / 范围 / 恢复摘要绑定
 - 运行时证据或 `not_applicable` 声明
+- `budget_risk` 摘要
 - 风险与回滚边界
 - 未决阻断项
 - 当前 head 是否仍在批准范围内
@@ -99,6 +100,12 @@
   - 退回前序 gate，重新做范围与方向收口
 - GitHub controlled merge 的 required checks / protection / ruleset 不满足
   - 回到宿主控制面补齐强制条件；Loom 只阻断，不越权代做 merge
+
+`budget_risk` 只作为 advisory evidence：
+
+- 高风险 budget 可以进入 merge gate 摘要，提醒后续 controlled merge / closeout 消费
+- 缺失或 unavailable budget 不得进入 `missing_inputs`
+- advisory budget 不得单独把 merge gate 改成 block 或 fallback
 
 ## 5. 边界约束
 

--- a/src/skills/shared/references/harness/review-execution.md
+++ b/src/skills/shared/references/harness/review-execution.md
@@ -98,11 +98,26 @@ Context pack 至少包含：
 - `review_path`
 - `current_head`
 - `validation_summary`
+- `budget_risk`
 - `history_available`
 - `recent_findings`
 - `repeated_blocker_signal`
 
 `recent_findings` 从可读的历史 review record 与 `.loom/runtime/review/<item>/*/normalized-findings.json` 投影而来，只保留 finding id、summary、severity、disposition、reviewed head、validation summary 和 source locator。
+
+`budget_risk` 是从 `github_control_plane.api_snapshot.budget` 派生的 provider-neutral 风险摘要，schema 为 `loom-execution-budget-risk/v1`。它至少暴露：
+
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+
+该字段在 v0.9.0 中只作为 advisory review input：
+
+- 高风险 budget 可以提示 reviewer 关注 retry / request / token 压力
+- 缺失或 unavailable budget 只说明预算读面不可用
+- 不得因为 budget risk 单独改变 review `decision`
 
 `repeated_blocker_signal` 的 schema 为 `loom-repeated-blocker-signal/v1`。它在 v0.8.0 中只作为 advisory evidence：
 
@@ -144,6 +159,8 @@ review record 至少应包含：
 - `blocking_issues` / `follow_ups` 只是从 `findings` 投影出的兼容字段，不构成第二真相源
 - `consumed_inputs.engine_adapter`、`consumed_inputs.engine_evidence`、`consumed_inputs.normalized_findings`
   - 只记录 evidence 来源，不构成第二 authored truth
+- `consumed_inputs.budget_risk`
+  - 只记录 review 消费的 budget risk 摘要，不构成第二 authored truth，也不覆盖 review decision
 - `consumed_inputs.behavior_evidence` 与 `consumed_inputs.test_evidence`
   - 只记录 review 消费的证据 locator / 摘要 / fresh 绑定，不构成第二 authored truth
 

--- a/src/skills/shared/references/harness/status-surface-contract.md
+++ b/src/skills/shared/references/harness/status-surface-contract.md
@@ -165,7 +165,22 @@
 
 `dimensions[*].id` 必须限定为 `turns`、`tokens`、`requests`、`retries`、`time_window`，每项只能保留 `unit`、`used`、`limit`、`remaining`、`risk`、`source` 中的稳定字段。缺失预算时可输出 `not_applicable` 或 `unavailable`，其 `enforcement` 必须是 `advisory`。
 
-### 3.7.2 `execution_failure`
+### 3.7.2 `execution_budget_risk`
+
+状态面必须展示从 `execution_budget` 派生的 provider-neutral 风险摘要：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`: `present` / `not_applicable` / `unavailable`
+- `enforcement`: `advisory`
+- `highest_risk`: `none` / `low` / `medium` / `high` / `unknown`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+该字段组只说明“当前预算是否显示风险压力”，供 review / merge-ready / closeout 消费；不得把 advisory budget risk 直接提升为 gate blocker。
+
+### 3.7.3 `execution_failure`
 
 - `schema_version`: `loom-execution-failure/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`
@@ -176,7 +191,7 @@
 
 该字段组只消费最近 `execution_attempt` evidence，不创建 scheduler state，也不单独阻断 merge。
 
-### 3.7.3 `retry_evidence`
+### 3.7.4 `retry_evidence`
 
 - `schema_version`: `loom-retry-evidence/v1`
 - `status`: `present` / `not_applicable` / `stale` / `missing` / `invalid`

--- a/src/skills/shared/references/harness/status-surface.md
+++ b/src/skills/shared/references/harness/status-surface.md
@@ -41,6 +41,12 @@
   - 从 host binding surface 派生
 - `github`
   - 从 host / control-plane mirror 派生
+- `execution_budget`
+  - 从 `github_control_plane.api_snapshot.budget` 派生
+  - 仅作 advisory evidence，不作为 gate 阻断条件
+- `execution_budget_risk`
+  - 从 `execution_budget` 派生 provider-neutral 风险摘要
+  - 仅作 advisory evidence，不作为 gate 阻断条件
 - retained host / repo-native result
   - 作为 evidence provenance 或 gate 前置结果派生
 - `taxonomy`
@@ -103,6 +109,7 @@ Approval / sandbox policy 也只能派生读取：
 - TDD 内环测试或等价检查的证据覆盖状态
 - fresh verification evidence 的 `head_sha` / 范围 / 摘要绑定
 - execution_budget 报告（`status` 为 `not_applicable`/`unavailable` 时不阻断）
+- execution_budget risk 摘要（`highest_risk = high` 时可提示 merge / review 风险，但不阻断）
 - 最近 execution failure 分类（只作风险输入）
 - retry evidence 摘要
 - dynamic tool availability 与 failure summary
@@ -123,6 +130,19 @@ Approval / sandbox policy 也只能派生读取：
 - `adapter_evidence_locator`
 
 `status` 为 `not_applicable` 或 `unavailable` 时仍为 advisory 证据，不得作为 merge-ready 的缺失输入 blocking 条件。
+
+状态面还应派生 `execution_budget_risk`：
+
+- `schema_version`: `loom-execution-budget-risk/v1`
+- `status`
+- `enforcement`
+- `highest_risk`
+- `risk_dimensions`
+- `summary`
+- `budget_summary`
+- `provenance`
+
+其中 `highest_risk = high` 只表示预算风险应被 review / merge-ready / closeout 消费，不表示 Loom 自动阻断当前 gate。
 
 ## 4.1 execution_failure
 

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -114,6 +114,15 @@ LOOM_EXECUTION_BUDGET_ENFORCEMENT = "advisory"
 LOOM_EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 LOOM_EXECUTION_BUDGET_DIMENSION_IDS = {"turns", "tokens", "requests", "retries", "time_window"}
 LOOM_EXECUTION_BUDGET_DIMENSION_FIELDS = ("id", "unit", "used", "limit", "remaining", "risk", "source")
+LOOM_EXECUTION_BUDGET_RISK_SCHEMA = "loom-execution-budget-risk/v1"
+LOOM_EXECUTION_BUDGET_RISK_LEVELS = {"none", "low", "medium", "high", "unknown"}
+LOOM_EXECUTION_BUDGET_RISK_RANK = {
+    "unknown": -1,
+    "none": 0,
+    "low": 1,
+    "medium": 2,
+    "high": 3,
+}
 
 
 def normalize_execution_budget_dimensions(raw_dimensions: object) -> list[dict[str, Any]]:
@@ -146,12 +155,15 @@ def execution_budget_payload(
     enforcement: str = LOOM_EXECUTION_BUDGET_ENFORCEMENT,
 ) -> dict[str, Any]:
     normalized_status = status if status in LOOM_EXECUTION_BUDGET_STATUS else "not_applicable"
+    normalized_dimensions = normalize_execution_budget_dimensions(dimensions or [])
+    if normalized_status != "present":
+        normalized_dimensions = []
     return {
         "schema_version": LOOM_EXECUTION_BUDGET_SCHEMA,
         "status": normalized_status,
         "enforcement": enforcement,
         "summary": str(summary).strip() or f"execution budget status is {normalized_status}",
-        "dimensions": normalize_execution_budget_dimensions(dimensions or []),
+        "dimensions": normalized_dimensions,
         "provenance": provenance or {"source": "github_host"},
         "adapter_evidence_locator": str(adapter_evidence_locator) if adapter_evidence_locator else "",
     }
@@ -194,6 +206,61 @@ def normalize_execution_budget_payload(
             else LOOM_EXECUTION_BUDGET_ENFORCEMENT
         ),
     )
+
+
+def normalize_execution_budget_risk_level(raw_risk: object) -> str:
+    if isinstance(raw_risk, str):
+        normalized = raw_risk.strip().lower()
+        if normalized in LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+            return normalized
+    return "unknown"
+
+
+def derive_execution_budget_risk(raw_budget: object) -> dict[str, Any]:
+    budget = normalize_execution_budget_payload(raw_budget)
+    status = budget.get("status")
+    enforcement = budget.get("enforcement")
+    dimensions = budget.get("dimensions") if isinstance(budget.get("dimensions"), list) else []
+
+    highest_risk = "none"
+    risk_dimensions: list[str] = []
+    for dimension in dimensions:
+        if not isinstance(dimension, dict):
+            continue
+        risk_level = normalize_execution_budget_risk_level(dimension.get("risk"))
+        if risk_level not in {"low", "medium", "high"}:
+            continue
+        dimension_id = dimension.get("id")
+        if isinstance(dimension_id, str):
+            risk_dimensions.append(dimension_id)
+        if LOOM_EXECUTION_BUDGET_RISK_RANK[risk_level] > LOOM_EXECUTION_BUDGET_RISK_RANK[highest_risk]:
+            highest_risk = risk_level
+
+    risk_dimensions = list(dict.fromkeys(risk_dimensions))
+    if status != "present":
+        highest_risk = "none"
+        risk_dimensions = []
+        summary = f"execution budget is {status}; budget risk remains advisory and non-blocking"
+    elif not risk_dimensions:
+        summary = "execution budget is present with no declared elevated risk dimensions; budget risk remains advisory"
+    else:
+        dimension_summary = ", ".join(risk_dimensions)
+        summary = (
+            f"execution budget reports {highest_risk} advisory risk across {dimension_summary}; "
+            "review and merge-ready may consume it as evidence only"
+        )
+
+    return {
+        "schema_version": LOOM_EXECUTION_BUDGET_RISK_SCHEMA,
+        "status": status,
+        "enforcement": enforcement,
+        "highest_risk": highest_risk,
+        "risk_dimensions": risk_dimensions,
+        "summary": summary,
+        "budget_summary": budget.get("summary"),
+        "adapter_evidence_locator": budget.get("adapter_evidence_locator"),
+        "provenance": budget.get("provenance") if isinstance(budget.get("provenance"), dict) else {"source": "github_host"},
+    }
 
 
 def local_worker_backend_contract() -> dict[str, object]:

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -281,6 +281,17 @@ EXECUTION_BUDGET_FIXTURE_SCHEMA = "loom-execution-budget-fixtures/v1"
 EXECUTION_BUDGET_STABLE_FIELDS = {"schema_version", "status", "enforcement", "summary", "dimensions", "provenance", "adapter_evidence_locator"}
 EXECUTION_BUDGET_DIMENSION_FIELDS = {"id", "unit", "used", "limit", "remaining", "risk", "source"}
 EXECUTION_BUDGET_DIMENSION_IDS = set(governance_surface_module.LOOM_EXECUTION_BUDGET_DIMENSION_IDS)
+EXECUTION_BUDGET_RISK_STABLE_FIELDS = {
+    "schema_version",
+    "status",
+    "enforcement",
+    "highest_risk",
+    "risk_dimensions",
+    "summary",
+    "budget_summary",
+    "adapter_evidence_locator",
+    "provenance",
+}
 EXECUTION_BUDGET_STATUS = {"present", "not_applicable", "unavailable"}
 EXECUTION_FAILURE_FIXTURE_SCHEMA = "loom-execution-failure-fixtures/v1"
 RETRY_EVIDENCE_FIXTURE_SCHEMA = "loom-retry-evidence-fixtures/v1"
@@ -2151,6 +2162,41 @@ def require_review_record_contract(
                 failures.append(Failure(category, f"{context} review finding disposition must include non-empty `summary`"))
 
 
+def require_execution_budget_risk_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must include `budget_risk` as an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA:
+        failures.append(
+            Failure(
+                category,
+                f"{context} budget_risk schema_version must be `{governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_SCHEMA}`",
+            )
+        )
+    extra_fields = set(payload.keys()) - EXECUTION_BUDGET_RISK_STABLE_FIELDS
+    if extra_fields:
+        failures.append(Failure(category, f"{context} budget_risk must stay in stable field vocabulary"))
+    if payload.get("status") not in governance_surface_module.LOOM_EXECUTION_BUDGET_STATUS:
+        failures.append(Failure(category, f"{context} budget_risk status must stay within the stable contract"))
+    if payload.get("enforcement") != "advisory":
+        failures.append(Failure(category, f"{context} budget_risk enforcement must stay `advisory`"))
+    if payload.get("highest_risk") not in governance_surface_module.LOOM_EXECUTION_BUDGET_RISK_LEVELS:
+        failures.append(Failure(category, f"{context} budget_risk highest_risk must stay within the stable contract"))
+    risk_dimensions = payload.get("risk_dimensions")
+    if not isinstance(risk_dimensions, list):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must be a list"))
+    elif any(not isinstance(item, str) or item not in EXECUTION_BUDGET_DIMENSION_IDS for item in risk_dimensions):
+        failures.append(Failure(category, f"{context} budget_risk risk_dimensions must use stable dimension ids"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} budget_risk must include non-empty `summary`"))
+
+
 def require_review_run_payload(
     failures: list[Failure],
     *,
@@ -3817,6 +3863,7 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`loom_status` must report `command: status`"))
             governance_status = payload.get("governance_status")
             execution_budget = payload.get("execution_budget")
+            execution_budget_risk = payload.get("execution_budget_risk")
             execution_failure = payload.get("execution_failure")
             retry_evidence = payload.get("retry_evidence")
             if not isinstance(execution_budget, dict):
@@ -3850,6 +3897,12 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                             "`loom_status` should not block merge-ready gate on advisory execution budget status",
                         )
                     )
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`loom_status`",
+                payload=execution_budget_risk,
+            )
             if not isinstance(execution_failure, dict):
                 failures.append(Failure("daily-execution-cli", "`loom_status` must include `execution_failure`"))
             else:
@@ -4282,9 +4335,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `command: flow`"))
             if payload.get("operation") != "review":
                 failures.append(Failure("daily-execution-cli", "`flow review` must report `operation: review`"))
-            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "state_check", "runtime_evidence", "build_checkpoint", "review", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow review` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow review`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -4448,9 +4507,15 @@ def check_daily_execution_cli(root: Path) -> list[Failure]:
                         "`flow merge-ready` fallback must be `null` or a known checkpoint",
                     )
                 )
-            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements"):
+            for key in ("item", "runtime_state", "execution_ledger", "state_check", "runtime_evidence", "build_checkpoint", "merge_checkpoint", "current_checkpoint", "repo_specific_requirements", "budget_risk"):
                 if not isinstance(payload.get(key), dict):
                     failures.append(Failure("daily-execution-cli", f"`flow merge-ready` must include `{key}`"))
+            require_execution_budget_risk_payload(
+                failures,
+                category="daily-execution-cli",
+                context="`flow merge-ready`",
+                payload=payload.get("budget_risk"),
+            )
             require_runtime_state_payload(
                 failures,
                 category="daily-execution-cli",
@@ -10600,6 +10665,28 @@ def check_execution_budget_fixture_contract(root: Path) -> list[Failure]:
         locator = payload.get("adapter_evidence_locator")
         if locator is not None and not isinstance(locator, str):
             failures.append(Failure(category, f"`{context}` budget adapter_evidence_locator must be a string when present"))
+
+        derived_risk = governance_surface_module.derive_execution_budget_risk(payload)
+        if derived_risk.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` derived budget risk must remain advisory"))
+        expected_highest_risk = expect.get("highest_risk")
+        if expected_highest_risk is not None and derived_risk.get("highest_risk") != expected_highest_risk:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived highest_risk `{derived_risk.get('highest_risk')}` != expected `{expected_highest_risk}`",
+                )
+            )
+        expected_risk_dimensions = expect.get("risk_dimensions")
+        if isinstance(expected_risk_dimensions, list) and derived_risk.get("risk_dimensions") != expected_risk_dimensions:
+            failures.append(
+                Failure(
+                    category,
+                    f"`{context}` derived risk_dimensions {derived_risk.get('risk_dimensions')} != expected {expected_risk_dimensions}",
+                )
+            )
+        if status == "present" and derived_risk.get("highest_risk") == "high" and payload.get("enforcement") != "advisory":
+            failures.append(Failure(category, f"`{context}` high-risk budget must not bypass advisory enforcement"))
 
     return failures
 

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -31,7 +31,11 @@ from fact_chain_support import (
     path_boundary_missing_details,
     resolve_repo_relative_path,
 )
-from governance_surface import build_governance_surface, workspace_lifecycle_expectations
+from governance_surface import (
+    build_governance_surface,
+    derive_execution_budget_risk,
+    workspace_lifecycle_expectations,
+)
 from runtime_paths import shared_asset, shared_script
 from runtime_state import detect_runtime_state
 
@@ -3251,6 +3255,18 @@ def review_context_finding_entry(
 
 
 def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict[str, Any]:
+    governance_surface = build_governance_surface(context["target_root"])
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     recent_findings: list[dict[str, Any]] = []
     review_record, _, review_errors = load_review_record(context["target_root"], context["item_id"], review_path)
     if review_record and not review_errors:
@@ -3321,6 +3337,7 @@ def build_review_context_pack(context: dict[str, Any], review_path: str) -> dict
         "history_available": bool(recent_findings),
         "history_policy": "not_applicable when no prior review record or normalized findings are available",
         "recent_findings": recent_findings[-20:],
+        "budget_risk": budget_risk,
         "repeated_blocker_signal": {
             "schema_version": REPEATED_BLOCKER_SIGNAL_SCHEMA,
             "result": "present" if candidates else "absent",
@@ -3490,6 +3507,17 @@ def build_review_flow_payload(
 
     build_payload = checkpoint_payload("build", context)
     governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     surface_name = "review"
     repo_specific_requirements = repo_specific_requirements_payload(
         governance_surface.get("repo_interface"),
@@ -3644,6 +3672,7 @@ def build_review_flow_payload(
             "checks": state_payload["checks"],
         },
         "runtime_evidence": runtime_fields,
+        "budget_risk": budget_risk,
         "build_checkpoint": {
             "result": build_payload["result"],
             "summary": build_payload["summary"],
@@ -3922,6 +3951,7 @@ def run_default_review_engine(
             "engine_profile": engine_profile,
             "context_pack": relative_to_root(context_pack_path, context["target_root"]),
             "normalized_findings": relative_to_root(findings_path, context["target_root"]),
+            "budget_risk": context_pack.get("budget_risk"),
         },
     }
 
@@ -4684,6 +4714,7 @@ def build_default_review_prompt(
     if not recent_lines:
         recent_lines = ["- not_applicable: no prior review findings were available."]
     repeated_signal = context_pack.get("repeated_blocker_signal") if isinstance(context_pack.get("repeated_blocker_signal"), dict) else {}
+    budget_risk = context_pack.get("budget_risk") if isinstance(context_pack.get("budget_risk"), dict) else {}
     repeated_candidates = repeated_signal.get("candidates") if isinstance(repeated_signal.get("candidates"), list) else []
     repeated_lines = [
         f"- {candidate.get('repeat_key')}: count={candidate.get('count')}, sources={', '.join(str(source) for source in candidate.get('sources', []))}"
@@ -4735,6 +4766,13 @@ def build_default_review_prompt(
             "Recent Review Context Pack：",
             f"- Schema: {context_pack.get('schema_version')}",
             f"- History Available: {context_pack.get('history_available')}",
+            (
+                "- Budget Risk: "
+                f"{budget_risk.get('highest_risk', 'none')} "
+                f"(status={budget_risk.get('status', 'not_applicable')}, "
+                f"enforcement={budget_risk.get('enforcement', 'advisory')})"
+            ),
+            f"- Budget Risk Summary: {budget_risk.get('summary', 'not_applicable')}",
             f"- Repeated Blocker Signal: {repeated_signal.get('result', 'absent')} ({repeated_signal.get('enforcement', 'advisory')})",
             "Recent Findings:",
             *recent_lines,
@@ -5174,7 +5212,20 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     review_record: dict[str, Any] | None = None
     review_path: str | None = None
     spec_review: dict[str, Any] | None = None
+    budget_risk: dict[str, Any] | None = None
     if stage == "merge":
+        governance_surface = build_governance_surface(context["target_root"])
+        github_control_plane = (
+            governance_surface.get("github_control_plane")
+            if isinstance(governance_surface, dict)
+            else None
+        )
+        execution_budget = (
+            github_control_plane.get("api_snapshot", {}).get("budget")
+            if isinstance(github_control_plane, dict)
+            else None
+        )
+        budget_risk = derive_execution_budget_risk(execution_budget)
         pr_template, pr_template_errors = check_pr_template(context["target_root"])
         if pr_template_errors:
             missing_inputs.extend(pr_template_errors)
@@ -5235,6 +5286,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
     else:
         fallback_label = fallback_to or "admission"
         summary = f"{stage} checkpoint cannot proceed from the current state; fall back to `{fallback_label}`."
+    if stage == "merge" and isinstance(budget_risk, dict) and budget_risk.get("status") == "present":
+        summary = f"{summary} Budget risk remains advisory: {budget_risk.get('summary')}"
 
     payload = {
         "command": "checkpoint",
@@ -5275,6 +5328,8 @@ def checkpoint_payload(stage: str, context: dict[str, Any]) -> dict[str, Any]:
         }
     if spec_review is not None:
         payload["spec_review"] = spec_review
+    if budget_risk is not None:
+        payload["budget_risk"] = budget_risk
     return payload
 
 
@@ -8739,6 +8794,7 @@ def handle_review(args: argparse.Namespace) -> int:
                     "runtime_state": flow_payload.get("runtime_state"),
                     "state_check": flow_payload.get("state_check"),
                     "runtime_evidence": flow_payload.get("runtime_evidence"),
+                    "budget_risk": flow_payload.get("budget_risk"),
                     "build_checkpoint": flow_payload.get("build_checkpoint"),
                     "review": review_surface,
                     "spec_review": flow_payload.get("spec_review"),
@@ -8796,6 +8852,7 @@ def handle_review(args: argparse.Namespace) -> int:
                 "runtime_state": flow_payload.get("runtime_state"),
                 "state_check": flow_payload.get("state_check"),
                 "runtime_evidence": flow_payload.get("runtime_evidence"),
+                "budget_risk": flow_payload.get("budget_risk"),
                 "build_checkpoint": flow_payload.get("build_checkpoint"),
                 "review": review_surface,
                 "spec_review": flow_payload.get("spec_review"),
@@ -8909,6 +8966,18 @@ def handle_review(args: argparse.Namespace) -> int:
         )
 
     blocking_issues, follow_ups = compat_lists_from_findings(findings)
+    governance_surface = build_governance_surface(target_root)
+    github_control_plane = (
+        governance_surface.get("github_control_plane")
+        if isinstance(governance_surface, dict)
+        else None
+    )
+    execution_budget = (
+        github_control_plane.get("api_snapshot", {}).get("budget")
+        if isinstance(github_control_plane, dict)
+        else None
+    )
+    budget_risk = derive_execution_budget_risk(execution_budget)
     review_payload = {
         "schema_version": "loom-review/v1",
         "item_id": context["item_id"],
@@ -8927,6 +8996,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "recovery_entry": str(context["report"]["fact_chain"]["entry_points"]["recovery_entry"]),
             "status_surface": str(context["report"]["fact_chain"]["entry_points"]["status_surface"]),
             "build_checkpoint": build_payload["result"],
+            "budget_risk": budget_risk,
             "engine_adapter": args.engine_adapter,
             "engine_evidence": args.engine_evidence,
             "normalized_findings": args.normalized_findings,
@@ -8975,6 +9045,7 @@ def handle_review(args: argparse.Namespace) -> int:
             "missing_inputs": [],
             "fallback_to": None,
             "review": {"path": review_path, "record": verified_record},
+            "budget_risk": budget_risk,
             "build_checkpoint": {
                 "result": build_payload["result"],
                 "summary": build_payload["summary"],
@@ -10221,6 +10292,11 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "missing_inputs": build_payload["missing_inputs"],
                         "fallback_to": build_payload["fallback_to"],
                     },
+                    "budget_risk": derive_execution_budget_risk(
+                        governance_surface.get("github_control_plane", {}).get("api_snapshot", {}).get("budget")
+                        if isinstance(governance_surface.get("github_control_plane"), dict)
+                        else None
+                    ),
                     "review": review_payload,
                     "repo_specific_requirements": repo_specific_requirements,
                     "current_checkpoint": {
@@ -10254,6 +10330,7 @@ def handle_flow(args: argparse.Namespace) -> int:
                         "fallback_to": merge_payload["fallback_to"],
                         "pr_template": merge_payload.get("pr_template"),
                     },
+                    "budget_risk": merge_payload.get("budget_risk"),
                     "spec_review": merge_payload.get("spec_review"),
                     "current_checkpoint": {
                         "raw": context["current_checkpoint_raw"],

--- a/src/skills/shared/scripts/loom_status.py
+++ b/src/skills/shared/scripts/loom_status.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from governance_surface import build_governance_surface
+from governance_surface import build_governance_surface, derive_execution_budget_risk, normalize_execution_budget_payload
 from loom_flow import (
     checkpoint_payload,
     closeout_payload,
@@ -440,16 +440,13 @@ def main(argv: list[str]) -> int:
         if isinstance(github_control_plane, dict)
         else None
     )
-    if not isinstance(execution_budget, dict):
-        execution_budget = {
-            "schema_version": "loom-execution-budget/v1",
-            "status": "not_applicable",
-            "enforcement": "advisory",
-            "summary": "execution budget is not available for this execution path",
-            "dimensions": [],
-            "provenance": {"source": "github_control_plane"},
-            "adapter_evidence_locator": "",
-        }
+    execution_budget = normalize_execution_budget_payload(
+        execution_budget,
+        fallback_status="not_applicable",
+        fallback_summary="execution budget is not available for this execution path",
+        fallback_provenance={"source": "github_control_plane"},
+    )
+    execution_budget_risk = derive_execution_budget_risk(execution_budget)
     github_status, github_errors = github_status_payload(
         target_root,
         issue_number=args.issue,
@@ -533,6 +530,7 @@ def main(argv: list[str]) -> int:
             "tool_availability": tool_availability,
             "policy_readiness": policy_readiness,
             "execution_budget": execution_budget,
+            "execution_budget_risk": execution_budget_risk,
             "blocking_failures": report_blocking_failures(context["report"]),
             "item": {
                 "id": context["item_id"],


### PR DESCRIPTION
## Summary
- wire provider-neutral `budget_risk` derived from `loom-execution-budget/v1` into review, merge-ready, and status read surfaces
- keep `enforcement=advisory` fixed and make sure high-risk budget evidence never becomes a budget-only blocker
- refresh fixtures, docs, generated skill/runtime surfaces, installer payload version, and `examples/new-project` bootstrap carriers

## Validation
- [x] `python3 -m py_compile tools/loom_flow.py tools/loom_status.py tools/loom_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- [x] `python3 tools/skills_surface.py check`
- [x] `python3 tools/version_surface_check.py`
- [x] `npm --prefix packages/loom-installer test`
- [x] `npm pack --dry-run` (in `packages/loom-installer`)
- [x] `make check`

## Risks And Follow-ups
- Risks: advisory budget risk now appears in review and merge summaries; downstream consumers must continue treating it as evidence only.
- Follow-ups: close `#590/#591/#592` and `#589` with Delivery Evidence after merge.

## Related Work
- Phase: #532
- FR: #589
- Work Items: #590, #591, #592
