### PR TITLE
feat(live): 增加 v0.10.0 live smoke foundation

### DIFF
--- a/docs/evidence/live-smoke-profile.md
+++ b/docs/evidence/live-smoke-profile.md
@@ -1,0 +1,82 @@
+# Live Smoke Profile
+
+本文件定义 v0.10.0 的 adopted-repo live smoke foundation。
+
+它回答的不是“某个 adopted repo 是否已经通过所有治理面”，而是“Loom 是否能用真实 adopted repo 或 versioned prior-pass evidence 产出可消费的 `orchestration-live` confidence input”。
+
+## Command
+
+`python3 tools/loom_flow.py live-smoke run --target <repo> [--item <id>] [--dry-run] [--include-blocking-shadow]`
+
+`python3 tools/loom_flow.py live-smoke replay --prior-evidence <path>`
+
+输出 schema 固定为 `loom-live-smoke/v1`。
+
+## Run Contract
+
+`run` 必须记录：
+
+- target path
+- branch / commit / worktree
+- planned commands
+- command reports
+- result
+- date
+- release interpretation
+
+默认 command set：
+
+- target / worktree availability check
+- `governance-profile status`
+- `governance-profile upgrade-plan`
+- `runtime-parity validate`
+- `shadow-parity` validation-only
+- `flow resume --item <id>`
+
+`shadow-parity --blocking` 只能通过显式 `--include-blocking-shadow` 加入 command set。单个 adopted repo smoke 不得被描述为 blocking shadow parity 升级证据。
+
+## Unavailable Evidence
+
+若 adopted repo target、worktree、宿主、路径或凭证不可用，`run` 必须输出 explicit unavailable evidence，而不是静默 pass。
+
+最小 unavailable evidence 字段：
+
+- target path
+- commands that were planned
+- result
+- missing precondition
+- date
+- release interpretation
+
+这类 unavailable evidence 是 non-blocking confidence input，`fallback_to` 为 `live-smoke-retry-or-record-unavailable`。
+
+## Replay Contract
+
+`replay` 只读取 versioned evidence，不执行 adopted-repo commands。
+
+它至少要读取：
+
+- prior evidence path
+- prior evidence status
+- recorded target family
+- recorded branch / commit / worktree when present
+- recorded command set
+- recorded release interpretation
+
+当前 v0.10.0 允许 replay v0.7 prior-pass evidence，例如 [validation-v0.7-live-orchestration-smoke.md](./validations/validation-v0.7-live-orchestration-smoke.md)。
+
+## Result Semantics
+
+顶层 `result` 只允许：
+
+- `pass`
+- `warn`
+- `block`
+
+稳定语义：
+
+- target 不存在、路径 / 凭证不可用、profile-local live command failure：`warn`
+- replay evidence 缺失或不可读、subcommand JSON 不可读、runtime state 不一致：`block`
+- 全部 planned live checks 成功，或 prior-pass evidence replay 成功：`pass`
+
+`run` / `replay` 都不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate。

--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -1,6 +1,8 @@
 # Orchestration Conformance Profiles
 
-本文件定义 Loom v0.7.0 的 orchestration conformance profiles。
+本文件定义 Loom 的 orchestration conformance profiles。
+
+这些 profiles 最初冻结于 v0.7.0，并由后续版本继续扩展。
 
 这些 profiles 回答的是“当前 release 的编排能力是否可证明”，不得替代 governance maturity profile。
 
@@ -52,6 +54,8 @@ Extension 缺口不得污染 `orchestration-core` pass/fail。若某 adopted rep
 - 明确记录 target、branch/commit/worktree、命令、结果与日期
 - smoke 不可运行时，必须输出 explicit skip / unavailable evidence，说明缺少的宿主、路径、凭据或环境前置
 - live smoke 失败可以降低 release confidence，但不得自动替代 `orchestration-core` 的 blocking 判定
+
+当前 live smoke 的稳定命令与 evidence 形态见 [live-smoke-profile.md](./live-smoke-profile.md)。
 
 Live profile 的目标是防止 release 只在模型内自洽；它提供真实反馈证据，但不把外部仓库可用性变成每个普通 PR 的默认阻断条件。
 

