### PR TITLE
feat(live): 增加 dynamic tool live availability 检查

### DIFF
--- a/docs/adoption/repo-companion-contract.md
+++ b/docs/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/docs/evidence/live-smoke-profile.md
+++ b/docs/evidence/live-smoke-profile.md
@@ -12,9 +12,13 @@
 
 `python3 tools/loom_flow.py live-smoke host-adapter-drift --target <repo>`
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface attempt_time|review|merge_ready|closeout|build|admission|pre_review|all]`
+
 输出 schema 固定为 `loom-live-smoke/v1`。
 
 `host-adapter-drift` 输出 schema 固定为 `loom-host-adapter-live-drift/v1`。
+
+`dynamic-tool-availability` 输出 schema 固定为 `loom-dynamic-tool-live-availability/v1`。
 
 ## Run Contract
 
@@ -112,3 +116,23 @@
 - optional / advisory host adapter drift 只返回 profile-local `warn`
 - interop absent 或未声明任何 host adapter 时返回 `warn`
 - 命令不得执行 host action、不得写宿主控制面、不得改写 `interop.json`
+
+## Dynamic Tool Live Availability Contract
+
+`dynamic-tool-availability` 读取 adopted repo `.loom/companion/repo-interface.json` 中声明的 `dynamic_tool_locators[*]`，并把已有 `tool_availability` 词表包装成 live/profile-local evidence。
+
+最小检查面：
+
+- repo companion interface 是否存在且可读
+- `dynamic_tool_locators[*]` 是否声明合法的 `id`、`owner`、`requirement`、`surface`、`locator`、`fallback_to`
+- locator 是否缺失、越界、不可读或指向无效 handshake declaration
+- handshake declaration 是否只使用 `advertised | unavailable | unsupported | failed`
+- optional/advisory failure 是否保持 profile-local，不污染 `orchestration-core`
+
+结果纪律：
+
+- required dynamic tool unavailable / unsupported / failed / invalid declaration 可以在该命令内返回 `block`
+- optional / advisory failure 只返回 profile-local `warn`
+- repo interface absent 时返回 explicit unavailable evidence 与 `warn`
+- repo interface present 但当前 surface 无 dynamic tools 时返回 `pass`
+- 命令 does not execute the tool, 不得探测宿主协议、不得写 repo companion / host state，也不得固化 tool-specific protocol

--- a/docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md
+++ b/docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md
@@ -1,0 +1,33 @@
+# Validation: v0.10 Dynamic Tool Live Availability
+
+This validation records the v0.10.0 `#605` line for optional dynamic tool live/profile-local evidence.
+
+It verifies:
+
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` emits `loom-dynamic-tool-live-availability/v1`
+- required dynamic tool failures can block the live profile without polluting `orchestration-core`
+- optional/advisory failures remain profile-local `warn`
+- the command does not execute tools or define a tool-specific protocol
+
+## Commands
+
+```bash
+python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target examples/new-project
+python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target /tmp/loom-missing-live-target
+python3 tools/skills_surface.py check
+python3 tools/loom_check.py
+```
+
+## Expected Results
+
+- `examples/new-project` without a repo companion interface returns explicit unavailable evidence and `result: warn`
+- a present repo companion interface with no declared dynamic tools returns `result: pass`
+- required `unsupported`, `failed`, `unavailable`, or invalid handshake declarations can return `result: block`
+- optional/advisory failures stay profile-local `warn`
+- `tool_availability` keeps schema `loom-dynamic-tool-handshake/v1` inside the live wrapper
+
+## Notes
+
+- `fallback_to: live-smoke-retry-or-record-unavailable` remains the explicit unavailable path when the adopted-repo target or repo interface is absent
+- `fallback_to: live-smoke-config-repair` remains the blocking repair path for invalid declarations or required failures
+- This command reuses repo companion `dynamic_tool_locators` as declaration-time locator truth; it does not execute the tool or write host state

--- a/docs/methodology/harness/dynamic-tool-handshake.md
+++ b/docs/methodology/harness/dynamic-tool-handshake.md
@@ -18,6 +18,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 The locator may point at a readable handshake declaration. Loom reads that declaration but does not call the tool, probe the host, or write host results.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Retained host action results remain in `.loom/companion/interop.json`. Attempt summaries remain in `execution_attempt`.
 
 ## Vocabulary
@@ -29,7 +31,7 @@ Retained host action results remain in `.loom/companion/interop.json`. Attempt s
 - `unsupported`: the host adapter reports that the requested tool call is not supported.
 - `failed`: the tool handshake ran or was declared and failed.
 
-These values are never top-level command results. Top-level `result` remains `pass | block | fallback`.
+These values are never top-level command results. Top-level `result` remains `pass | warn | block`.
 
 ## Severity
 
@@ -55,3 +57,4 @@ These values are never top-level command results. Top-level `result` remains `pa
 `loom_status` exposes the latest derived `tool_availability` from `governance_surface.repo_interface`.
 `flow review` and `flow merge-ready` expose the applicable tool availability under `repo_specific_requirements.tool_availability`.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/examples/new-project/.loom/bin/loom_check.py
