### PR TITLE
feat(live): 增加 host adapter live drift 检查

### DIFF
--- a/docs/adoption/repo-interop-contract.md
+++ b/docs/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/docs/evidence/live-smoke-profile.md
+++ b/docs/evidence/live-smoke-profile.md
@@ -10,7 +10,11 @@
 
 `python3 tools/loom_flow.py live-smoke replay --prior-evidence <path>`
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>`
+
 输出 schema 固定为 `loom-live-smoke/v1`。
+
+`host-adapter-drift` 输出 schema 固定为 `loom-host-adapter-live-drift/v1`。
 
 ## Run Contract
 
@@ -80,3 +84,31 @@
 - 全部 planned live checks 成功，或 prior-pass evidence replay 成功：`pass`
 
 `run` / `replay` 都不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate。
+
+## Host Adapter Drift Contract
+
+`host-adapter-drift` 读取 adopted repo `.loom/companion/interop.json` 中声明的 `host_adapters[*]`，并对每个 retained host action locator 产出 profile-local drift evidence。
+
+最小检查面：
+
+- repo interop contract 是否存在且可读
+- `host_adapters[*]` 是否声明合法的 `id`、`owner`、`requirement`、`surfaces`、`locator`、`fallback_to`
+- locator 是否缺失、越界、不可读或指向目录
+- envelope 是否显式报告 `permission_unavailable`
+- envelope 若声明 `host_adapter_version`，是否与当前 Loom host adapter authority 一致
+
+稳定 drift classification：
+
+- `version_drift`
+- `locator_missing`
+- `locator_unreadable`
+- `permission_unavailable`
+- `unsafe_locator`
+- `invalid_declaration`
+
+结果纪律：
+
+- required host adapter drift 可以在该命令内返回 `block`
+- optional / advisory host adapter drift 只返回 profile-local `warn`
+- interop absent 或未声明任何 host adapter 时返回 `warn`
+- 命令不得执行 host action、不得写宿主控制面、不得改写 `interop.json`

--- a/docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md
+++ b/docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md
@@ -1,0 +1,41 @@
+# v0.10.0 Host Adapter Live Drift
+
+本记录归档 `#601` 的 host adapter live drift 验证结果。
+
+它证明：
+
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 能产出 `loom-host-adapter-live-drift/v1`
+- interop absent 或未声明 host adapters 时返回 profile-local `warn`
+- required locator 缺失、unsafe locator 或不可读 retained result envelope 会在该命令内 `block`
+- optional / advisory drift 不污染 `orchestration-core`
+
+## Commands
+
+```bash
+python3 tools/loom_flow.py live-smoke host-adapter-drift --target examples/new-project
+python3 tools/loom_flow.py live-smoke host-adapter-drift --target /tmp/loom-missing-live-target
+python3 tools/skills_surface.py check
+python3 tools/host_adapter_check.py
+python3 tools/loom_check.py
+make check
+```
+
+## Result
+
+- Date: 2026-05-09
+- `examples/new-project` result: `warn`
+- `examples/new-project` interpretation:
+  - repo interop contract is readable
+  - no `host_adapters` are declared
+  - this is profile-local live evidence, not a core blocker
+- `/tmp/loom-missing-live-target` result: `warn`
+- Missing-target interpretation:
+  - target path unavailable
+  - `fallback_to: live-smoke-retry-or-record-unavailable`
+  - explicit unavailable evidence remains non-blocking confidence input
+- `python3 tools/skills_surface.py check`: `pass`
+- `python3 tools/host_adapter_check.py`: `pass`
+- `python3 tools/loom_check.py`: `pass`
+- `make check`: `pass`
+- Remaining risk:
+  - current repository fixtures prove drift classification and profile-local boundary, but not yet a fully green retained host action sample from a downstream strong-governance repo

