### PR TITLE
test(live): 固化 validation-only guardrail 回归

### DIFF
--- a/docs/evidence/live-smoke-profile.md
+++ b/docs/evidence/live-smoke-profile.md
@@ -41,7 +41,7 @@
 - `shadow-parity` validation-only
 - `flow resume --item <id>`
 
-`shadow-parity --blocking` 只能通过显式 `--include-blocking-shadow` 加入 command set。单个 adopted repo smoke 不得被描述为 blocking shadow parity 升级证据。
+`shadow-parity --blocking` 只能通过显式 `--include-blocking-shadow` 加入 command set。单个 adopted repo smoke 不得被描述为 blocking shadow parity 升级证据；该步骤 is not sufficient blocking-upgrade evidence on its own.
 
 ## Unavailable Evidence
 

--- a/docs/evidence/v0.10.0-release-readiness.md
+++ b/docs/evidence/v0.10.0-release-readiness.md
@@ -32,6 +32,7 @@ release readiness 读取 `loom-live-smoke/v1` 时，至少要区分：
 - profile-local failure：降低 release confidence，但不自动阻断 core
 - replayed prior-pass evidence：允许作为 confidence input，被明确标记为 replay，而不是 fresh run
 - explicit blocking opt-in：只记录为额外 evidence，不等于 blocking upgrade judgment
+- live blocking 只有在 owner、fallback、override path、authority-of-truth 与 live evidence 同时成立时，才允许被上层权威合同消费；缺任何一项都只能回退为配置问题或附加 evidence
 
 ## Blocking Boundary
 
@@ -43,3 +44,5 @@ release readiness 不得因为以下情况直接把 core 变成 `block`：
 - 单个 adopted repo smoke 失败
 
 只有 core gate 自身失败，或 live smoke command output 不再满足 `loom-live-smoke/v1` 稳定合同，才允许把 release coordination 判为 `block`。
+
+单个 adopted repo smoke，即使显式加入 `shadow-parity --blocking`，也只记录为 explicit blocking opt-in evidence；它本身不是 shadow parity blocking 升级证据。