--- a/docs/evidence/v0.10.0-release-readiness.md
+++ b/docs/evidence/v0.10.0-release-readiness.md
@@ -1,0 +1,45 @@
+# v0.10.0 Release Readiness
+
+本文件定义 v0.10.0 如何消费 live smoke foundation。
+
+它延续 `orchestration-core` / `orchestration-extension` / `orchestration-live` 三分法，不把 adopted-repo live smoke 升级成 core blocking gate。
+
+## Release Inputs
+
+v0.10.0 release readiness 必须区分：
+
+- `orchestration-core`
+  - blocking input
+- `orchestration-extension`
+  - profile-local input
+- `orchestration-live`
+  - confidence input
+
+## Live Smoke Consumption
+
+release readiness 读取 `loom-live-smoke/v1` 时，至少要区分：
+
+- fresh live smoke `pass`
+- explicit unavailable evidence
+- profile-local failure
+- replayed prior-pass evidence
+- explicit blocking opt-in command presence
+
+稳定解释：
+
+- live smoke `pass`：提高 release confidence，但不替代 core pass
+- unavailable evidence：保留风险并允许继续收口
+- profile-local failure：降低 release confidence，但不自动阻断 core
+- replayed prior-pass evidence：允许作为 confidence input，被明确标记为 replay，而不是 fresh run
+- explicit blocking opt-in：只记录为额外 evidence，不等于 blocking upgrade judgment
+
+## Blocking Boundary
+
+release readiness 不得因为以下情况直接把 core 变成 `block`：
+
+- adopted repo target 不存在
+- local worktree / credentials 不可用
+- validation-only shadow parity mismatch
+- 单个 adopted repo smoke 失败
+
+只有 core gate 自身失败，或 live smoke command output 不再满足 `loom-live-smoke/v1` 稳定合同，才允许把 release coordination 判为 `block`。