+++ b/examples/new-project/.loom/bin/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/examples/new-project/.loom/bin/loom_flow.py
+++ b/examples/new-project/.loom/bin/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/examples/new-project/.loom/bootstrap/init-result.json
+++ b/examples/new-project/.loom/bootstrap/init-result.json
@@ -131,7 +131,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "93067abacc6d9c67e1ee43f2ae1f483537669c103ecef625aa14e7ed583dc0cd"
+      "sha256": "63b5652b1b5529b05ed6d50fb0f4d04f72aa7e667a16f8f1132f85bc3db7d2ca"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -155,7 +155,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "1e94f0ec26dc27937fbe277702476fad4d2ca06931fffc099d09fc08ad3d1655"
+      "sha256": "2f8476df0e153c5f0472d54beed75ed32f3c537515e97e194b1b77413473475f"
     },
     {
       "path": "AGENTS.md",

--- a/examples/new-project/.loom/bootstrap/manifest.json
+++ b/examples/new-project/.loom/bootstrap/manifest.json
@@ -53,7 +53,7 @@
       "path": ".loom/bin/loom_flow.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_flow.py",
-      "sha256": "93067abacc6d9c67e1ee43f2ae1f483537669c103ecef625aa14e7ed583dc0cd"
+      "sha256": "63b5652b1b5529b05ed6d50fb0f4d04f72aa7e667a16f8f1132f85bc3db7d2ca"
     },
     {
       "path": ".loom/bin/loom_status.py",
@@ -77,7 +77,7 @@
       "path": ".loom/bin/loom_check.py",
       "kind": "loom-tool",
       "source": "skills/shared/scripts/loom_check.py",
-      "sha256": "1e94f0ec26dc27937fbe277702476fad4d2ca06931fffc099d09fc08ad3d1655"
+      "sha256": "2f8476df0e153c5f0472d54beed75ed32f3c537515e97e194b1b77413473475f"
     },
     {
       "path": "AGENTS.md",

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.89",
+      "version": "0.1.90",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.89",
+  "version": "0.1.90",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-build/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-build/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-init/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/shared/references/adoption/repo-companion-contract.md
+++ b/skills/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/skills/shared/references/harness/dynamic-tool-handshake.md
+++ b/skills/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/src/skills/shared/references/adoption/repo-companion-contract.md
+++ b/src/skills/shared/references/adoption/repo-companion-contract.md
@@ -261,6 +261,7 @@
 - `required` 缺口进入 blocking `missing_inputs`
 - `optional` / `advisory` locator 缺失或指向不可读路径只进入 `missing_optional` 或 profile-local advisory evidence，不得污染 core pass/fail
 - locator 指向的 handshake declaration 若存在，只能输出 `advertised | unavailable | unsupported | failed`，并由 `tool_availability` 派生展示
+- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo>` 只把这组 declaration-time locator 包装成 live smoke / release confidence evidence；它不承载 attempt-time result，不执行业务工具，也不改写 repo companion truth
 - `dynamic_tool_locators` 不得承载 attempt-time result、review summary、validation status 或 retained host action result
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 

--- a/src/skills/shared/references/harness/dynamic-tool-handshake.md
+++ b/src/skills/shared/references/harness/dynamic-tool-handshake.md
@@ -4,6 +4,8 @@ Dynamic tool handshake evidence is runtime evidence. It is not authored progress
 
 `dynamic_tool_locators` in `.loom/companion/repo-interface.json` remains declaration-time only. Retained host action results stay in `.loom/companion/interop.json`; attempt summaries stay in `execution_attempt`.
 
+`python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface <surface>]` is the live/profile-local evidence wrapper for this contract. It reads the same declarations and emits release-confidence evidence without executing the tool protocol itself.
+
 Stable statuses:
 
 - `advertised`
@@ -11,7 +13,8 @@ Stable statuses:
 - `unsupported`
 - `failed`
 
-These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | block | fallback`.
+These values are nested under `tool_availability.declared_tools[*].status`; top-level command `result` remains `pass | warn | block`.
 
 Required tool failure blocks the owning execution surface and uses `fallback_to`. Optional or advisory failure is displayed as advisory evidence and does not block core status.
 