--- a/docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md
+++ b/docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md
@@ -1,0 +1,33 @@
+# Validation: v0.10 Live Validation-Only Guardrail
+
+This validation records the v0.10.0 `#609` line for the default validation-only boundary after live smoke foundation, host adapter live drift, and dynamic tool live availability were merged.
+
+It verifies:
+
+- validation-only live mismatch does not block ordinary orchestration-core consumption
+- explicit blocking opt-in remains evidence, not an automatic upgrade judgment
+- missing blocking prerequisites stay as configuration or contract gaps rather than silently upgrading a live result into final authority
+- a single adopted repo live smoke run is not sufficient shadow parity blocking upgrade evidence
+
+## Commands
+
+```bash
+python3 tools/loom_flow.py live-smoke run --target /tmp/loom-missing-live-target --item INIT-0001
+python3 tools/loom_flow.py live-smoke run --target examples/new-project --dry-run --include-blocking-shadow
+python3 tools/loom_flow.py shadow-parity --target <fixture>
+python3 tools/loom_flow.py shadow-parity --target <fixture> --blocking
+python3 tools/loom_check.py
+```
+
+## Expected Results
+
+- missing adopted-repo target returns explicit unavailable evidence and top-level `warn`
+- validation-only shadow parity mismatch returns `warn`
+- blocking shadow parity returns `block` only when blocking mode is explicitly requested
+- `--include-blocking-shadow` only records explicit blocking opt-in command presence; it does not by itself establish owner, fallback, override path, authority-of-truth, or sufficient live evidence for a blocking upgrade
+- `interop.json` and `repo-interface.json` remain read surfaces and do not become the place where blocking ownership or final winner semantics are declared
+
+## Notes
+
+- this batch does not add a new checker entrypoint; it relies on the existing `shadow-parity`, `live-smoke`, release-readiness, and `loom_check` surfaces
+- the guardrail is complete only when both advisory/default behavior and explicit blocking behavior are covered by regression evidence

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.90",
+      "version": "0.1.91",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.90",
+  "version": "0.1.91",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -11188,6 +11188,143 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/evidence/v0.10.0-release-readiness.md": [
+            "validation-only shadow parity mismatch",
+            "explicit blocking opt-in",
+            "owner、fallback、override path、authority-of-truth 与 live evidence",
+            "单个 adopted repo smoke",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "--include-blocking-shadow",
+            "not sufficient blocking-upgrade evidence on its own",
+            "不得把 `orchestration-live` 提升为普通 PR 的默认 blocking gate",
+        ],
+        "docs/methodology/harness/closeout-gate.md": [
+            "shadow parity` 默认不进入 closeout 阻断面",
+            "owner、fallback、override path 与 authority-of-truth",
+        ],
+        "docs/evidence/validations/validation-v0.10-live-validation-only-guardrail.md": [
+            "validation-only shadow parity mismatch returns `warn`",
+            "explicit blocking opt-in",
+            "single adopted repo live smoke run is not sufficient",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("live-validation-only-guardrail", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("live-validation-only-guardrail", f"`{relative}` must mention `{anchor}`"))
+
+    missing_target = Path("/tmp/loom-missing-live-target")
+    unavailable_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "run", "--target", str(missing_target), "--item", "INIT-0001"],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run` unavailable sample failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="unavailable-live-smoke-guardrail",
+            payload=unavailable_payload,
+            expected_operation="run",
+        )
+        if not isinstance(unavailable_payload, dict) or unavailable_payload.get("result") != "warn":
+            failures.append(Failure("live-validation-only-guardrail", "missing target live smoke must warn"))
+
+    dry_run_payload, error = load_command_json(
+        root,
+        [
+            "python3",
+            "tools/loom_flow.py",
+            "live-smoke",
+            "run",
+            "--target",
+            str(root / "examples/new-project"),
+            "--dry-run",
+            "--include-blocking-shadow",
+        ],
+    )
+    if error:
+        failures.append(Failure("live-validation-only-guardrail", f"`live-smoke run --include-blocking-shadow --dry-run` failed: {error}"))
+    else:
+        require_live_smoke_payload(
+            failures,
+            category="live-validation-only-guardrail",
+            context="dry-run-live-smoke-guardrail",
+            payload=dry_run_payload,
+            expected_operation="run",
+        )
+        command_plan = dry_run_payload.get("command_plan")
+        if not isinstance(command_plan, list):
+            failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include command_plan"))
+        else:
+            blocking_steps = [step for step in command_plan if isinstance(step, dict) and step.get("id") == "shadow-parity-blocking"]
+            if len(blocking_steps) != 1:
+                failures.append(Failure("live-validation-only-guardrail", "dry-run live smoke must include exactly one explicit blocking shadow step when requested"))
+            elif "not sufficient blocking-upgrade evidence on its own" not in str(blocking_steps[0].get("description") or ""):
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow step must say it is not sufficient blocking-upgrade evidence on its own"))
+
+    example_target = root / "examples/new-project"
+    with tempfile.TemporaryDirectory(prefix="loom-live-validation-guardrail-") as tmp:
+        mismatch_target = Path(tmp) / "shadow-mismatch"
+        shutil.copytree(example_target, mismatch_target)
+        shadow_payload = load_json_file(mismatch_target / ".loom/shadow/review-repo.json")
+        if isinstance(shadow_payload, dict):
+            shadow_payload["source_sha256"] = {"native/status/review.json": "0" * 64}
+            write_json_local(mismatch_target / ".loom/shadow/review-repo.json", shadow_payload)
+
+        warn_payload, warn_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review"],
+        )
+        if warn_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity` validation-only mismatch sample failed: {warn_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="validation-only-shadow-mismatch",
+                payload=warn_payload,
+                expected_reports=1,
+            )
+            if not isinstance(warn_payload, dict) or warn_payload.get("result") != "warn":
+                failures.append(Failure("live-validation-only-guardrail", "validation-only shadow mismatch must warn"))
+
+        block_payload, block_error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "shadow-parity", "--target", str(mismatch_target), "--surface", "review", "--blocking"],
+        )
+        if block_error:
+            failures.append(Failure("live-validation-only-guardrail", f"`shadow-parity --blocking` mismatch sample failed: {block_error}"))
+        else:
+            require_shadow_parity_payload(
+                failures,
+                category="live-validation-only-guardrail",
+                context="blocking-shadow-mismatch",
+                payload=block_payload,
+                expected_reports=1,
+            )
+            if not isinstance(block_payload, dict) or block_payload.get("result") != "block":
+                failures.append(Failure("live-validation-only-guardrail", "blocking shadow mismatch must block"))
+
+    return failures
+
+
 def fake_event_evidence(
     *,
     event_id: str,
@@ -12301,6 +12438,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
     failures.extend(check_execution_budget_fixture_contract(root))
@@ -12313,7 +12451,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 31
+    categories_checked = 32
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/tools/fact_chain_support.py
+++ b/tools/fact_chain_support.py
@@ -68,6 +68,24 @@ RUNTIME_EVIDENCE_FIELDS = {
     "Lane Entry": "lane_entry",
 }
 
+EXECUTION_LEDGER_FIELDS = {
+    "Ledger Binding": "ledger_binding",
+    "Plan Locator": "plan_locator",
+    "Acceptance Locator": "acceptance_locator",
+    "Validation Evidence Locator": "validation_evidence_locator",
+    "Handoff Notes Locator": "handoff_notes_locator",
+    "Evidence Freshness": "evidence_freshness",
+}
+
+PROVENANCE_KINDS = {
+    "authored_truth",
+    "host_control_mirror",
+    "retained_result",
+    "derived_surface",
+    "runtime_state",
+    "runtime_evidence",
+}
+
 FORBIDDEN_DYNAMIC_KEYS = {
     "current_checkpoint",
     "current_stop",
@@ -88,6 +106,24 @@ FORBIDDEN_STATIC_KEYS = {
     "validation_entry",
     "closing_condition",
 }
+
+PARALLEL_TRUTH_CONTAINER_KEYS = {
+    "host_mirror",
+    "host_control_mirror",
+    "host_control_plane_mirror",
+    "retained_result",
+    "retained_results",
+}
+
+FORBIDDEN_AUTHORED_KEYS = FORBIDDEN_DYNAMIC_KEYS | FORBIDDEN_STATIC_KEYS
+
+FIELD_LABELS = {
+    **{canonical: label for label, canonical in STATIC_FACT_FIELDS.items()},
+    **{canonical: label for label, canonical in DYNAMIC_FACT_FIELDS.items()},
+}
+
+RUNTIME_EVIDENCE_FIELD_LABELS = {canonical: label for label, canonical in RUNTIME_EVIDENCE_FIELDS.items()}
+EXECUTION_LEDGER_FIELD_LABELS = {canonical: label for label, canonical in EXECUTION_LEDGER_FIELDS.items()}
 
 
 def load_json_file(path: Path) -> dict[str, object]:
@@ -183,7 +219,59 @@ def parse_list_section(sections: dict[str, list[str]], section_name: str, relati
 
 
 def _relative(path: Path, root: Path) -> str:
-    return str(path.relative_to(root))
+    return str(path.resolve().relative_to(root.resolve()))
+
+
+def resolve_repo_relative_path(target_root: Path, relative: str, *, label: str) -> tuple[Path | None, list[str]]:
+    """Resolve a repository locator while rejecting absolute paths and path escapes."""
+    if not isinstance(relative, str) or not relative.strip():
+        return None, [f"{label} must be a non-empty repo-relative path"]
+    locator = relative.strip()
+    candidate_raw = Path(locator)
+    if candidate_raw.is_absolute():
+        return None, [f"{label} must be repo-relative, got absolute path: {locator}"]
+    if ".." in candidate_raw.parts:
+        return None, [f"{label} must stay within the target root and inside the target repository: {locator}"]
+    candidate = (target_root / candidate_raw).resolve()
+    try:
+        candidate.relative_to(target_root.resolve())
+    except ValueError:
+        return None, [f"{label} must stay within the target root and inside the target repository: {locator}"]
+    return candidate, []
+
+
+def path_boundary_missing_details(*, label: str, locator: object, errors: list[str]) -> list[dict[str, object]]:
+    """Return stable machine-readable details for repo locator boundary failures."""
+    locator_text = "" if locator is None else str(locator)
+    details: list[dict[str, object]] = []
+    for message in errors:
+        if "non-empty" in message:
+            kind = "empty_locator"
+        elif "absolute path" in message or "repo-relative" in message:
+            kind = "absolute_locator"
+        else:
+            kind = "repo_locator_escape"
+
+        scopes: list[str] = []
+        if "target root" in message:
+            scopes.append("target_root")
+        if "repository" in message or "repo-relative" in message:
+            scopes.append("repository_root")
+        if not scopes:
+            scopes.append("repository_root")
+
+        for scope in scopes:
+            details.append(
+                {
+                    "category": "path_boundary",
+                    "kind": kind,
+                    "scope": scope,
+                    "label": label,
+                    "locator": locator_text,
+                    "message": message,
+                }
+            )
+    return details
 
 
 def parse_work_item(path: Path, root: Path) -> tuple[dict[str, object], list[str]]:
@@ -202,15 +290,70 @@ def parse_work_item(path: Path, root: Path) -> tuple[dict[str, object], list[str
     return data, errors
 
 
-def parse_recovery_entry(path: Path, root: Path) -> tuple[dict[str, str], list[str]]:
+def parse_execution_ledger(
+    sections: dict[str, list[str]],
+    relative_path: str,
+    recovery_ref: str,
+) -> tuple[dict[str, str], list[str]]:
+    ledger, errors = parse_key_value_section(
+        sections,
+        "Execution Ledger",
+        EXECUTION_LEDGER_FIELDS,
+        relative_path,
+    )
+    section_lines = sections.get("Execution Ledger", [])
+    forbidden_labels = {
+        label
+        for label, canonical in DYNAMIC_FACT_FIELDS.items()
+        if canonical in {"next_step", "blockers", "latest_validation_summary"}
+    }
+    for raw_line in section_lines:
+        match = KEY_VALUE_BULLET_RE.match(raw_line.strip())
+        if not match:
+            continue
+        label = match.group(1).strip()
+        if label in forbidden_labels:
+            errors.append(f"{relative_path}: `Execution Ledger` must not author `{label}`")
+
+    if errors:
+        return ledger, errors
+
+    binding = ledger["ledger_binding"]
+    if binding not in {"recovery_entry", recovery_ref}:
+        errors.append(
+            f"{relative_path}: `Execution Ledger` must bind to `recovery_entry` or `{recovery_ref}`, got `{binding}`"
+        )
+    freshness = ledger["evidence_freshness"].strip().lower()
+    if freshness not in {"current", "not_applicable"}:
+        errors.append(
+            f"{relative_path}: `Execution Ledger` evidence must be `current` or `not_applicable`, got `{ledger['evidence_freshness']}`"
+        )
+    for field_name in ("plan_locator", "acceptance_locator", "validation_evidence_locator", "handoff_notes_locator"):
+        value = ledger[field_name]
+        if not value.strip():
+            errors.append(
+                f"{relative_path}: `Execution Ledger` `{EXECUTION_LEDGER_FIELD_LABELS[field_name]}` must be non-empty or `not_applicable`"
+            )
+    return ledger, errors
+
+
+def parse_recovery_entry(path: Path, root: Path, recovery_ref: str | None = None) -> tuple[dict[str, str], list[str]]:
     relative_path = _relative(path, root)
     sections = markdown_sections(path)
     dynamic_facts, errors = parse_key_value_section(sections, "Dynamic Facts", DYNAMIC_FACT_FIELDS, relative_path)
+    execution_ledger, ledger_errors = parse_execution_ledger(
+        sections,
+        relative_path,
+        recovery_ref or relative_path,
+    )
+    errors.extend(ledger_errors)
 
     for forbidden_key in FORBIDDEN_STATIC_KEYS:
         if forbidden_key in dynamic_facts:
             errors.append(f"{relative_path}: `{forbidden_key}` must not be authored in `Dynamic Facts`")
 
+    if execution_ledger:
+        dynamic_facts["execution_ledger"] = execution_ledger
     return dynamic_facts, errors
 
 
@@ -272,6 +415,39 @@ def find_forbidden_dynamic_keys(payload: object, prefix: str = "") -> list[str]:
     return errors
 
 
+def find_forbidden_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in FORBIDDEN_AUTHORED_KEYS:
+                errors.append(current_prefix)
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_forbidden_authored_keys(value, current_prefix))
+    return errors
+
+
+def find_parallel_truth_authored_keys(payload: object, prefix: str = "") -> list[str]:
+    errors: list[str] = []
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            normalized = _normalize_json_key(str(key))
+            current_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if normalized in PARALLEL_TRUTH_CONTAINER_KEYS:
+                errors.extend(find_forbidden_authored_keys(value, current_prefix))
+            else:
+                errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            current_prefix = f"{prefix}[{index}]"
+            errors.extend(find_parallel_truth_authored_keys(value, current_prefix))
+    return errors
+
+
 def expected_status_values(
     work_item: dict[str, object],
     recovery_entry: dict[str, str],
@@ -296,12 +472,234 @@ def expected_status_values(
     }
 
 
+def _provenance_entry(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    authority: str,
+    freshness: str,
+    trusted_because: str,
+    path: str | None = None,
+    locator: str | None = None,
+) -> dict[str, str]:
+    if kind not in PROVENANCE_KINDS:
+        raise ValueError(f"unsupported provenance kind: {kind}")
+    entry = {
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "freshness": freshness,
+        "trusted_because": trusted_because,
+    }
+    if path is not None:
+        entry["path"] = path
+    if locator is not None:
+        entry["locator"] = locator
+    return entry
+
+
+def _blocking_failure(
+    *,
+    kind: str,
+    carrier: str,
+    field: str,
+    message: str,
+    authority: str,
+    path: str | None = None,
+    expected: object | None = None,
+    actual: object | None = None,
+) -> dict[str, object]:
+    failure: dict[str, object] = {
+        "category": "drift" if kind != "missing_authored_truth" else "gate_failure",
+        "kind": kind,
+        "carrier": carrier,
+        "field": field,
+        "authority": authority,
+        "message": message,
+        "blocking": True,
+        "fallback_to": "admission",
+    }
+    if path is not None:
+        failure["path"] = path
+    if expected is not None:
+        failure["expected"] = expected
+    if actual is not None:
+        failure["actual"] = actual
+    return failure
+
+
+def build_fact_report(
+    *,
+    target_root: Path,
+    output_relative: str,
+    mode: str,
+    read_entry: str,
+    current_item_id: str,
+    work_item_ref: str,
+    recovery_ref: str,
+    status_ref: str,
+    work_item: dict[str, object],
+    recovery_entry: dict[str, str],
+    status_surface: dict[str, str],
+    runtime_evidence: dict[str, str],
+    execution_ledger: dict[str, str],
+    status_sources: dict[str, str],
+    expected_status: dict[str, str],
+    expected_sources: dict[str, str],
+    provenance: list[dict[str, str]],
+    blocking_failures: list[dict[str, object]],
+    stale_fields: list[dict[str, object]],
+    drift_fields: list[dict[str, object]],
+    parallel_truth_drift: list[dict[str, object]],
+) -> dict[str, object]:
+    facts: dict[str, dict[str, object]] = {}
+    for field_name in STATIC_FACT_FIELDS.values():
+        if field_name not in work_item:
+            continue
+        facts[field_name] = {
+            "value": work_item[field_name] if field_name == "associated_artifacts" else str(work_item[field_name]),
+            "source": {
+                "carrier": "work_item",
+                "path": work_item_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+    if "associated_artifacts" in work_item:
+        facts["associated_artifacts"] = {
+            "value": list(work_item["associated_artifacts"]),
+            "source": {"carrier": "work_item", "path": work_item_ref, "field": "Associated Artifacts"},
+        }
+    for field_name in DYNAMIC_FACT_FIELDS.values():
+        if field_name == "item_id":
+            continue
+        if field_name not in recovery_entry:
+            continue
+        facts[field_name] = {
+            "value": recovery_entry[field_name],
+            "source": {
+                "carrier": "recovery_entry",
+                "path": recovery_ref,
+                "field": FIELD_LABELS.get(field_name, field_name),
+            },
+        }
+
+    runtime_evidence_report = {
+        field_name: {
+            "value": value,
+            "status": "not_applicable" if value == "not_applicable" else "present",
+            "source": {
+                "carrier": "status_surface",
+                "path": status_ref,
+                "field": label,
+            },
+        }
+        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
+        if field_name in runtime_evidence
+        for value in (runtime_evidence[field_name],)
+    }
+    ledger_missing = [
+        canonical
+        for canonical in EXECUTION_LEDGER_FIELDS.values()
+        if not str(execution_ledger.get(canonical, "")).strip()
+    ]
+    ledger_freshness = execution_ledger.get("evidence_freshness", "")
+    ledger_status = "complete"
+    if ledger_missing:
+        ledger_status = "missing"
+    elif ledger_freshness == "not_applicable":
+        ledger_status = "not_applicable"
+
+    surface_status = "fresh"
+    if stale_fields:
+        surface_status = "stale"
+    elif drift_fields or parallel_truth_drift:
+        surface_status = "drift"
+
+    recovery_status = "ready"
+    if blocking_failures:
+        recovery_status = "blocked"
+    elif parallel_truth_drift:
+        recovery_status = "parallel_truth_drift"
+    elif stale_fields or drift_fields:
+        recovery_status = "needs_refresh"
+
+    return {
+        "target": str(target_root),
+        "fact_chain": {
+            "mode": mode,
+            "read_entry": read_entry,
+            "entry_points": {
+                "current_item_id": current_item_id,
+                "work_item": work_item_ref,
+                "recovery_entry": recovery_ref,
+                "status_surface": status_ref,
+            },
+        },
+        "provenance": provenance,
+        "facts": facts,
+        "runtime_evidence": runtime_evidence_report,
+        "execution_ledger": {
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "status": ledger_status,
+            "completeness": "complete" if not ledger_missing else "missing",
+            "freshness": ledger_freshness,
+            "fields": execution_ledger,
+            "missing_fields": ledger_missing,
+            "forbidden_authored_fields": [],
+        },
+        "derived_status_surface": {
+            "path": status_ref,
+            "status": surface_status,
+            "values": expected_status,
+            "actual_values": status_surface,
+            "runtime_evidence": runtime_evidence,
+            "sources": expected_sources,
+            "actual_sources": status_sources,
+            "stale": stale_fields,
+            "drift": drift_fields,
+            "blocking_failures": blocking_failures,
+        },
+        "recovery_readiness": {
+            "result": "block" if blocking_failures else "pass",
+            "status": recovery_status,
+            "summary": (
+                "authored work item and recovery entry are readable, and the derived status surface is fresh."
+                if not blocking_failures
+                else "recovery is blocked because authored truth and derived or mirror surfaces drift."
+            ),
+            "missing_inputs": [
+                str(failure["message"])
+                for failure in blocking_failures
+                if isinstance(failure.get("message"), str)
+            ],
+            "fallback_to": "admission" if blocking_failures else None,
+            "checks": {
+                "authored_work_item": "pass",
+                "authored_recovery_entry": "pass",
+                "derived_status_surface": "block" if stale_fields or drift_fields else "pass",
+                "parallel_truth": "block" if parallel_truth_drift else "pass",
+            },
+            "authoritative_carrier": "recovery_entry",
+            "authoritative_path": recovery_ref,
+            "parallel_truth_drift": parallel_truth_drift,
+            "blocking_failures": blocking_failures,
+        },
+        "blocking_failures": blocking_failures,
+    }
+
+
 def inspect_fact_chain(
     target_root: Path,
     output_relative: str = ".loom/bootstrap/init-result.json",
 ) -> tuple[dict[str, object], list[str]]:
     errors: list[str] = []
-    output_path = target_root / output_relative
+    output_path, output_errors = resolve_repo_relative_path(target_root, output_relative, label="init-result locator")
+    if output_errors:
+        return {}, output_errors
+    assert output_path is not None
     if not output_path.exists():
         return {}, [f"missing init-result: {output_relative}"]
 
@@ -325,10 +723,28 @@ def inspect_fact_chain(
         errors.append("init-result.fact_chain.entry_points must be an object")
         entry_points = {}
 
-    forbidden_init_keys = find_forbidden_dynamic_keys(fact_chain, "fact_chain")
+    blocking_failures: list[dict[str, object]] = []
+    stale_fields: list[dict[str, object]] = []
+    drift_fields: list[dict[str, object]] = []
+    parallel_truth_drift: list[dict[str, object]] = []
+
+    forbidden_init_keys = sorted(
+        set(find_forbidden_dynamic_keys(fact_chain, "fact_chain"))
+        | set(find_parallel_truth_authored_keys(init_result))
+    )
     if forbidden_init_keys:
         for key_path in forbidden_init_keys:
-            errors.append(f"init-result must not author dynamic execution state at `{key_path}`")
+            message = f"init-result mirror or retained result must not author Work Item or recovery state at `{key_path}`"
+            failure = _blocking_failure(
+                kind="parallel_truth_drift",
+                carrier="init_result",
+                field=key_path,
+                authority="recovery_entry",
+                path=output_relative,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            parallel_truth_drift.append(failure)
 
     work_item_ref = entry_points.get("work_item")
     recovery_ref = entry_points.get("recovery_entry")
@@ -343,12 +759,33 @@ def inspect_fact_chain(
         if not isinstance(value, str) or not value:
             errors.append(f"init-result.fact_chain.entry_points.{label} must be a non-empty string")
 
-    if errors:
+    fatal_entry_errors = [error for error in errors if not error.startswith("init-result must not author dynamic")]
+    if fatal_entry_errors:
         return {}, errors
 
-    work_item_path = target_root / str(work_item_ref)
-    recovery_path = target_root / str(recovery_ref)
-    status_path = target_root / str(status_ref)
+    work_item_path, work_item_path_errors = resolve_repo_relative_path(
+        target_root,
+        str(work_item_ref),
+        label="init-result.fact_chain.entry_points.work_item",
+    )
+    recovery_path, recovery_path_errors = resolve_repo_relative_path(
+        target_root,
+        str(recovery_ref),
+        label="init-result.fact_chain.entry_points.recovery_entry",
+    )
+    status_path, status_path_errors = resolve_repo_relative_path(
+        target_root,
+        str(status_ref),
+        label="init-result.fact_chain.entry_points.status_surface",
+    )
+    errors.extend(work_item_path_errors)
+    errors.extend(recovery_path_errors)
+    errors.extend(status_path_errors)
+    if work_item_path_errors or recovery_path_errors or status_path_errors:
+        return {}, errors
+    assert work_item_path is not None
+    assert recovery_path is not None
+    assert status_path is not None
     for label, path in (
         ("work_item", work_item_path),
         ("recovery_entry", recovery_path),
@@ -360,38 +797,106 @@ def inspect_fact_chain(
         return {}, errors
 
     work_item, work_item_errors = parse_work_item(work_item_path, target_root)
-    recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root)
-    status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
-    errors.extend(work_item_errors)
-    errors.extend(recovery_errors)
-    errors.extend(status_errors)
+    ledger_locator_keys = (
+        "execution_ledger",
+        "execution_ledger_entry",
+        "ledger",
+        "ledger_entry",
+    )
+    declared_ledger_locators = {
+        key: value
+        for key, value in entry_points.items()
+        if key in ledger_locator_keys and isinstance(value, str) and value
+    }
+    if declared_ledger_locators:
+        unique_ledger_locators = set(declared_ledger_locators.values())
+        if unique_ledger_locators != {str(recovery_ref)}:
+            errors.append(
+                "init-result.fact_chain.entry_points declares a second execution ledger locator; "
+                f"ledger must bind to recovery_entry `{recovery_ref}`"
+            )
     if errors:
+        return {}, errors
+    recovery_entry, recovery_errors = parse_recovery_entry(recovery_path, target_root, str(recovery_ref))
+    status_surface, runtime_evidence, status_sources, status_errors = parse_status_surface(status_path, target_root)
+    parse_errors = work_item_errors + recovery_errors + status_errors
+    errors.extend(parse_errors)
+    if parse_errors:
         return {}, errors
 
     if str(work_item["item_id"]) != str(recovery_entry["item_id"]):
-        errors.append(
+        message = (
             "work item and recovery entry disagree on item id: "
             f"{work_item['item_id']} vs {recovery_entry['item_id']}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="authored_truth_drift",
+                carrier="recovery_entry",
+                field="item_id",
+                authority="work_item",
+                path=str(recovery_ref),
+                expected=str(work_item["item_id"]),
+                actual=str(recovery_entry["item_id"]),
+                message=message,
+            )
+        )
     if str(work_item["recovery_entry"]) != str(recovery_ref):
-        errors.append(
+        message = (
             "work item recovery entry does not match init-result locator: "
             f"{work_item['recovery_entry']} vs {recovery_ref}"
         )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="locator_drift",
+                carrier="work_item",
+                field="recovery_entry",
+                authority="init_result",
+                path=str(work_item_ref),
+                expected=str(recovery_ref),
+                actual=str(work_item["recovery_entry"]),
+                message=message,
+            )
+        )
     if str(work_item["item_id"]) != str(current_item_id):
-        errors.append(
+        message = (
             "init-result.fact_chain.entry_points.current_item_id does not match work item id: "
             f"{current_item_id} vs {work_item['item_id']}"
+        )
+        blocking_failures.append(
+            _blocking_failure(
+                kind="host_control_mirror_drift",
+                carrier="init_result",
+                field="current_item_id",
+                authority="work_item",
+                path=output_relative,
+                expected=str(work_item["item_id"]),
+                actual=str(current_item_id),
+                message=message,
+            )
         )
 
     expected_status = expected_status_values(work_item, recovery_entry)
     for field_name, expected_value in expected_status.items():
         actual_value = status_surface.get(field_name)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface mismatch for "
                 f"`{field_name}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure_kind = "derived_surface_stale"
+            failure = _blocking_failure(
+                kind=failure_kind,
+                carrier="status_surface",
+                field=field_name,
+                authority="recovery_entry" if field_name in FORBIDDEN_DYNAMIC_KEYS else "work_item",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
     expected_sources = {
         "work_item": str(work_item_ref),
@@ -402,117 +907,133 @@ def inspect_fact_chain(
     for source_key, expected_value in expected_sources.items():
         actual_value = status_sources.get(source_key)
         if actual_value != expected_value:
-            errors.append(
+            message = (
                 "status surface source mismatch for "
                 f"`{source_key}`: expected `{expected_value}`, got `{actual_value}`"
             )
+            failure = _blocking_failure(
+                kind="source_stale",
+                carrier="status_surface",
+                field=source_key,
+                authority="init_result",
+                path=str(status_ref),
+                expected=expected_value,
+                actual=actual_value,
+                message=message,
+            )
+            blocking_failures.append(failure)
+            stale_fields.append(failure)
 
-    runtime_evidence_report = {
-        field_name: {
-            "value": value,
-            "status": "not_applicable" if value == "not_applicable" else "present",
-            "source": {
-                "carrier": "status_surface",
-                "path": str(status_ref),
-                "field": label,
-            },
-        }
-        for label, field_name in RUNTIME_EVIDENCE_FIELDS.items()
-        for value in (runtime_evidence[field_name],)
-    }
+    provenance = [
+        _provenance_entry(
+            kind="host_control_mirror",
+            carrier="init_result",
+            locator=output_relative,
+            field="fact_chain",
+            authority="host_control",
+            freshness="current" if not forbidden_init_keys else "drift",
+            trusted_because="init-result only selects carriers and must not author recovery execution state",
+        ),
+        _provenance_entry(
+            kind="runtime_state",
+            carrier="init_result",
+            locator=output_relative,
+            field="current_item_id",
+            authority="work_item",
+            freshness="current" if str(work_item["item_id"]) == str(current_item_id) else "drift",
+            trusted_because="current item id is a host runtime selection mirror checked against authored work item truth",
+        ),
+        _provenance_entry(
+            kind="derived_surface",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Derived Fact Chain View",
+            authority="work_item+recovery_entry",
+            freshness="current" if not stale_fields and not drift_fields else "stale",
+            trusted_because="status surface is retained output derived from authored carriers and verified before consumption",
+        ),
+        _provenance_entry(
+            kind="retained_result",
+            carrier="status_surface",
+            path=str(status_ref),
+            field="Sources",
+            authority="init_result",
+            freshness="current" if not stale_fields else "stale",
+            trusted_because="retained source bindings are accepted only when they match init-result locators",
+        ),
+    ]
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="work_item",
+            path=str(work_item_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="work_item",
+            freshness="current",
+            trusted_because="work item owns static fact-chain truth",
+        )
+        for field_name in STATIC_FACT_FIELDS.values()
+        if field_name in work_item
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field=FIELD_LABELS.get(field_name, field_name),
+            authority="recovery_entry",
+            freshness="current",
+            trusted_because="recovery entry owns dynamic execution truth",
+        )
+        for field_name in DYNAMIC_FACT_FIELDS.values()
+        if field_name in recovery_entry
+    )
+    provenance.extend(
+        _provenance_entry(
+            kind="runtime_evidence",
+            carrier="status_surface",
+            path=str(status_ref),
+            field=RUNTIME_EVIDENCE_FIELD_LABELS.get(field_name, field_name),
+            authority="runtime_evidence",
+            freshness="not_applicable" if value == "not_applicable" else "current",
+            trusted_because="runtime evidence is consumed as status-surface evidence, not authored recovery truth",
+        )
+        for field_name, value in runtime_evidence.items()
+    )
+    execution_ledger = dict(recovery_entry.get("execution_ledger", {}))
+    provenance.append(
+        _provenance_entry(
+            kind="authored_truth",
+            carrier="recovery_entry",
+            path=str(recovery_ref),
+            field="Execution Ledger",
+            authority="recovery_entry",
+            freshness=execution_ledger.get("evidence_freshness", "missing"),
+            trusted_because="execution ledger is a locator/evidence view bound to the recovery entry, not a second recovery state source",
+        )
+    )
 
-    report = {
-        "target": str(target_root),
-        "fact_chain": {
-            "mode": str(mode),
-            "read_entry": str(read_entry),
-            "entry_points": {
-                "current_item_id": str(current_item_id),
-                "work_item": str(work_item_ref),
-                "recovery_entry": str(recovery_ref),
-                "status_surface": str(status_ref),
-            },
-        },
-        "facts": {
-            "item_id": {
-                "value": str(work_item["item_id"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Item ID"},
-            },
-            "goal": {
-                "value": str(work_item["goal"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Goal"},
-            },
-            "scope": {
-                "value": str(work_item["scope"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Scope"},
-            },
-            "execution_path": {
-                "value": str(work_item["execution_path"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Execution Path"},
-            },
-            "associated_artifacts": {
-                "value": list(work_item["associated_artifacts"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Associated Artifacts"},
-            },
-            "workspace_entry": {
-                "value": str(work_item["workspace_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Workspace Entry"},
-            },
-            "recovery_entry": {
-                "value": str(work_item["recovery_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Recovery Entry"},
-            },
-            "review_entry": {
-                "value": str(work_item["review_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Review Entry"},
-            },
-            "validation_entry": {
-                "value": str(work_item["validation_entry"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Validation Entry"},
-            },
-            "closing_condition": {
-                "value": str(work_item["closing_condition"]),
-                "source": {"carrier": "work_item", "path": str(work_item_ref), "field": "Closing Condition"},
-            },
-            "current_checkpoint": {
-                "value": recovery_entry["current_checkpoint"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Checkpoint"},
-            },
-            "current_stop": {
-                "value": recovery_entry["current_stop"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Stop"},
-            },
-            "next_step": {
-                "value": recovery_entry["next_step"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Next Step"},
-            },
-            "blockers": {
-                "value": recovery_entry["blockers"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Blockers"},
-            },
-            "latest_validation_summary": {
-                "value": recovery_entry["latest_validation_summary"],
-                "source": {
-                    "carrier": "recovery_entry",
-                    "path": str(recovery_ref),
-                    "field": "Latest Validation Summary",
-                },
-            },
-            "recovery_boundary": {
-                "value": recovery_entry["recovery_boundary"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Recovery Boundary"},
-            },
-            "current_lane": {
-                "value": recovery_entry["current_lane"],
-                "source": {"carrier": "recovery_entry", "path": str(recovery_ref), "field": "Current Lane"},
-            },
-        },
-        "runtime_evidence": runtime_evidence_report,
-        "derived_status_surface": {
-            "path": str(status_ref),
-            "values": expected_status,
-            "runtime_evidence": runtime_evidence,
-            "sources": expected_sources,
-        },
-    }
-    return report, errors
+    report = build_fact_report(
+        target_root=target_root,
+        output_relative=output_relative,
+        mode=str(mode),
+        read_entry=str(read_entry),
+        current_item_id=str(current_item_id),
+        work_item_ref=str(work_item_ref),
+        recovery_ref=str(recovery_ref),
+        status_ref=str(status_ref),
+        work_item=work_item,
+        recovery_entry=recovery_entry,
+        status_surface=status_surface,
+        runtime_evidence=runtime_evidence,
+        execution_ledger=dict(recovery_entry.get("execution_ledger", {})),
+        status_sources=status_sources,
+        expected_status=expected_status,
+        expected_sources=expected_sources,
+        provenance=provenance,
+        blocking_failures=blocking_failures,
+        stale_fields=stale_fields,
+        drift_fields=drift_fields,
+        parallel_truth_drift=parallel_truth_drift,
+    )
+    return report, []


### PR DESCRIPTION
## Summary
- close `#609`
- close `#610`
- close `#611`
- close `#612`
- finalize the v0.10 validation-only guardrail after batch 1 and batch 2 were absorbed
- add dedicated evidence and `loom_check` regression coverage without introducing a new live checker entrypoint

## Validation
- `python3 -m py_compile tools/fact_chain_support.py tools/loom_check.py tools/loom_flow.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py generate`
- `python3 tools/skills_surface.py check`
- `python3 tools/loom_flow.py live-smoke run --target /tmp/loom-missing-live-target --item INIT-0001`
- `python3 tools/loom_flow.py live-smoke run --target examples/new-project --dry-run --include-blocking-shadow`
- targeted `loom_check.check_live_validation_only_guardrail_contract(...)`
- targeted `loom_check.check_dynamic_tool_live_availability_contract(...)`

## Risks And Follow-ups
- full `python3 tools/loom_check.py` was started locally and remained long-running, so CI is treated as the authoritative full-suite confirmation for this guardrail-only PR.
- no new checker command was added; `#611` is satisfied by confirming the existing checker surfaces already distinguish advisory/default behavior from explicit blocking behavior.

## Related Work
- Parent: `#533` batch 3
- Prior absorbed lines: #728, #729, #730