--- a/docs/evidence/validations/validation-v0.10-live-smoke-foundation.md
+++ b/docs/evidence/validations/validation-v0.10-live-smoke-foundation.md
@@ -1,0 +1,48 @@
+# v0.10.0 Live Smoke Foundation
+
+本记录归档 `#597` 的 live smoke foundation 验证结果。
+
+它证明：
+
+- `python3 tools/loom_flow.py live-smoke run --target <repo>` 能产出 `loom-live-smoke/v1`
+- target 不存在时会产出 explicit unavailable evidence
+- `python3 tools/loom_flow.py live-smoke replay --prior-evidence <path>` 能消费 versioned prior-pass evidence
+- `orchestration-live` 仍保持 validation-only / confidence-input 边界
+
+## Commands
+
+```bash
+python3 tools/loom_flow.py live-smoke run --target /tmp/loom-missing-live-target --item INIT-0001
+python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md
+python3 tools/loom_flow.py live-smoke run --target /Users/mc/dev/syvert --item INIT-0001
+python3 tools/skills_surface.py check
+python3 tools/loom_check.py
+make check
+```
+
+## Result
+
+- Date: 2026-05-09
+- Missing target run result: `warn`
+- Missing target evidence:
+  - target path unavailable
+  - `fallback_to: live-smoke-retry-or-record-unavailable`
+  - release interpretation: explicit unavailable evidence is a non-blocking confidence input and does not silently pass
+- Replay result: `pass`
+- Replay evidence:
+  - prior evidence path: `docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md`
+  - prior status: `versioned-prior-pass`
+  - replay does not rerun adopted-repo commands
+- Local adopted repo run result: `warn`
+- Local adopted repo target: `/Users/mc/dev/syvert`
+- Local adopted repo warnings:
+  - `governance-profile upgrade-plan` reports missing `basic_host_binding` and `closeout_reconciliation_read`
+  - `runtime-parity validate` reports `.loom/progress/INIT-0001.md` missing `Execution Ledger`
+  - `shadow-parity` reports unreadable repo interop carrier fields
+  - `flow resume` reports the same fact-chain gap
+- `python3 tools/skills_surface.py check`: `pass`
+- `python3 tools/loom_check.py`: `pass`
+- `make check`: `pass`
+- Release interpretation: profile-local live smoke failure lowers release confidence but does not replace `orchestration-core` gate results.
+- Remaining risk:
+  - current live target still exposes repo-local adoption gaps, so v0.10.0 currently proves real feedback wiring, not a full adopted-repo green path

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "78c5d1e85a1d49046b015d0addb0eb35310d607fc486b576f2c76fca880f8558"
+      "sha256": "35ab222a0e17f3f26fa06263966faec63378401d7c590eaed6a5a8f87228dce9"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "703503e23265e0c63c89f53bb9ed2e060dd9c63614fe67d2aed809ac3056fd16"
+      "sha256": "ed42b15973962d184f5ff69f0f663bc115834be31505f0a9bed75bbaaf463625"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "78c5d1e85a1d49046b015d0addb0eb35310d607fc486b576f2c76fca880f8558"
+      "sha256": "35ab222a0e17f3f26fa06263966faec63378401d7c590eaed6a5a8f87228dce9"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "703503e23265e0c63c89f53bb9ed2e060dd9c63614fe67d2aed809ac3056fd16"
+      "sha256": "ed42b15973962d184f5ff69f0f663bc115834be31505f0a9bed75bbaaf463625"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.87",
+      "version": "0.1.88",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -25,6 +25,9 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+
 TOP_LEVEL_DIRS = (
     "docs",
     "examples",
@@ -537,6 +540,15 @@ def run_command(
     )
 
 
+def command_timeout_seconds(args: list[str], requested_timeout_seconds: float | None) -> float:
+    if requested_timeout_seconds is not None:
+        return requested_timeout_seconds
+    normalized = [str(part) for part in args]
+    if "adopt" in normalized and "verify" in normalized:
+        return ADOPT_VERIFY_TIMEOUT_SECONDS
+    return DEFAULT_COMMAND_TIMEOUT_SECONDS
+
+
 def load_command_json(
     root: Path,
     args: list[str],
@@ -545,10 +557,11 @@ def load_command_json(
     env: dict[str, str] | None = None,
     timeout_seconds: float | None = None,
 ) -> tuple[dict[str, object] | None, str | None]:
+    timeout_seconds = command_timeout_seconds(args, timeout_seconds)
     try:
         result = run_command(root, args, cwd=cwd, env=env, timeout_seconds=timeout_seconds)
     except subprocess.TimeoutExpired:
-        return None, f"command timed out after {int(timeout_seconds or 0)}s"
+        return None, f"command timed out after {int(timeout_seconds)}s"
     if not result.stdout.strip():
         detail = "command produced no JSON output"
         if result.stderr.strip():
@@ -1819,6 +1832,113 @@ def require_runtime_parity_payload(
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} check `{check.get('name')}` must include `evidence`"))
+
+
+def require_live_smoke_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+    expected_operation: str,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != expected_operation:
+        failures.append(Failure(category, f"{context} must report `operation: {expected_operation}`"))
+    if payload.get("schema_version") != "loom-live-smoke/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-live-smoke/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "record-prior-evidence",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable live smoke contract"))
+    runtime_state = payload.get("runtime_state")
+    allowed_runtime_results = {"pass", "block"} if payload.get("result") == "block" else {"pass"}
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=runtime_state,
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results=allowed_runtime_results,
+    )
+    command_plan = payload.get("command_plan")
+    if not isinstance(command_plan, list) or not command_plan:
+        failures.append(Failure(category, f"{context} must include non-empty `command_plan`"))
+    else:
+        for index, step in enumerate(command_plan):
+            if not isinstance(step, dict):
+                failures.append(Failure(category, f"{context} command_plan[{index}] must be an object"))
+                continue
+            for field in ("id", "command", "description"):
+                value = step.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} command_plan[{index}] missing `{field}`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list) or not reports:
+        failures.append(Failure(category, f"{context} must include non-empty `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    live_smoke = payload.get("live_smoke")
+    if not isinstance(live_smoke, dict):
+        failures.append(Failure(category, f"{context} must include `live_smoke`"))
+    else:
+        if live_smoke.get("status") not in {"passed", "failed", "unavailable", "replayed", "dry_run"}:
+            failures.append(Failure(category, f"{context} live_smoke.status must stay within the stable contract"))
+        for field in ("executed_at", "release_interpretation"):
+            value = live_smoke.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} live_smoke must include non-empty `{field}`"))
+    if expected_operation == "run":
+        target = payload.get("target")
+        if not isinstance(target, dict):
+            failures.append(Failure(category, f"{context} run payload must include `target`"))
+        else:
+            if not isinstance(target.get("path"), str) or not target.get("path"):
+                failures.append(Failure(category, f"{context} target.path must be non-empty"))
+            if not isinstance(target.get("exists"), bool):
+                failures.append(Failure(category, f"{context} target.exists must be boolean"))
+        if payload.get("prior_evidence") is not None:
+            failures.append(Failure(category, f"{context} run payload must not include `prior_evidence`"))
+    else:
+        prior_evidence = payload.get("prior_evidence")
+        if not isinstance(prior_evidence, dict):
+            failures.append(Failure(category, f"{context} replay payload must include `prior_evidence`"))
+        else:
+            for field in ("path", "status"):
+                value = prior_evidence.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
 def require_github_binding_payload(
@@ -10036,6 +10156,163 @@ def check_orchestration_conformance_profiles(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+    docs = {
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-live-smoke/v1",
+            "versioned prior-pass evidence",
+            "explicit unavailable evidence",
+            "validation-only",
+            "shadow-parity --blocking",
+        ],
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "orchestration-core",
+            "orchestration-live",
+            "confidence input",
+            "profile-local failure",
+            "blocking opt-in",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-smoke-foundation.md": [
+            "live-smoke run",
+            "live-smoke replay",
+            "unavailable evidence",
+            "versioned prior-pass evidence",
+            "validation-only / confidence-input",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-smoke-foundation", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-smoke-foundation", f"`{relative}` must mention `{anchor}`"))
+
+    unavailable_payload = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "warn",
+        "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+        "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/missing-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/missing-live-target",
+            "exists": False,
+            "worktree": "/tmp/missing-live-target",
+            "git_branch": None,
+            "head_sha": None,
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/missing-live-target", "description": "Confirm the adopted-repo target path exists before running live smoke checks."},
+            {"id": "governance-profile-status", "command": "python3 tools/loom_flow.py governance-profile status --target /tmp/missing-live-target", "description": "Read the adopted repo governance maturity surface."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/missing-live-target",
+                "reported_command": "target-check",
+                "reported_result": "unavailable",
+                "result": "warn",
+                "summary": "adopted-repo target root is unavailable.",
+                "missing_inputs": ["adopted repo target is unavailable: /tmp/missing-live-target"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            }
+        ],
+        "live_smoke": {
+            "status": "unavailable",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "explicit unavailable evidence is a non-blocking confidence input and does not silently pass.",
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="unavailable-live-smoke",
+        payload=unavailable_payload,
+        expected_operation="run",
+    )
+
+    replay_payload = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": "loom-live-smoke/v1",
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "runtime_state": unavailable_payload["runtime_state"],
+        "command_plan": [
+            {"id": "prior-evidence-read", "command": "python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md", "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands."}
+        ],
+        "reports": [
+            {
+                "id": "prior-evidence",
+                "attempted": False,
+                "command": "read docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+                "reported_command": "prior-evidence",
+                "reported_result": "versioned-prior-pass",
+                "result": "pass",
+                "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        ],
+        "live_smoke": {
+            "status": "replayed",
+            "executed_at": "2026-05-09T00:00:00Z",
+            "release_interpretation": "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands.",
+        },
+        "prior_evidence": {
+            "path": "docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md",
+            "status": "versioned-prior-pass",
+            "target_family": "Syvert-style strong governance adopted repo",
+            "smoke_branch": "chore/loom-phase-d-smoke-companion",
+            "smoke_commit": "9a7b2923b6ab39631d8a3eafc1be8e5090709b9d",
+            "smoke_worktree": "/Users/mc/dev/syvert-loom-phase-d-smoke",
+            "commands": [
+                "test -d /Users/mc/dev/syvert-loom-phase-d-smoke",
+                "python3 <loom_repo_root>/tools/loom_flow.py governance-profile status --target /Users/mc/dev/syvert-loom-phase-d-smoke",
+            ],
+        },
+    }
+    require_live_smoke_payload(
+        failures,
+        category="live-smoke-foundation",
+        context="replayed-live-smoke",
+        payload=replay_payload,
+        expected_operation="replay",
+    )
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11146,6 +11423,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_github_cli_budget(root))
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
+    failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11158,7 +11436,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 29
+    categories_checked = 30
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -113,6 +113,10 @@ DEFAULT_REVIEW_ENGINE_TIMEOUT_SECONDS = 120
 REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
+LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
+LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
+LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -496,6 +500,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     governance_profile.add_argument("--branch", help="GitHub branch name bound to the work item")
     governance_profile.add_argument("--sync", action="store_true", help="Preview host binding repairs; writes are intentionally disabled in this phase")
 
+    live_smoke = subparsers.add_parser(
+        "live-smoke",
+        help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
+    )
+    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
+    live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
+    live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
+    live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--include-blocking-shadow",
+        action="store_true",
+        help="Explicitly include shadow-parity --blocking in the smoke command set",
+    )
+
     flow = subparsers.add_parser("flow", help="Run a bundled high-frequency Loom flow")
     flow.add_argument("operation", choices=("build", "pre-review", "review", "spec-review", "resume", "handoff", "merge-ready"))
     flow.add_argument("--target", required=True, help="Target repository root")