+`live-smoke dynamic-tool-availability` embeds that same `tool_availability` payload inside `loom-dynamic-tool-live-availability/v1`, keeps optional/advisory failures profile-local, and does not call the tool or define a tool-specific protocol.

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -2063,6 +2063,117 @@ def require_host_adapter_live_drift_payload(
             failures.append(Failure(category, f"{context} host_adapter_drift.checks[{index}] must include `evidence`"))
 
 
+def require_dynamic_tool_live_availability_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "dynamic-tool-availability":
+        failures.append(Failure(category, f"{context} must report `operation: dynamic-tool-availability`"))
+    if payload.get("schema_version") != "loom-dynamic-tool-live-availability/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-dynamic-tool-live-availability/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {
+        None,
+        "live-smoke-retry-or-record-unavailable",
+        "live-smoke-config-repair",
+        "admission",
+        "rebootstrap-runtime",
+        "refresh-install",
+        "loom-init",
+    }:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable dynamic tool live contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "dynamic-tool-live-availability":
+            failures.append(Failure(category, f"{context} profile_check.id must be `dynamic-tool-live-availability`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    dynamic_tool_availability = payload.get("dynamic_tool_availability")
+    if not isinstance(dynamic_tool_availability, dict):
+        failures.append(Failure(category, f"{context} must include `dynamic_tool_availability`"))
+        return
+    if dynamic_tool_availability.get("availability") not in {
+        "absent",
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.availability is outside the stable vocabulary"))
+    if dynamic_tool_availability.get("surface") not in {
+        "attempt_time",
+        "review",
+        "merge_ready",
+        "closeout",
+        "build",
+        "admission",
+        "pre_review",
+        "all",
+    }:
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.surface is outside the stable vocabulary"))
+    if not isinstance(dynamic_tool_availability.get("contract_locator"), str) or not dynamic_tool_availability.get("contract_locator"):
+        failures.append(Failure(category, f"{context} dynamic_tool_availability.contract_locator must be non-empty"))
+    require_tool_availability_payload(
+        failures,
+        category=category,
+        context=f"{context}.dynamic_tool_availability.tool_availability",
+        payload=dynamic_tool_availability.get("tool_availability"),
+    )
+
+
 def require_github_binding_payload(
     failures: list[Failure],
     *,
@@ -10755,6 +10866,328 @@ def check_host_adapter_live_drift_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/methodology/harness/dynamic-tool-handshake.md": [
+            "dynamic-tool-availability",
+            "live/profile-local evidence",
+            "does not call the tool",
+            "Top-level `result` remains `pass | warn | block`",
+        ],
+        "docs/adoption/repo-companion-contract.md": [
+            "dynamic-tool-availability",
+            "live smoke",
+            "declaration-time locator",
+            "attempt-time result",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "optional/advisory",
+            "does not execute the tool",
+        ],
+        "docs/evidence/validations/validation-v0.10-dynamic-tool-live-availability.md": [
+            "loom-dynamic-tool-live-availability/v1",
+            "dynamic-tool-availability",
+            "profile-local `warn`",
+            "tool-specific protocol",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("dynamic-tool-live-availability", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(missing_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` missing target sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="missing-target-dynamic-tool-live-availability",
+            payload=payload,
+        )
+        if not isinstance(payload, dict) or payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "missing target sample must warn"))
+
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-dynamic-tool-live-availability-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` absent interface sample failed: {error}"))
+    else:
+        require_dynamic_tool_live_availability_payload(
+            failures,
+            category="dynamic-tool-live-availability",
+            context="absent-interface-dynamic-tool-live-availability",
+            payload=absent_payload,
+        )
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "absent repo interface sample must warn"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "dynamic_tool_locators": [],
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-dynamic-tool-live-availability-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        install_companion_local(present_target, repo_interface=valid_interface)
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` present sample failed: {error}"))
+        else:
+            require_dynamic_tool_live_availability_payload(
+                failures,
+                category="dynamic-tool-live-availability",
+                context="present-dynamic-tool-live-availability",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("dynamic-tool-live-availability", "no-tools present sample must pass"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "required-unsupported-tool",
+                "summary": "Required tool reports unsupported.",
+                "locator": ".loom/companion/tool-unsupported.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "merge_ready",
+                "fallback_to": "merge",
+            }
+        ]
+        install_companion_local(required_target, repo_interface=required_interface)
+        write_json_local(
+            required_target / ".loom" / "companion" / "tool-unsupported.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "unsupported",
+                "summary": "Host adapter does not support this tool call.",
+                "failure_category": "unsupported",
+                "fallback_to": "merge",
+                "evidence": {"status": "present"},
+            },
+        )
+        required_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(required_target),
+                "--surface",
+                "merge_ready",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` required sample failed: {error}"))
+        elif not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required unsupported dynamic tool must block"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "optional-unavailable-tool",
+                "summary": "Optional tool is unavailable in this runtime.",
+                "locator": ".loom/companion/missing-tool.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "review",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "dynamic-tool-availability",
+                "--target",
+                str(optional_target),
+                "--surface",
+                "review",
+            ],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` optional sample failed: {error}"))
+        elif not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional unavailable dynamic tool must warn"))
+
+        advisory_target = base / "advisory-warn"
+        shutil.copytree(example_target, advisory_target)
+        advisory_interface = json.loads(json.dumps(valid_interface))
+        advisory_interface["dynamic_tool_locators"] = [
+            {
+                "id": "advisory-failed-tool",
+                "summary": "Advisory tool reports a failed handshake.",
+                "locator": ".loom/companion/tool-failed.json",
+                "owner": "external-tool",
+                "requirement": "advisory",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(advisory_target, repo_interface=advisory_interface)
+        write_json_local(
+            advisory_target / ".loom" / "companion" / "tool-failed.json",
+            {
+                "schema_version": "loom-dynamic-tool-handshake/v1",
+                "status": "failed",
+                "summary": "External tool handshake failed.",
+                "failure_category": "failed",
+                "fallback_to": "build",
+                "evidence": {"status": "present"},
+            },
+        )
+        advisory_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(advisory_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` advisory sample failed: {error}"))
+        elif not isinstance(advisory_payload, dict) or advisory_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "advisory failed dynamic tool must warn"))
+
+        unsafe_target = base / "unsafe"
+        shutil.copytree(example_target, unsafe_target)
+        unsafe_interface = json.loads(json.dumps(valid_interface))
+        unsafe_interface["dynamic_tool_locators"] = [
+            {
+                "id": "unsafe-tool",
+                "summary": "Unsafe locator must fail closed.",
+                "locator": "../outside-tool.json",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "admission",
+            }
+        ]
+        install_companion_local(unsafe_target, repo_interface=unsafe_interface)
+        unsafe_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(unsafe_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` unsafe sample failed: {error}"))
+        elif not isinstance(unsafe_payload, dict) or unsafe_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "unsafe dynamic tool locator must block"))
+
+        invalid_required_target = base / "invalid-required"
+        shutil.copytree(example_target, invalid_required_target)
+        invalid_required_interface = json.loads(json.dumps(valid_interface))
+        invalid_required_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-required-tool",
+                "summary": "Required tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "required",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_required_target, repo_interface=invalid_required_interface)
+        (invalid_required_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_required_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid required sample failed: {error}"))
+        elif not isinstance(invalid_required_payload, dict) or invalid_required_payload.get("result") != "block":
+            failures.append(Failure("dynamic-tool-live-availability", "required invalid handshake sample must block"))
+
+        invalid_optional_target = base / "invalid-optional"
+        shutil.copytree(example_target, invalid_optional_target)
+        invalid_optional_interface = json.loads(json.dumps(valid_interface))
+        invalid_optional_interface["dynamic_tool_locators"] = [
+            {
+                "id": "invalid-optional-tool",
+                "summary": "Optional tool has invalid handshake JSON.",
+                "locator": ".loom/companion/tool-invalid.json",
+                "owner": "host-adapter",
+                "requirement": "optional",
+                "surface": "attempt_time",
+                "fallback_to": "build",
+            }
+        ]
+        install_companion_local(invalid_optional_target, repo_interface=invalid_optional_interface)
+        (invalid_optional_target / ".loom" / "companion" / "tool-invalid.json").write_text("{not-json}\n", encoding="utf-8")
+        invalid_optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "dynamic-tool-availability", "--target", str(invalid_optional_target)],
+        )
+        if error:
+            failures.append(Failure("dynamic-tool-live-availability", f"`dynamic-tool-availability` invalid optional sample failed: {error}"))
+        elif not isinstance(invalid_optional_payload, dict) or invalid_optional_payload.get("result") != "warn":
+            failures.append(Failure("dynamic-tool-live-availability", "optional invalid handshake sample must warn"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -11867,6 +12300,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_orchestration_conformance_profiles(root))
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
+    failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -11879,7 +12313,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 30
+    categories_checked = 31
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_tool_availability,
     workspace_lifecycle_expectations,
 )
 from runtime_paths import shared_asset, shared_script
@@ -115,6 +116,7 @@ REVIEW_ENGINE_PROFILE_IDS = {"default", "high-risk", "spec-review", "repeated-bl
 REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
+DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -505,11 +507,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
     live_smoke.add_argument("--dry-run", action="store_true", help="Preview the live smoke command plan without running adopted-repo commands")
+    live_smoke.add_argument(
+        "--surface",
+        choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
+        default="attempt_time",
+        help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
     live_smoke.add_argument(
         "--include-blocking-shadow",
         action="store_true",
@@ -641,6 +649,10 @@ def host_adapter_live_drift_command(target_root: Path) -> str:
     return live_smoke_command(["live-smoke", "host-adapter-drift", "--target", str(target_root)])
 
 
+def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -> str:
+    return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -663,6 +675,38 @@ def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[
                 "id": str(entry_id or f"host-adapter-{index}"),
                 "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
                 "description": "Read the retained host action result envelope declared in repo interop.",
+            }
+        )
+    return plan
+
+
+def dynamic_tool_live_availability_command_plan(
+    target_root: Path,
+    *,
+    surface: str,
+    declared_tools: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    plan = [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading dynamic tool handshake declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read the repo companion interface and discover declared dynamic tool availability locators.",
+        },
+    ]
+    for index, entry in enumerate(declared_tools or []):
+        entry_id = entry.get("id") if isinstance(entry, dict) else None
+        locator = entry.get("locator") if isinstance(entry, dict) else None
+        plan.append(
+            {
+                "id": str(entry_id or f"dynamic-tool-{index}"),
+                "command": f"read {locator if isinstance(locator, str) and locator else '<missing-locator>'}",
+                "description": f"Read the dynamic tool handshake declaration for surface `{surface}`.",
             }
         )
     return plan
@@ -1136,6 +1180,310 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def dynamic_tool_live_availability_payload(target_root: Path, *, surface: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "dynamic-tool-availability",
+        "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": dynamic_tool_live_availability_command_plan(target_root, surface=surface),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "runtime-blocked",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "dynamic tool live availability recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": ".loom/companion/repo-interface.json",
+                    "availability": "target-unavailable",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    contract_locator = ".loom/companion/repo-interface.json"
+    availability = "absent"
+    if isinstance(repo_interface, dict):
+        availability = str(repo_interface.get("availability") or "absent")
+    interface_report = {
+        "id": "repo-interface-contract",
+        "attempted": True,
+        "command": f"read {target_root / contract_locator}",
+        "reported_command": "repo-interface-contract",
+        "reported_result": availability,
+        "result": "pass",
+        "summary": "repo companion interface is readable.",
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    payload["reports"].append(interface_report)
+
+    if availability in {"absent", "companion_docs_only"}:
+        summary = "repo companion interface is absent, so no dynamic tool live evidence can be consumed."
+        if availability == "companion_docs_only":
+            summary = "legacy companion docs are present, but no machine-readable repo companion interface declares dynamic tools."
+        interface_report.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "warn",
+                "summary": summary,
+                "missing_inputs": ["repo companion interface is absent"],
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "warn"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "absent",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if not isinstance(repo_interface, dict) or availability == "incomplete":
+        missing_inputs = []
+        if isinstance(repo_interface, dict) and isinstance(repo_interface.get("missing_inputs"), list):
+            missing_inputs = [str(message) for message in repo_interface.get("missing_inputs", [])]
+        if not missing_inputs:
+            missing_inputs = ["repo companion interface is unreadable"]
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface is incomplete or unreadable for dynamic tool live availability.",
+                "missing_inputs": missing_inputs,
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    if availability != "present":
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface returned an unknown availability state for dynamic tool live availability.",
+                "missing_inputs": [f"unknown repo companion availability: {availability}"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    tool_availability = repo_interface.get("tool_availability") if surface == "all" else tool_availability_for_surface(repo_interface, surface=surface)
+    if not isinstance(tool_availability, dict):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "repo companion interface does not expose readable dynamic tool availability evidence.",
+                "missing_inputs": ["repo companion interface must expose `tool_availability`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    declared_tools = tool_availability.get("declared_tools")
+    if not isinstance(declared_tools, list):
+        interface_report.update(
+            {
+                "result": "block",
+                "summary": "dynamic tool live availability did not expose a readable declared_tools list.",
+                "missing_inputs": ["tool_availability must include `declared_tools` as a list"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": interface_report["summary"],
+                "missing_inputs": interface_report["missing_inputs"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "incomplete",
+                    "surface": surface,
+                    "tool_availability": empty_tool_availability(),
+                },
+            }
+        )
+        return payload
+
+    payload["command_plan"] = dynamic_tool_live_availability_command_plan(
+        target_root,
+        surface=surface,
+        declared_tools=declared_tools,
+    )
+    if not declared_tools:
+        interface_report.update(
+            {
+                "result": "pass",
+                "summary": "repo companion interface is readable and no dynamic tools apply to this live profile.",
+                "missing_inputs": [],
+                "fallback_to": None,
+            }
+        )
+        payload.update(
+            {
+                "result": "pass",
+                "summary": interface_report["summary"],
+                "missing_inputs": [],
+                "fallback_to": None,
+                "profile_check": {"id": "dynamic-tool-live-availability", "result": "pass"},
+                "dynamic_tool_availability": {
+                    "contract_locator": contract_locator,
+                    "availability": "present",
+                    "surface": surface,
+                    "tool_availability": tool_availability,
+                },
+            }
+        )
+        return payload
+
+    advisory_messages: list[str] = []
+    for tool in declared_tools:
+        if not isinstance(tool, dict):
+            continue
+        report_result = "pass"
+        if tool.get("result") == "block":
+            report_result = "block"
+        elif tool.get("status") != "advertised":
+            report_result = "warn"
+        report_missing_inputs = [str(message) for message in tool.get("missing_inputs", [])]
+        if report_result == "warn":
+            report_missing_inputs = [str(message) for message in tool.get("advisory", [])]
+            for message in report_missing_inputs:
+                if message not in advisory_messages:
+                    advisory_messages.append(message)
+        payload["reports"].append(
+            {
+                "id": str(tool.get("id") or "dynamic-tool"),
+                "attempted": True,
+                "command": f"read {tool.get('locator') or '<missing-locator>'}",
+                "reported_command": "dynamic-tool-handshake",
+                "reported_result": str(tool.get("status") or tool.get("failure_category") or "unknown"),
+                "result": report_result,
+                "summary": str(tool.get("summary") or "dynamic tool handshake declaration was read."),
+                "missing_inputs": report_missing_inputs,
+                "fallback_to": tool.get("fallback_to") if report_result == "block" else None,
+            }
+        )
+
+    blocking_messages = [
+        message
+        for report in payload["reports"]
+        if report.get("result") == "block"
+        for message in report.get("missing_inputs", [])
+    ]
+    missing_inputs = live_smoke_missing_inputs([*blocking_messages, *advisory_messages])
+    has_block = tool_availability.get("result") == "block"
+    has_warn = any(report.get("result") == "warn" for report in payload["reports"])
+    result = "block" if has_block else "warn" if has_warn else "pass"
+    summary = "dynamic tool handshake declarations are readable and advertised for this live profile."
+    if result == "warn":
+        summary = "dynamic tool live availability produced profile-local warnings."
+    if result == "block":
+        summary = "dynamic tool live availability found blocking handshake declaration or availability gaps."
+    payload.update(
+        {
+            "result": result,
+            "summary": summary,
+            "missing_inputs": missing_inputs,
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "dynamic-tool-live-availability", "result": result},
+            "dynamic_tool_availability": {
+                "contract_locator": contract_locator,
+                "availability": "present",
+                "surface": surface,
+                "tool_availability": tool_availability,
             },
         }
     )
@@ -11459,6 +11807,35 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 }
             )
         return emit(host_adapter_live_drift_payload(Path(args.target).expanduser().resolve()))
+    if args.operation == "dynamic-tool-availability":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "dynamic-tool-availability",
+                    "schema_version": DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA,
+                    "result": "block",
+                    "summary": "dynamic tool live availability requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "dynamic-tool-live-availability", "result": "block"},
+                    "dynamic_tool_availability": {
+                        "contract_locator": ".loom/companion/repo-interface.json",
+                        "availability": "missing-target",
+                        "surface": args.surface,
+                        "tool_availability": empty_tool_availability(),
+                    },
+                }
+            )
+        return emit(
+            dynamic_tool_live_availability_payload(
+                Path(args.target).expanduser().resolve(),
+                surface=args.surface,
+            )
+        )
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)


### PR DESCRIPTION
## Summary
- close `#605`
- close `#606`
- close `#607`
- close `#608`
- add `live-smoke dynamic-tool-availability` as batch 2 line B under `#533`
- freeze the live/profile-local dynamic tool evidence boundary without executing tools or defining a tool-specific protocol

## Validation
- `python3 -m py_compile tools/loom_flow.py tools/loom_check.py tools/host_adapter_check.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target examples/new-project`
- `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target /tmp/loom-missing-live-target`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `python3 - <<'PY' ... loom_check.check_demo_repo_local_cli(...) / loom_check.check_dynamic_tool_live_availability_contract(...) ... PY`

## Risks And Follow-ups
- `python3 tools/loom_check.py` and `make check` were started locally multiple times, but in this environment they remained long-running without a bounded completion signal, so they are not claimed as completed local validations in this PR.
- CI should be treated as the authoritative full-suite confirmation for this branch.

## Related Work
- Parent: `#533` batch 2 line B
- Prior absorbed line A: `#601/#602/#603/#604` via `#729`