--- a/docs/methodology/harness/host-action-contract.md
+++ b/docs/methodology/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "35ab222a0e17f3f26fa06263966faec63378401d7c590eaed6a5a8f87228dce9"
+      "sha256": "93067abacc6d9c67e1ee43f2ae1f483537669c103ecef625aa14e7ed583dc0cd"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "ed42b15973962d184f5ff69f0f663bc115834be31505f0a9bed75bbaaf463625"
+      "sha256": "1e94f0ec26dc27937fbe277702476fad4d2ca06931fffc099d09fc08ad3d1655"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "35ab222a0e17f3f26fa06263966faec63378401d7c590eaed6a5a8f87228dce9"
+      "sha256": "93067abacc6d9c67e1ee43f2ae1f483537669c103ecef625aa14e7ed583dc0cd"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "ed42b15973962d184f5ff69f0f663bc115834be31505f0a9bed75bbaaf463625"
+      "sha256": "1e94f0ec26dc27937fbe277702476fad4d2ca06931fffc099d09fc08ad3d1655"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.88",
+      "version": "0.1.89",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-build/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-build/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-init/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-init/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-action-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/shared/references/adoption/repo-interop-contract.md
+++ b/skills/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/skills/shared/references/harness/host-action-contract.md
+++ b/skills/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/src/skills/shared/references/adoption/repo-interop-contract.md
+++ b/src/skills/shared/references/adoption/repo-interop-contract.md
@@ -98,6 +98,20 @@ approval / sandbox policy read locator 属于 [repo-companion-contract.md](./rep
 - `optional` / `advisory` locator 缺失或指向不可读路径只能进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - `host_adapters` 不定义 attempt-time advertised / unavailable / unsupported / failed 结果，也不调用宿主动作
 
+`python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只在 adopted repo 上读取这组 `host_adapters[*]` 声明及其 locator 指向的 retained result envelope，用来回答：
+
+- 该仓库是否声明了可消费的 retained host action 读面
+- locator 是否缺失、不可读、越界或 unsafe
+- envelope 是否暴露 `permission_unavailable` 或 `host_adapter_version` 漂移
+
+它仍然属于 `orchestration-live` / profile-local evidence：
+
+- 不执行 host action
+- 不写宿主控制面
+- 不改写 `interop.json`
+- 不把 optional / advisory host adapter drift 升级成 `orchestration-core` blocker
+- `required` drift 只在该 live/profile-local 命令内返回 `block`
+
 典型对象包括：
 
 - guardian verdict

--- a/src/skills/shared/references/harness/host-action-contract.md
+++ b/src/skills/shared/references/harness/host-action-contract.md
@@ -32,6 +32,7 @@ Loom 的宿主动作面不是新的 umbrella CLI，也不是宿主平台替身�
 
 - 结果 locator 通过 companion-owned `.loom/companion/interop.json` 声明
 - Loom 只消费这些结果，不接管动作执行本身
+- `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>` 只读取这组 locator 与 retained result envelope，产出 profile-local drift evidence；它不是新的 host-facing action，也不扩展本文件的顶层结果词表
 
 当成熟既有仓库需要声明 dynamic tool availability 时：
 

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -1941,6 +1941,128 @@ def require_live_smoke_payload(
                     failures.append(Failure(category, f"{context} prior_evidence missing `{field}`"))
 
 
+def require_host_adapter_live_drift_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "host-adapter-drift":
+        failures.append(Failure(category, f"{context} must report `operation: host-adapter-drift`"))
+    if payload.get("schema_version") != "loom-host-adapter-live-drift/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-host-adapter-live-drift/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable host adapter live drift contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "host-adapter-live-drift":
+            failures.append(Failure(category, f"{context} profile_check.id must be `host-adapter-live-drift`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    host_adapter_drift = payload.get("host_adapter_drift")
+    if not isinstance(host_adapter_drift, dict):
+        failures.append(Failure(category, f"{context} must include `host_adapter_drift`"))
+        return
+    if host_adapter_drift.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} host_adapter_drift.availability is outside the stable vocabulary"))
+    if not isinstance(host_adapter_drift.get("contract_locator"), str) or not host_adapter_drift.get("contract_locator"):
+        failures.append(Failure(category, f"{context} host_adapter_drift.contract_locator must be non-empty"))
+    checks = host_adapter_drift.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} host_adapter_drift.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "owner", "requirement", "summary", "result", "classification"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "version_drift",
+            "locator_missing",
+            "locator_unreadable",
+            "permission_unavailable",
+            "unsafe_locator",
+            "invalid_declaration",
+        }:
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10313,6 +10435,326 @@ def check_live_smoke_foundation_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_interop_local(target: Path, *, interop: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        write_json_local(companion_dir / "interop.json", interop)
+
+    docs = {
+        "docs/adoption/repo-interop-contract.md": [
+            "live-smoke host-adapter-drift",
+            "host_adapter_version",
+            "permission_unavailable",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/host-action-contract.md": [
+            "live-smoke host-adapter-drift",
+            "profile-local drift evidence",
+            "不是新的 host-facing action",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-host-adapter-live-drift/v1",
+            "host-adapter-drift",
+            "version_drift",
+            "permission_unavailable",
+        ],
+        "docs/evidence/validations/validation-v0.10-host-adapter-live-drift.md": [
+            "loom-host-adapter-live-drift/v1",
+            "examples/new-project",
+            "profile-local `warn`",
+            "python3 tools/host_adapter_check.py",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("host-adapter-live-drift", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("host-adapter-live-drift", f"`{relative}` must mention `{anchor}`"))
+
+    expected_version = "1.0.0"
+
+    absent_payload = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": "loom-host-adapter-live-drift/v1",
+        "result": "warn",
+        "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+        "missing_inputs": ["repo interop contract is absent"],
+        "fallback_to": "live-smoke-retry-or-record-unavailable",
+        "runtime_state": {
+            "result": "pass",
+            "summary": "runtime carrier `repo-local-wrapper` is executing as `repo-local-demo` with a consistent bundled runtime.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "scene": "repo-local-demo",
+            "carrier": "repo-local-wrapper",
+            "entry_family": "loom-flow",
+            "install_root": "/tmp/install-root",
+            "runtime_root": "/tmp/runtime-root",
+            "registry_path": "/tmp/registry.json",
+            "layout_or_manifest_path": "/tmp/install-layout.json",
+            "source_repo_root": "/tmp/source-repo",
+            "target_root": "/tmp/absent-live-target",
+            "checks": {
+                "scene_marker": {"status": "pass", "summary": "scene marker is consistent."},
+                "carrier_layout": {"status": "pass", "summary": "carrier layout is readable.", "evidence": {"install_root": "/tmp/install-root"}},
+                "registry_contract": {"status": "pass", "summary": "registry contract is readable.", "evidence": {"path": "/tmp/registry.json"}},
+                "shared_runtime": {"status": "pass", "summary": "shared runtime is readable.", "evidence": {"path": "/tmp/runtime-root"}},
+                "referenced_resources": {"status": "pass", "summary": "referenced resources are present."},
+            },
+        },
+        "target": {
+            "path": "/tmp/absent-live-target",
+            "exists": True,
+            "worktree": "/tmp/absent-live-target",
+            "git_branch": "main",
+            "head_sha": "deadbeef",
+        },
+        "command_plan": [
+            {"id": "target-check", "command": "test -d /tmp/absent-live-target", "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators."},
+            {"id": "repo-interop-contract", "command": "read /tmp/absent-live-target/.loom/companion/interop.json", "description": "Read the repo interop contract and discover declared host adapter retained result locators."},
+        ],
+        "reports": [
+            {
+                "id": "target-check",
+                "attempted": True,
+                "command": "test -d /tmp/absent-live-target",
+                "reported_command": "target-check",
+                "reported_result": "pass",
+                "result": "pass",
+                "summary": "adopted-repo target root exists.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            },
+            {
+                "id": "repo-interop-contract",
+                "attempted": True,
+                "command": "read /tmp/absent-live-target/.loom/companion/interop.json",
+                "reported_command": "repo-interop-contract",
+                "reported_result": "absent",
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": "live-smoke-retry-or-record-unavailable",
+            },
+        ],
+        "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+        "host_adapter_drift": {
+            "contract_locator": ".loom/companion/interop.json",
+            "availability": "absent",
+            "expected_host_adapter_version": expected_version,
+            "checks": [],
+        },
+    }
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="absent-host-adapter-live-drift",
+        payload=absent_payload,
+    )
+
+    permission_payload = json.loads(json.dumps(absent_payload))
+    permission_payload.update(
+        {
+            "result": "block",
+            "summary": "host adapter live drift found blocking retained result declaration or readability gaps.",
+            "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+            "fallback_to": "live-smoke-config-repair",
+            "reports": [
+                absent_payload["reports"][0],
+                {
+                    "id": "guardian-review",
+                    "attempted": True,
+                    "command": "read host/guardian-review.json",
+                    "reported_command": "host-adapter-retained-result",
+                    "reported_result": "permission_unavailable",
+                    "result": "block",
+                    "summary": "host adapter requires additional permission before its retained result can be read.",
+                    "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                    "fallback_to": "build",
+                },
+            ],
+            "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+            "host_adapter_drift": {
+                "contract_locator": ".loom/companion/interop.json",
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": [
+                    {
+                        "id": "guardian-review",
+                        "owner": "host-adapter",
+                        "requirement": "required",
+                        "surfaces": ["review", "merge_ready"],
+                        "locator": "host/guardian-review.json",
+                        "result": "block",
+                        "classification": "permission_unavailable",
+                        "summary": "host adapter requires additional permission before its retained result can be read.",
+                        "missing_inputs": ["host adapter `guardian-review` reported permission_unavailable"],
+                        "fallback_to": "build",
+                        "evidence": {
+                            "locator_status": "readable",
+                            "envelope_status": "permission_unavailable",
+                            "declared_host_adapter_version": expected_version,
+                            "expected_host_adapter_version": expected_version,
+                        },
+                    }
+                ],
+            },
+        }
+    )
+    require_host_adapter_live_drift_payload(
+        failures,
+        category="host-adapter-live-drift",
+        context="permission-unavailable-host-adapter-live-drift",
+        payload=permission_payload,
+    )
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-host-adapter-live-drift-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    (absent_target / ".loom" / "companion" / "interop.json").unlink(missing_ok=True)
+    payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(absent_target)])
+    if error:
+        failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` absent sample failed: {error}"))
+    else:
+        require_host_adapter_live_drift_payload(
+            failures,
+            category="host-adapter-live-drift",
+            context="absent-host-adapter-live-drift-command",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "absent host adapter live drift sample must warn"))
+
+    with tempfile.TemporaryDirectory(prefix="loom-host-adapter-live-drift-") as tmp:
+        base = Path(tmp)
+        valid_interop = {
+            "schema_version": "loom-repo-interop/v1",
+            "host_adapters": [
+                {
+                    "id": "guardian-review",
+                    "summary": "Read guardian review verdicts without reimplementing the host action.",
+                    "surfaces": ["review", "merge_ready"],
+                    "locator": "host/guardian-review.json",
+                    "owner": "host-adapter",
+                    "requirement": "required",
+                    "fallback_to": "build",
+                }
+            ],
+            "repo_native_carriers": [],
+            "shadow_surfaces": {
+                "admission": {"summary": "Compare admission parity.", "loom_locator": ".loom/shadow/admission-loom.json", "repo_locator": ".loom/shadow/admission-repo.json"},
+                "review": {"summary": "Compare review parity.", "loom_locator": ".loom/shadow/review-loom.json", "repo_locator": ".loom/shadow/review-repo.json"},
+                "merge_ready": {"summary": "Compare merge-ready parity.", "loom_locator": ".loom/shadow/merge-ready-loom.json", "repo_locator": ".loom/shadow/merge-ready-repo.json"},
+                "closeout": {"summary": "Compare closeout parity.", "loom_locator": ".loom/shadow/closeout-loom.json", "repo_locator": ".loom/shadow/closeout-repo.json"},
+            },
+        }
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_interop_local(present_target, interop=valid_interop)
+        write_json_local(
+            present_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict is readable.",
+                "status": "pass",
+                "host_adapter_version": expected_version,
+            },
+        )
+        present_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(present_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` present sample failed: {error}"))
+        else:
+            require_host_adapter_live_drift_payload(
+                failures,
+                category="host-adapter-live-drift",
+                context="present-host-adapter-live-drift-command",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("host-adapter-live-drift", "present host adapter live drift sample must pass"))
+
+        missing_target = base / "missing"
+        shutil.copytree(example_target, missing_target)
+        install_interop_local(missing_target, interop=valid_interop)
+        missing_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(missing_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` missing sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required missing host adapter locator must block"))
+
+        optional_target = base / "optional"
+        shutil.copytree(example_target, optional_target)
+        optional_interop = json.loads(json.dumps(valid_interop))
+        optional_interop["host_adapters"][0]["requirement"] = "optional"
+        install_interop_local(optional_target, interop=optional_interop)
+        optional_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(optional_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "optional missing host adapter locator must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interop = json.loads(json.dumps(valid_interop))
+        unsafe_interop["host_adapters"][0]["locator"] = "../outside-host.json"
+        install_interop_local(unsafe_target, interop=unsafe_interop)
+        unsafe_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(unsafe_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "unsafe host adapter locator must block"))
+
+        version_target = base / "version-drift"
+        shutil.copytree(example_target, version_target)
+        install_interop_local(version_target, interop=valid_interop)
+        write_json_local(
+            version_target / "host" / "guardian-review.json",
+            {
+                "summary": "guardian review verdict came from an older host adapter version.",
+                "status": "pass",
+                "host_adapter_version": "9.9.9",
+            },
+        )
+        version_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(version_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` version drift sample failed: {error}"))
+        elif not isinstance(version_payload, dict) or version_payload.get("result") != "warn":
+            failures.append(Failure("host-adapter-live-drift", "host adapter version drift sample must warn"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        install_interop_local(permission_target, interop=valid_interop)
+        write_json_local(
+            permission_target / "host" / "guardian-review.json",
+            {
+                "summary": "host adapter requires additional permission before its retained result can be read.",
+                "status": "permission_unavailable",
+                "host_adapter_version": expected_version,
+            },
+        )
+        permission_command_payload, error = load_command_json(root, ["python3", "tools/loom_flow.py", "live-smoke", "host-adapter-drift", "--target", str(permission_target)])
+        if error:
+            failures.append(Failure("host-adapter-live-drift", f"`host-adapter-drift` permission sample failed: {error}"))
+        elif not isinstance(permission_command_payload, dict) or permission_command_payload.get("result") != "block":
+            failures.append(Failure("host-adapter-live-drift", "required permission unavailable sample must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11424,6 +11866,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_operating_layer_contract(root))
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
+    failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -114,6 +114,7 @@ REVIEW_ENGINE_PROFILE_SCHEMA = "loom-review-engine-profile/v1"
 REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-blocker"}
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
+HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -504,7 +505,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -605,6 +606,540 @@ def live_smoke_release_interpretation(status: str) -> str:
     if status == "unavailable":
         return "explicit unavailable evidence is a non-blocking confidence input and does not silently pass."
     return "profile-local live smoke failure lowers release confidence but does not replace orchestration-core gate results."
+
+
+def current_host_adapter_version() -> str | None:
+    source_repo_root = os.environ.get("LOOM_SOURCE_REPO_ROOT")
+    candidates: list[tuple[Path, str]] = []
+    if source_repo_root:
+        candidates.append((Path(source_repo_root).expanduser().resolve() / "plugins/loom/.codex-plugin/plugin.json", "plugin"))
+    installed_skills_root = os.environ.get("LOOM_INSTALLED_SKILLS_ROOT")
+    if installed_skills_root:
+        installed_root = Path(installed_skills_root).expanduser().resolve()
+        candidates.append((installed_root / "loom-init" / "loom-package.json", "package"))
+        candidates.append((installed_root / "loom-adopt" / "loom-package.json", "package"))
+    for path, source in candidates:
+        if not path.exists():
+            continue
+        try:
+            payload = load_json_file(path)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if source == "plugin":
+            x_loom = payload.get("x-loom")
+            version = x_loom.get("host_adapter_version") if isinstance(x_loom, dict) else None
+        else:
+            version = payload.get("host_adapter_version")
+        if isinstance(version, str) and version.strip():
+            return version.strip()
+    return None
+
+
+def host_adapter_live_drift_command(target_root: Path) -> str:
+    return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
+
+
+def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading host adapter retained result locators.",
+        },
+        {
+            "id": "repo-interop-contract",
+            "command": f"read {target_root / '.loom/companion/interop.json'}",
+            "description": "Read the repo interop contract and discover declared host adapter retained result locators.",
+        },
+    ]
+    for index, entry in enumerate(host_adapters or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"host-adapter-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
+    candidates: list[str] = []
+    for key in ("status", "result", "classification", "failure_category"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            candidates.append(value)
+    read_status = payload.get("read_status")
+    if isinstance(read_status, dict):
+        for key in ("status", "result", "classification", "failure_category"):
+            value = read_status.get(key)
+            if isinstance(value, str):
+                candidates.append(value)
+    normalized = {value.strip().lower().replace("-", "_") for value in candidates if value.strip()}
+    return "permission_unavailable" in normalized
+
+
+def host_adapter_envelope_version(payload: dict[str, Any]) -> str | None:
+    direct = payload.get("host_adapter_version")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    version_context = payload.get("version_context")
+    if isinstance(version_context, dict):
+        nested = version_context.get("host_adapter_version")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def host_adapter_drift_check(
+    target_root: Path,
+    *,
+    entry: object,
+    index: int,
+    expected_host_adapter_version: str | None,
+) -> dict[str, Any]:
+    prefix = f"host_adapters[{index}]"
+    if not isinstance(entry, dict):
+        return {
+            "id": f"invalid-{index}",
+            "owner": "unknown",
+            "requirement": "required",
+            "surfaces": [],
+            "locator": None,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": f"{prefix} must be an object.",
+            "missing_inputs": [f"{prefix} must be an object"],
+            "fallback_to": "admission",
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    entry_id = str(entry.get("id") or f"host-adapter-{index}")
+    requirement = str(entry.get("requirement") or "required")
+    fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) and entry.get("fallback_to") else "admission"
+    owner = str(entry.get("owner") or "unknown")
+    surfaces = entry.get("surfaces")
+    locator_value = entry.get("locator")
+    missing_inputs: list[str] = []
+    if not isinstance(entry.get("summary"), str) or not entry.get("summary"):
+        missing_inputs.append(f"{prefix} missing `summary`")
+    if owner not in {"repo", "repo-companion", "host", "host-adapter", "platform", "external-tool"}:
+        missing_inputs.append(f"{prefix} owner must stay repo/host/platform-owned, not Loom core")
+    if requirement not in {"required", "optional", "advisory"}:
+        missing_inputs.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    if not isinstance(surfaces, list) or not surfaces:
+        missing_inputs.append(f"{prefix} must include `surfaces` as a non-empty list")
+    else:
+        for surface_index, surface in enumerate(surfaces):
+            if surface not in {"admission", "pre_review", "review", "build", "merge_ready", "closeout"}:
+                missing_inputs.append(
+                    f"{prefix}.surfaces[{surface_index}] must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`"
+                )
+    if not isinstance(locator_value, str) or not locator_value.strip():
+        classification = "locator_missing"
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": result,
+            "classification": classification,
+            "summary": "host adapter locator is missing.",
+            "missing_inputs": [*missing_inputs, f"{prefix} `{entry_id}` locator missing `locator`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if missing_inputs:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": surfaces if isinstance(surfaces, list) else [],
+            "locator": locator_value,
+            "result": "block",
+            "classification": "invalid_declaration",
+            "summary": "host adapter declaration is incomplete or invalid.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "invalid"},
+        }
+
+    locator_path, locator_errors = resolve_repo_relative_path(
+        target_root,
+        locator_value,
+        label=f"{prefix} `{entry_id}` locator",
+    )
+    if locator_errors:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "block",
+            "classification": "unsafe_locator",
+            "summary": "host adapter locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": locator_errors,
+            "fallback_to": fallback_to,
+            "evidence": {"locator_status": "unsafe"},
+        }
+    assert locator_path is not None
+    if not locator_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_missing",
+            "summary": "host adapter locator points to a missing retained result path.",
+            "missing_inputs": [f"{prefix} locator points to missing path `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+    if locator_path.is_dir():
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter locator points to a directory, not a retained result envelope.",
+            "missing_inputs": [f"{prefix} locator points to a directory `{locator_value}`"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "directory"},
+        }
+    try:
+        envelope = load_json_file(locator_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope is unreadable.",
+            "missing_inputs": [f"{prefix} locator is unreadable: {exc}"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    if not isinstance(envelope, dict):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "locator_unreadable",
+            "summary": "host adapter retained result envelope must be a JSON object.",
+            "missing_inputs": [f"{prefix} locator must expose a JSON object envelope"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": {"locator_status": "invalid-envelope"},
+        }
+
+    declared_version = host_adapter_envelope_version(envelope)
+    evidence = {
+        "locator_status": "readable",
+        "envelope_status": str(envelope.get("status") or envelope.get("result") or "present"),
+        "declared_host_adapter_version": declared_version,
+        "expected_host_adapter_version": expected_host_adapter_version,
+    }
+    summary = str(envelope.get("summary") or "host adapter retained result envelope is readable.")
+    if host_adapter_permission_unavailable(envelope):
+        result = "block" if requirement == "required" else "warn"
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": result,
+            "classification": "permission_unavailable",
+            "summary": summary,
+            "missing_inputs": [f"host adapter `{entry_id}` reported permission_unavailable"],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    if declared_version and expected_host_adapter_version and declared_version != expected_host_adapter_version:
+        return {
+            "id": entry_id,
+            "owner": owner,
+            "requirement": requirement,
+            "surfaces": list(surfaces),
+            "locator": locator_value,
+            "result": "warn",
+            "classification": "version_drift",
+            "summary": summary,
+            "missing_inputs": [
+                f"host adapter `{entry_id}` version drift: expected `{expected_host_adapter_version}`, found `{declared_version}`"
+            ],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    return {
+        "id": entry_id,
+        "owner": owner,
+        "requirement": requirement,
+        "surfaces": list(surfaces),
+        "locator": locator_value,
+        "result": "pass",
+        "classification": "none",
+        "summary": summary,
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
+
+
+def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "host-adapter-drift",
+        "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": host_adapter_live_drift_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "host adapter live drift is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "runtime-blocked",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "host adapter live drift recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": ".loom/companion/interop.json",
+                    "availability": "target-unavailable",
+                    "expected_host_adapter_version": current_host_adapter_version(),
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interop = governance_surface.get("repo_interop")
+    expected_version = current_host_adapter_version()
+    contract_locator = ".loom/companion/interop.json"
+    availability = "absent"
+    if isinstance(repo_interop, dict):
+        availability = str(repo_interop.get("availability") or "absent")
+        contract = repo_interop.get("contract")
+        if isinstance(contract, dict) and isinstance(contract.get("locator"), str) and contract.get("locator"):
+            contract_locator = str(contract["locator"])
+    interop_report = {
+        "id": "repo-interop-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interop-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo interop contract is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interop_report)
+
+    if availability == "absent":
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is absent, so no host adapter retained result can be consumed.",
+                "missing_inputs": ["repo interop contract is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": interop_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    interop_payload, interop_errors = load_repo_interop_contract(repo_interop, target_root=target_root)
+    if interop_errors or not isinstance(interop_payload, dict):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract is incomplete or unreadable for host adapter live drift.",
+                "missing_inputs": interop_errors or ["repo interop contract is unreadable"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    host_adapters = interop_payload.get("host_adapters")
+    if not isinstance(host_adapters, list):
+        interop_report.update(
+            {
+                "result": "block",
+                "summary": "repo interop contract does not expose a readable host_adapters list.",
+                "missing_inputs": ["repo interop contract must include `host_adapters` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = host_adapter_live_drift_command_plan(target_root, host_adapters=host_adapters)
+    if not host_adapters:
+        interop_report.update(
+            {
+                "result": "warn",
+                "summary": "repo interop contract is readable but declares no host adapters.",
+                "missing_inputs": ["repo interop contract declares no host adapters"],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": interop_report["summary"],
+                "missing_inputs": list(interop_report["missing_inputs"]),
+                "fallback_to": None,
+                "profile_check": {"id": "host-adapter-live-drift", "result": "warn"},
+                "host_adapter_drift": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "expected_host_adapter_version": expected_version,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    checks = [
+        host_adapter_drift_check(
+            target_root,
+            entry=entry,
+            index=index,
+            expected_host_adapter_version=expected_version,
+        )
+        for index, entry in enumerate(host_adapters)
+    ]
+    for check in checks:
+        payload["reports"].append(
+            {
+                "id": str(check["id"]),
+                "attempted": True,
+                "command": f"read {check.get('locator') or '<missing-locator>'}",
+                "reported_command": "host-adapter-retained-result",
+                "reported_result": str(check["classification"]),
+                "result": str(check["result"]),
+                "summary": str(check["summary"]),
+                "missing_inputs": list(check.get("missing_inputs", [])),
+                "fallback_to": check.get("fallback_to"),
+            }
+        )
+    missing_inputs = live_smoke_missing_inputs(
+        [message for report in payload["reports"] for message in report.get("missing_inputs", [])]
+    )
+    has_block = any(check["result"] == "block" for check in checks)
+    has_warn = any(check["result"] == "warn" for check in checks)
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "host adapter retained result locators are readable and show no drift."
+    if result == "warn":
+        summary = "host adapter live drift produced profile-local warnings."
+    if result == "block":
+        summary = "host adapter live drift found blocking retained result declaration or readability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "host-adapter-live-drift", "result": result},
+            "host_adapter_drift": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "expected_host_adapter_version": expected_version,
+                "checks": checks,
+            },
+        }
+    )
+    return payload
 
 
 def live_smoke_command_plan(target_root: Path, *, item: str, include_blocking_shadow: bool) -> list[dict[str, Any]]:
@@ -10900,6 +11435,30 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 include_blocking_shadow=args.include_blocking_shadow,
             )
         )
+    if args.operation == "host-adapter-drift":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "host-adapter-drift",
+                    "schema_version": HOST_ADAPTER_LIVE_DRIFT_SCHEMA,
+                    "result": "block",
+                    "summary": "host adapter live drift requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "host-adapter-live-drift", "result": "block"},
+                    "host_adapter_drift": {
+                        "contract_locator": ".loom/companion/interop.json",
+                        "availability": "missing-target",
+                        "expected_host_adapter_version": current_host_adapter_version(),
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)


### PR DESCRIPTION
## Summary
- add `live-smoke host-adapter-drift` as profile-local adopted-repo evidence
- document host adapter live drift boundaries in repo interop and host action contracts
- add validation evidence and loom_check synthetic coverage for drift classification

## Validation
- python3 -m py_compile tools/loom_flow.py tools/loom_check.py tools/host_adapter_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py
- python3 tools/loom_flow.py live-smoke host-adapter-drift --target examples/new-project
- python3 tools/loom_flow.py live-smoke host-adapter-drift --target /tmp/loom-missing-live-target
- python3 tools/skills_surface.py check
- python3 tools/host_adapter_check.py
- python3 tools/loom_check.py
- make check

## Related Work
- Parent: #533 batch 2 line A
- Closes #601
- Closes #602
- Closes #603
- Closes #604