@@ -542,6 +561,418 @@ def runtime_state_block_payload(
 
 def command_target(target_root: Path) -> str:
     return shlex.quote(str(target_root))
+
+
+def current_iso_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def discover_loom_flow_entrypoint() -> Path:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    if source_repo_root:
+        candidate = Path(source_repo_root).expanduser().resolve() / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        candidate = parent / "tools/loom_flow.py"
+        if candidate.exists():
+            return candidate
+    return current
+
+
+def live_smoke_command(args: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in [sys.executable, str(discover_loom_flow_entrypoint()), *args])
+
+
+def live_smoke_target_metadata(target_root: Path) -> dict[str, Any]:
+    return {
+        "path": str(target_root),
+        "exists": target_root.exists(),
+        "worktree": str(target_root),
+        "git_branch": git_branch(target_root),
+        "head_sha": git_head_sha(target_root),
+    }
+
+
+def live_smoke_release_interpretation(status: str) -> str:
+    if status == "passed":
+        return "fresh live smoke evidence raises release confidence and remains non-blocking by default."
+    if status == "replayed":
+        return "versioned prior-pass evidence can be consumed as release confidence input without rerunning adopted-repo commands."
+    if status == "dry_run":
+        return "dry-run only previews the live smoke command plan and does not create fresh adopted-repo evidence."
+    if status == "unavailable":
+        return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
+    return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before running live smoke checks.",
+        },
+        {
+            "id": "governance-profile-status",
+            "command": live_smoke_command(["governance-profile", "status", "--target", str(target_root)]),
+            "description": "Read the adopted repo governance maturity surface.",
+        },
+        {
+            "id": "governance-profile-upgrade-plan",
+            "command": live_smoke_command(["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+            "description": "Record upgrade requirements as live confidence input.",
+        },
+        {
+            "id": "runtime-parity",
+            "command": live_smoke_command(["runtime-parity", "validate", "--target", str(target_root)]),
+            "description": "Check Loom core runtime parity against the adopted repo surface.",
+        },
+        {
+            "id": "shadow-parity",
+            "command": live_smoke_command(["shadow-parity", "--target", str(target_root)]),
+            "description": "Read validation-only shadow parity without changing merge gates.",
+        },
+        {
+            "id": "flow-resume",
+            "command": live_smoke_command(["flow", "resume", "--target", str(target_root), "--item", item]),
+            "description": "Exercise resume flow on the adopted repo when the requested item exists.",
+        },
+    ]
+    if include_blocking_shadow:
+        plan.append(
+            {
+                "id": "shadow-parity-blocking",
+                "command": live_smoke_command(["shadow-parity", "--target", str(target_root), "--blocking"]),
+                "description": "Optional explicit blocking-mode shadow parity check; not sufficient blocking-upgrade evidence on its own.",
+            }
+        )
+    return plan
+
+
+def live_smoke_missing_inputs(messages: list[str]) -> list[str]:
+    return list(dict.fromkeys(message for message in messages if isinstance(message, str) and message))
+
+
+def live_smoke_target_check_report(target_root: Path) -> dict[str, Any]:
+    if target_root.exists():
+        return {
+            "id": "target-check",
+            "attempted": True,
+            "command": f"test -d {command_target(target_root)}",
+            "reported_command": "target-check",
+            "reported_result": "pass",
+            "result": "pass",
+            "summary": "adopted-repo target root exists.",
+            "missing_inputs": [],
+            "fallback_to": None,
+        }
+    return {
+        "id": "target-check",
+        "attempted": True,
+        "command": f"test -d {command_target(target_root)}",
+        "reported_command": "target-check",
+        "reported_result": "unavailable",
+        "result": "warn",
+        "summary": "adopted-repo target root is unavailable.",
+        "missing_inputs": [f"adopted repo target is unavailable: {target_root}"],
+        "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+    }
+
+
+def live_smoke_command_report(target_root: Path, *, report_id: str, args: list[str]) -> dict[str, Any]:
+    payload, errors = local_command_json(target_root, args)
+    command = live_smoke_command(args)
+    if payload is None:
+        return {
+            "id": report_id,
+            "attempted": True,
+            "command": command,
+            "reported_command": args[0],
+            "reported_result": "invalid-output",
+            "result": "block",
+            "summary": f"{args[0]} did not return readable JSON output.",
+            "missing_inputs": live_smoke_missing_inputs(errors),
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+        }
+    reported_result = str(payload.get("result") or "unknown")
+    return {
+        "id": report_id,
+        "attempted": True,
+        "command": command,
+        "reported_command": payload.get("command"),
+        "reported_result": reported_result,
+        "result": "pass" if reported_result == "pass" else "warn",
+        "summary": str(payload.get("summary") or f"{args[0]} completed without a summary."),
+        "missing_inputs": live_smoke_missing_inputs([str(message) for message in payload.get("missing_inputs", [])]),
+        "fallback_to": payload.get("fallback_to"),
+    }
+
+
+def parse_live_smoke_code_block(lines: list[str]) -> list[str]:
+    commands: list[str] = []
+    in_block = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if stripped.startswith("```"):
+            if in_block:
+                break
+            in_block = True
+            continue
+        if in_block and stripped:
+            commands.append(stripped)
+    return commands
+
+
+def strip_inline_code(value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if stripped.startswith("`") and stripped.endswith("`") and len(stripped) >= 2:
+        return stripped[1:-1]
+    return stripped or None
+
+
+def live_smoke_replay_payload(prior_evidence_path: Path, *, runtime_state: dict[str, Any]) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "replay",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "command_plan": [],
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+    if not prior_evidence_path.exists():
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay could not read the requested prior evidence.",
+                "missing_inputs": [f"prior evidence path is unavailable: {prior_evidence_path}"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": str(prior_evidence_path),
+                    "status": "missing",
+                },
+            }
+        )
+        return payload
+
+    relative_path = str(prior_evidence_path)
+    if prior_evidence_path.is_absolute():
+        relative_path = str(prior_evidence_path.resolve())
+    sections = markdown_sections(prior_evidence_path)
+    commands = parse_live_smoke_code_block(sections.get("2. Commands", []))
+    target_lines = sections.get("1. Target", [])
+    availability_lines = sections.get("4. Current PR Availability Evidence", [])
+    text = prior_evidence_path.read_text(encoding="utf-8")
+    status_match = re.search(r"Current release evidence status:\s*`([^`]+)`", text)
+    if status_match is None or "Release interpretation:" not in text:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke replay evidence is missing required status or interpretation fields.",
+                "missing_inputs": [f"{relative_path}: missing Current release evidence status or Release interpretation"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+                "prior_evidence": {
+                    "path": relative_path,
+                    "status": "invalid",
+                },
+            }
+        )
+        return payload
+
+    def find_prefix(lines: list[str], prefix: str) -> str | None:
+        for raw_line in lines:
+            stripped = raw_line.strip()
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].strip()
+        return None
+
+    prior_status = status_match.group(1).strip()
+    release_interpretation = find_prefix(availability_lines, "- Release interpretation:") or live_smoke_release_interpretation("replayed")
+    replay_report = {
+        "id": "prior-evidence",
+        "attempted": False,
+        "command": f"read {relative_path}",
+        "reported_command": "prior-evidence",
+        "reported_result": prior_status,
+        "result": "pass",
+        "summary": "versioned prior-pass live smoke evidence was replayed without rerunning adopted-repo commands.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload.update(
+        {
+            "result": "pass",
+            "summary": "versioned prior-pass live smoke evidence was replayed.",
+            "command_plan": [
+                {
+                    "id": "prior-evidence-read",
+                    "command": live_smoke_command(["live-smoke", "replay", "--prior-evidence", relative_path]),
+                    "description": "Replay versioned prior-pass evidence without rerunning adopted-repo commands.",
+                }
+            ],
+            "reports": [replay_report],
+            "live_smoke": {
+                "status": "replayed",
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": release_interpretation,
+            },
+            "prior_evidence": {
+                "path": relative_path,
+                "status": prior_status,
+                "target_family": find_prefix(target_lines, "- Adopted repo family:"),
+                "smoke_branch": strip_inline_code(find_prefix(target_lines, "- Smoke branch recorded there:")),
+                "smoke_commit": strip_inline_code(find_prefix(target_lines, "- Smoke commit recorded there:")),
+                "smoke_worktree": strip_inline_code(find_prefix(target_lines, "- Smoke worktree recorded there:")),
+                "commands": commands,
+            },
+        }
+    )
+    return payload
+
+
+def live_smoke_run_payload(
+    target_root: Path,
+    *,
+    item: str,
+    dry_run: bool,
+    include_blocking_shadow: bool,
+) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    command_plan = live_smoke_command_plan(target_root, item=item, include_blocking_shadow=include_blocking_shadow)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "run",
+        "schema_version": LIVE_SMOKE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": command_plan,
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "live smoke is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "live smoke recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "live_smoke": {
+                    "status": "unavailable",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("unavailable"),
+                },
+            }
+        )
+        return payload
+
+    if dry_run:
+        payload.update(
+            {
+                "result": "pass",
+                "summary": "live smoke command plan was generated without running adopted-repo commands.",
+                "live_smoke": {
+                    "status": "dry_run",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("dry_run"),
+                },
+            }
+        )
+        return payload
+
+    reports = [target_report]
+    for report_id, args in (
+        ("governance-profile-status", ["governance-profile", "status", "--target", str(target_root)]),
+        ("governance-profile-upgrade-plan", ["governance-profile", "upgrade-plan", "--target", str(target_root)]),
+        ("runtime-parity", ["runtime-parity", "validate", "--target", str(target_root)]),
+        ("shadow-parity", ["shadow-parity", "--target", str(target_root)]),
+        ("flow-resume", ["flow", "resume", "--target", str(target_root), "--item", item]),
+    ):
+        reports.append(live_smoke_command_report(target_root, report_id=report_id, args=args))
+    if include_blocking_shadow:
+        reports.append(
+            live_smoke_command_report(
+                target_root,
+                report_id="shadow-parity-blocking",
+                args=["shadow-parity", "--target", str(target_root), "--blocking"],
+            )
+        )
+
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in reports for message in report.get("missing_inputs", [])]
+    )
+    has_internal_block = any(report.get("result") == "block" for report in reports)
+    has_warning = any(report.get("result") == "warn" for report in reports)
+    result = "block" if has_internal_block else "warn" if has_warning else "pass"
+    status = "failed" if has_warning else "passed"
+    summary = "live smoke produced explicit profile-local warnings." if result == "warn" else "live smoke completed across the planned command set."
+    if result == "block":
+        summary = "live smoke failed to produce stable command output."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "reports": reports,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else LIVE_SMOKE_RETRY_FALLBACK if result == "warn" else None,
+            "live_smoke": {
+                "status": status,
+                "executed_at": current_iso_timestamp(),
+                "release_interpretation": live_smoke_release_interpretation(status),
+            },
+        }
+    )
+    return payload
 
 
 def adoption_validation_commands(target_root: Path) -> list[str]:
@@ -10439,6 +10870,62 @@ def handle_shadow_parity(args: argparse.Namespace) -> int:
     return emit(payload)
 
 
+def handle_live_smoke(args: argparse.Namespace) -> int:
+    if args.operation == "run":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "run",
+                    "schema_version": LIVE_SMOKE_SCHEMA,
+                    "result": "block",
+                    "summary": "live smoke run requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "live_smoke": {
+                        "status": "failed",
+                        "executed_at": current_iso_timestamp(),
+                        "release_interpretation": live_smoke_release_interpretation("failed"),
+                    },
+                }
+            )
+        return emit(
+            live_smoke_run_payload(
+                Path(args.target).expanduser().resolve(),
+                item=args.item,
+                dry_run=args.dry_run,
+                include_blocking_shadow=args.include_blocking_shadow,
+            )
+        )
+
+    repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
+    runtime_state = runtime_state_payload(repo_root)
+    if not args.prior_evidence:
+        return emit(
+            {
+                "command": "live-smoke",
+                "operation": "replay",
+                "schema_version": LIVE_SMOKE_SCHEMA,
+                "result": "block",
+                "summary": "live smoke replay requires --prior-evidence.",
+                "missing_inputs": ["pass --prior-evidence <versioned_evidence_path>"],
+                "fallback_to": LIVE_SMOKE_REPLAY_FALLBACK,
+                "runtime_state": runtime_state,
+                "command_plan": [],
+                "reports": [],
+                "live_smoke": {
+                    "status": "failed",
+                    "executed_at": current_iso_timestamp(),
+                    "release_interpretation": live_smoke_release_interpretation("failed"),
+                },
+            }
+        )
+    return emit(live_smoke_replay_payload(Path(args.prior_evidence).expanduser().resolve(), runtime_state=runtime_state))
+
+
 def handle_runtime_parity(args: argparse.Namespace) -> int:
     target_root = Path(args.target).expanduser().resolve()
     return emit(
@@ -10480,6 +10967,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_reconciliation(args)
     if args.command == "shadow-parity":
         return handle_shadow_parity(args)
+    if args.command == "live-smoke":
+        return handle_live_smoke(args)
     if args.command == "runtime-parity":
         return handle_runtime_parity(args)
     if args.command == "governance-profile":


### PR DESCRIPTION
## Summary
- add `live-smoke run|replay` to the repo-local `loom_flow` runtime and generated skills surface
- define the v0.10.0 live smoke profile and release-readiness consumption docs
- add validation evidence and `loom_check` coverage for versioned live smoke outputs

## Validation
- `python3 -m py_compile tools/loom_flow.py tools/loom_check.py skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py live-smoke run --target /tmp/loom-missing-live-target --item INIT-0001`
- `python3 tools/loom_flow.py live-smoke replay --prior-evidence docs/evidence/validations/validation-v0.7-live-orchestration-smoke.md`
- `python3 tools/loom_flow.py live-smoke run --target /Users/mc/dev/syvert --item INIT-0001`
- `python3 tools/skills_surface.py check`
- `python3 tools/loom_check.py`
- `make check`

## Risks And Follow-ups
- `/Users/mc/dev/syvert` currently returns profile-local `warn` results because its own adoption surfaces still expose host-binding, runtime-parity, and repo-interop gaps; that is recorded as live evidence and remains non-blocking by default.

## Related Work
- Closes #598
- Closes #599
- Closes #600
- Closes #597
- Part of #533
- Workspace entry: `/Users/mc/dev/Loom`
- Branch: `work/597-live-smoke-foundation`
- Head SHA: `1dbe41d`
