### PR TITLE
feat(harness): define hook locator contract

### DIFF
--- a/docs/adoption/host-adapter-matrix.md
+++ b/docs/adoption/host-adapter-matrix.md
@@ -61,3 +61,32 @@ Adapters must fail closed and report failure instead of partial success when:
 - host discovery cannot observe the installed skill
 - version metadata cannot be read
 - a conflicting user override shadows Loom without explicit operator intent
+
+## Lifecycle Hook Mapping
+
+Host adapters may install or generate host-native hook configuration from Loom
+`hook_locators`, but generated host config remains downstream of the Loom locator
+contract. Loom core does not store Codex or Claude Code native hook file shapes.
+
+Adapters report hook mapping with:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension; never required native hook
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+Host-native hook output must be mapped into Loom runtime evidence and must not
+write authored progress, recovery/status truth, review verdict, validation
+summary, host action result, or closeout basis.

--- a/docs/adoption/repo-companion-contract.md
+++ b/docs/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../methodology/harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../methodology/harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../methodology/harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/docs/methodology/harness/README.md
+++ b/docs/methodology/harness/README.md
@@ -19,6 +19,8 @@
   - 定义 dynamic tool availability 的 `advertised` / `unavailable` / `unsupported` / `failed` 词表、companion / interop 边界与状态展示规则
 - [policy-read-surface.md](./policy-read-surface.md)
   - 定义 approval / sandbox policy 读面、missing / conflict / unsafe 词表、风险摘要与 host-adapter 边界
+- [hook-locator-contract.md](./hook-locator-contract.md)
+  - 定义 lifecycle hook locator、host-native adapter mapping、extension 结果词表与 runtime-evidence-only 边界
 - [structured-event-evidence.md](./structured-event-evidence.md)
   - 定义 agent / tool / validation / failure / tracker event evidence 的字段、fake orchestration fixtures 与禁止承载 authored truth 的边界
 - [subagent-driven-execution.md](./subagent-driven-execution.md)

--- a/docs/methodology/harness/hook-locator-contract.md
+++ b/docs/methodology/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.94",
+      "version": "0.1.95",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-adopt/.loom-runtime/install-layout.json
+++ b/skills/loom-adopt/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-build/.loom-runtime/install-layout.json
+++ b/skills/loom-build/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-build/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-build/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-handoff/.loom-runtime/install-layout.json
+++ b/skills/loom-handoff/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-init/.loom-runtime/install-layout.json
+++ b/skills/loom-init/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-init/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-init/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-merge-ready/.loom-runtime/install-layout.json
+++ b/skills/loom-merge-ready/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-pre-review/.loom-runtime/install-layout.json
+++ b/skills/loom-pre-review/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-resume/.loom-runtime/install-layout.json
+++ b/skills/loom-resume/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-retire/.loom-runtime/install-layout.json
+++ b/skills/loom-retire/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-review/.loom-runtime/install-layout.json
+++ b/skills/loom-review/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-review/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-spec-review/.loom-runtime/install-layout.json
+++ b/skills/loom-spec-review/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-story/.loom-runtime/install-layout.json
+++ b/skills/loom-story/.loom-runtime/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-story/.loom-runtime/shared/references/adoption/repo-companion-contract.md
+++ b/skills/loom-story/.loom-runtime/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/loom-story/.loom-runtime/shared/references/harness/hook-locator-contract.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_init.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/shared/references/adoption/repo-companion-contract.md
+++ b/skills/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/skills/shared/references/harness/hook-locator-contract.md
+++ b/skills/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/skills/shared/scripts/loom_init.py
+++ b/skills/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/src/skills/install-layout.json
+++ b/src/skills/install-layout.json
@@ -46,6 +46,7 @@
     "shared/references/harness/workspace-profile.md",
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
+    "shared/references/harness/hook-locator-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/src/skills/shared/references/adoption/repo-companion-contract.md
+++ b/src/skills/shared/references/adoption/repo-companion-contract.md
@@ -143,6 +143,7 @@
   },
   "dynamic_tool_locators": [],
   "policy_locators": [],
+  "hook_locators": [],
   "release_targets": {
     "catalog_locator": ".loom/companion/releases/catalog.json",
     "current_target_locator": ".loom/companion/releases/current.json",
@@ -152,13 +153,14 @@
 }
 ```
 
-`v2` 在 `v1` 之上新增六个可选顶层 section：
+`v2` 在 `v1` 之上新增七个可选顶层 section：
 
 - `review_instruction_locators`
 - `metadata_contract`
 - `context_schema`
 - `dynamic_tool_locators`
 - `policy_locators`
+- `hook_locators`
 - `release_targets`
 
 稳定约束：
@@ -167,6 +169,7 @@
 - `review_instruction_locators` 只在 `v2` 合法
 - `dynamic_tool_locators` 只在 `v2` 合法
 - `policy_locators` 只在 `v2` 合法
+- `hook_locators` 只在 `v2` 合法
 - `release_targets` 只在 `v2` 合法
 - `v2` 不改变 `repo_specific_requirements` 与 `specialized_gates` 的既有纪律
 - `v2` 不把 repo runtime state、review summary、validation status 或 retained host action result 写入 `repo-interface.json`
@@ -317,7 +320,53 @@
 - retained host action result locator 必须留在 [repo-interop-contract.md](./repo-interop-contract.md) 的 `host_adapters`
 - policy 读面细节由 [policy-read-surface.md](../harness/policy-read-surface.md) 承接
 
-### 4.7 `release_targets`
+### 4.7 `hook_locators`
+
+`hook_locators` 用于声明 lifecycle hook locator，而不是执行 hooks 或保存宿主原生 hook 文件。
+
+它回答的是：
+
+- Loom lifecycle hook 声明去哪里读
+- 该 hook declaration 的 owner 是谁
+- 缺失或 unsafe 时按 required、optional 还是 advisory 处理
+- 缺失或阻断时回到哪个 Loom surface 或人工路径
+
+它不回答：
+
+- Codex、Claude Code 或其他宿主的原生 hook 文件长什么样
+- hook 是否已经执行
+- hook 执行结果是什么
+- runtime state、review verdict、validation summary 或 closeout basis 应写在哪里
+
+`hook_locators[*]` 固定字段：
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+其中：
+
+- `lifecycle` 只允许 `before-run | after-run | cleanup`
+- `locator` 必须是仓内相对路径；绝对路径、越界或非法路径对所有 requirement 都必须 fail closed
+- required locator 缺失或指向不可读路径必须 fail closed
+- optional / advisory locator 缺失或指向不可读路径只能进入 optional / advisory gap，不得污染 core pass/fail
+- `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
+- `requirement` 只允许 `required | optional | advisory`
+- `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+
+稳定约束：
+
+- `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
+- host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
+- cleanup hook 始终受 [workspace-lifecycle.md](../harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook
+- lifecycle 与宿主事件映射见 [hook-locator-contract.md](../harness/hook-locator-contract.md)
+
+### 4.8 `release_targets`
 
 `release_targets` 用于声明目标仓库自己的 release / version 真相入口。
 
@@ -357,7 +406,7 @@
 - `status_locator` 若缺失，Loom 仍应从 authored target release object 与 delivery chain 派生自己的 target release status summary
 - `release_targets` 不得承载 release verdict、review summary、validation status、host action result 或 scheduler state
 
-### 4.8 `metadata_contract`
+### 4.9 `metadata_contract`
 
 `metadata_contract` 用于声明 repo-specific metadata block 的 locator contract，而不是把这些字段抬升为 Loom core 默认字段或通用 schema。
 
@@ -402,7 +451,7 @@
 - 它们不得被回写成 Loom core 默认字段名
 - Loom 不为它们提供跨仓统一 taxonomy 承诺
 
-### 4.8.1 明确禁止上移的字段模式
+### 4.9.1 明确禁止上移的字段模式
 
 `metadata_contract` 不得承接以下字段模式：
 
@@ -425,7 +474,7 @@
 
 它们不能因为“看起来像 metadata”就被回塞到 `repo-interface.json`。
 
-### 4.8.2 与 `context_schema` 的边界
+### 4.9.2 与 `context_schema` 的边界
 
 `metadata_contract` 与 `context_schema` 的分工固定如下：
 
@@ -440,7 +489,7 @@
 - 不得在 `context_schema` 中伪装声明 repo-native metadata block 的 authority locator
 - 不得把同一字段同时当作“必传上下文字段”和“repo-local metadata result 字段”写成单一 Loom core 默认概念
 
-### 4.8.3 与 `interop.json` 的边界
+### 4.9.3 与 `interop.json` 的边界
 
 `metadata_contract` 不得声明以下 locator：
 
@@ -449,7 +498,7 @@
 - `shadow parity` compare surface 的 locator
 - external-runtime locator、runtime version、fallback runtime 或 de-vendor rollback mode
 
-这些入口固定属于 [repo-interop-contract.md](./repo-interop-contract.md)。
+这些入口固定属于 [repo-interop-contract.md](../adoption/repo-interop-contract.md)。
 external-runtime 迁移路径固定属于 [external-runtime-companion-contract.md](./external-runtime-companion-contract.md)。
 
 明确禁止事项：
@@ -459,7 +508,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - 不得把 `blocking ownership`、`override path`、`authority-of-truth` 写成 `metadata_contract` 字段
 - 不得把 external-runtime 的 runtime locator 或 rollback switch 写进 `repo-interface.json`
 
-### 4.9 `context_schema`
+### 4.10 `context_schema`
 
 `context_schema` 用于声明 repo-specific required context fields 与映射规则，不暗含单一 Loom 通用字段模型。
 
@@ -477,7 +526,7 @@ external-runtime 迁移路径固定属于 [external-runtime-companion-contract.m
 - `required` 必须是布尔值
 - `mapping_rule_locator` 指向仓库如何把宿主上下文映射到该字段的权威说明
 
-### 4.10 纪律重申
+### 4.11 纪律重申
 
 无论 `v1` 或 `v2`，以下纪律保持不变：
 

--- a/src/skills/shared/references/harness/hook-locator-contract.md
+++ b/src/skills/shared/references/harness/hook-locator-contract.md
@@ -1,0 +1,104 @@
+# Hook Locator Contract
+
+This file defines Loom's lifecycle hook locator contract. It freezes declaration
+and adapter semantics only; it does not introduce hook execution.
+
+## Goal
+
+Loom hooks let a repository declare where lifecycle hook guidance or scripts live
+without copying host-native hook files into Loom core.
+
+The stable lifecycle names are:
+
+- `before-run`
+- `after-run`
+- `cleanup`
+
+These names are Loom lifecycle semantics, not host event names.
+
+## Locator Rules
+
+Each hook locator must be a repository-relative path.
+
+Invalid locators fail closed for every requirement level:
+
+- absolute paths
+- paths containing `..`
+- paths that resolve outside the repository root
+- non-string or empty locators when the hook is `required`
+
+Missing optional or advisory locators are reported as optional gaps. They must
+not pollute core `missing_inputs`.
+
+## Repo Companion Declaration
+
+Adopted repositories declare hook locators through the repo companion
+`hook_locators` section.
+
+Each entry uses:
+
+- `id`
+- `summary`
+- `lifecycle`
+- `locator`
+- `owner`
+- `requirement`
+- `fallback_to`
+
+Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
+Allowed `requirement` values are `required`, `optional`, and `advisory`.
+
+`hook_locators` are declaration-time locators. They must not carry runtime
+state, execution result, authored progress, review verdict, validation status,
+host action result, or closeout basis.
+
+## Host Adapter Mapping
+
+Host adapters may install or generate host-native hook config from Loom
+locators, but generated config remains downstream of Loom's locator contract.
+It does not become Loom-authored truth.
+
+Codex mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`
+- `after-run`: `PostToolUse`, `Stop`, `PostCompact`
+- `cleanup`: `not_applicable` or Loom explicit `workspace cleanup|retire` extension
+
+Codex cleanup must never be required as a native host hook.
+
+Claude Code mapping:
+
+- `before-run`: `SessionStart`, `UserPromptSubmit`, `PreToolUse`
+- `after-run`: `PostToolUse`, `Stop`, `SubagentStop`, `PostCompact`
+- `cleanup`: optional `SessionEnd`, constrained by Loom cleanup safety
+
+The adapter result vocabulary is:
+
+- `supported`
+- `not_applicable`
+- `advisory`
+- `unsafe`
+
+## Evidence Boundary
+
+Host-native hook output can only become Loom runtime evidence after adapter
+mapping.
+
+Hook output must not write:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+Cleanup hooks are always constrained by [workspace-lifecycle.md](./workspace-lifecycle.md):
+only Loom-owned residue may be removed, and unmarked content must be preserved.
+
+## Non-goals
+
+- executing hooks
+- generating host-native hook files
+- copying Codex or Claude Code hook file shapes into Loom core
+- replacing `workspace cleanup|retire`

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -350,6 +350,7 @@ REPO_INTERFACE_V2_KEYS = REPO_INTERFACE_V1_KEYS | {
     "context_schema",
     "dynamic_tool_locators",
     "policy_locators",
+    "hook_locators",
     "release_targets",
 }
 DECLARED_LOCATOR_REQUIREMENTS = {"required", "optional", "advisory"}
@@ -364,6 +365,7 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
     "invalid_declaration",
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
+HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1105,6 +1107,71 @@ def validate_dynamic_tool_locator(
         blocking.append(
             f"{prefix} surface must be one of `admission`, `pre_review`, `review`, `build`, `merge_ready`, `closeout`, `attempt_time`"
         )
+    locator_value = entry.get("locator")
+    locator, target = resolve_locator(root, locator_value)
+    locator_error: str | None = None
+    locator_error_is_optional = False
+    if locator_field_missing(locator_value):
+        locator_error = f"{locator_label} missing `locator`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    elif locator is None or target is None:
+        locator_error = locator_boundary_error(locator_value, label=locator_label)
+    elif not target.exists():
+        locator_error = f"{prefix} locator points to missing path `{locator}`"
+        locator_error_is_optional = requirement in {"optional", "advisory"}
+    if locator_error:
+        if locator_error_is_optional:
+            optional.append(locator_error)
+        else:
+            blocking.append(locator_error)
+    return blocking, optional
+
+
+def validate_hook_locator(
+    *,
+    root: Path,
+    entry: object,
+    index: int,
+) -> tuple[list[str], list[str]]:
+    prefix = f"hook_locators[{index}]"
+    if not isinstance(entry, dict):
+        return [f"{prefix} must be an object"], []
+    entry_id = entry.get("id")
+    locator_label = f"{prefix} `{entry_id}` locator" if isinstance(entry_id, str) and entry_id.strip() else f"{prefix} locator"
+    blocking: list[str] = []
+    optional: list[str] = []
+    for field in ("id", "summary", "lifecycle", "owner", "requirement", "fallback_to"):
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            blocking.append(f"{prefix} missing `{field}`")
+    lifecycle = entry.get("lifecycle")
+    if lifecycle not in HOOK_LOCATOR_LIFECYCLES:
+        blocking.append(f"{prefix} lifecycle must be `before-run`, `after-run`, or `cleanup`")
+    owner = entry.get("owner")
+    if owner not in DECLARED_LOCATOR_OWNERS:
+        blocking.append(
+            f"{prefix} owner must be one of `repo`, `repo-companion`, `host`, `host-adapter`, `platform`, `external-tool`"
+        )
+    requirement = entry.get("requirement")
+    if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
+        blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+
+    forbidden_fields = sorted(
+        set(entry)
+        & {
+            "runtime_state",
+            "execution_result",
+            "authored_progress",
+            "review_verdict",
+            "review_summary",
+            "validation_status",
+            "host_action_result",
+            "closeout_basis",
+        }
+    )
+    if forbidden_fields:
+        blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)
     locator_error: str | None = None
@@ -1908,6 +1975,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "specialized_gates": carrier_entry("missing", "unknown", "repo companion interface"),
         "dynamic_tool_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "policy_locators": carrier_entry("missing", "unknown", "repo companion interface"),
+        "hook_locators": carrier_entry("missing", "unknown", "repo companion interface"),
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
@@ -2094,6 +2162,24 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                     else:
                         for index, entry in enumerate(policy_locators):
                             blocking, optional = validate_policy_locator(
+                                root=root,
+                                entry=entry,
+                                index=index,
+                            )
+                            missing_inputs.extend(blocking)
+                            missing_optional.extend(optional)
+                hook_locators = interface_payload.get("hook_locators")
+                if hook_locators is not None:
+                    repo_interface_surface["hook_locators"] = carrier_entry(
+                        "present",
+                        ".loom/companion/repo-interface.json",
+                        "repo companion interface",
+                    )
+                    if not isinstance(hook_locators, list):
+                        missing_inputs.append("hook_locators must be a list")
+                    else:
+                        for index, entry in enumerate(hook_locators):
+                            blocking, optional = validate_hook_locator(
                                 root=root,
                                 entry=entry,
                                 index=index,

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -1232,7 +1232,14 @@ def require_repo_interface_payload(
         payload=payload.get("manifest"),
         allowed_statuses={"present", "missing"},
     )
-    for key in ("companion_entry", "repo_specific_requirements", "specialized_gates", "dynamic_tool_locators", "policy_locators"):
+    for key in (
+        "companion_entry",
+        "repo_specific_requirements",
+        "specialized_gates",
+        "dynamic_tool_locators",
+        "policy_locators",
+        "hook_locators",
+    ):
         require_locator_entry(
             failures,
             category=category,
@@ -7760,6 +7767,9 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             "checkpoints.md",
             "metadata-contract.md",
             "context-schema.md",
+            "hooks/before-run.md",
+            "hooks/after-run.md",
+            "hooks/cleanup.md",
             "review-instructions/spec.md",
             "review-instructions/implementation.md",
         ):
@@ -7971,6 +7981,34 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "fallback_to": "merge",
             },
         ],
+        "hook_locators": [
+            {
+                "id": "before-run-hook",
+                "summary": "Declare a lifecycle hook locator without executing it.",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+                "owner": "repo-companion",
+                "requirement": "required",
+                "fallback_to": "admission",
+            },
+            {
+                "id": "optional-after-run-hook",
+                "summary": "Declare an optional after-run hook locator.",
+                "lifecycle": "after-run",
+                "locator": ".loom/companion/hooks/missing-after-run.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "handoff",
+            },
+            {
+                "id": "advisory-cleanup-hook",
+                "summary": "Declare an advisory cleanup hook without requiring host-native support.",
+                "lifecycle": "cleanup",
+                "owner": "host-adapter",
+                "requirement": "advisory",
+                "fallback_to": "workspace cleanup|retire",
+            },
+        ],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",
@@ -8160,6 +8198,89 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         elif "outside-tool.json" not in json.dumps(invalid_optional_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional dynamic tool path escape must stay in blocking missing_inputs"))
 
+        invalid_hook_escape_target = base / "invalid-hook-escape"
+        shutil.copytree(example_target, invalid_hook_escape_target)
+        install_companion(
+            invalid_hook_escape_target,
+            manifest=valid_manifest,
+            repo_interface=valid_interface_v2,
+        )
+        hook_escape_interface_path = invalid_hook_escape_target / ".loom" / "companion" / "repo-interface.json"
+        hook_escape_payload = json.loads(hook_escape_interface_path.read_text(encoding="utf-8"))
+        hook_escape_payload["hook_locators"] = [
+            {
+                "id": "escaped-hook",
+                "summary": "Optional hook locator must still respect repository path boundaries.",
+                "lifecycle": "before-run",
+                "locator": "../outside-hook.md",
+                "owner": "repo-companion",
+                "requirement": "optional",
+                "fallback_to": "admission",
+            }
+        ]
+        write_json(hook_escape_interface_path, hook_escape_payload)
+        invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
+        invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
+        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
+        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+
+        invalid_hook_truth_target = base / "invalid-hook-truth"
+        shutil.copytree(example_target, invalid_hook_truth_target)
+        install_companion(
+            invalid_hook_truth_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "truth-polluting-hook",
+                        "summary": "Hook declarations must not carry authored or runtime truth.",
+                        "lifecycle": "after-run",
+                        "locator": ".loom/companion/hooks/after-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "handoff",
+                        "validation_status": "pass",
+                    }
+                ],
+            },
+        )
+        invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
+        invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
+        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
+        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
+
+        required_hook_missing_target = base / "required-hook-missing"
+        shutil.copytree(example_target, required_hook_missing_target)
+        install_companion(
+            required_hook_missing_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-missing-hook",
+                        "summary": "Required hook locator must block when missing.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/missing-required.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
+        required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
+        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
+        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
         install_companion(
@@ -8203,6 +8324,14 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
+        if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must not pollute core missing_inputs"))
         if isinstance(present_interface, dict):
             availability = present_interface.get("tool_availability")
             require_tool_availability_payload(

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -2079,6 +2079,7 @@ def default_repo_interface() -> dict[str, Any]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",

--- a/src/skills/shared/scripts/loom_init.py
+++ b/src/skills/shared/scripts/loom_init.py
@@ -1317,6 +1317,7 @@ def repo_interface_payload() -> dict[str, object]:
         "context_schema": {"fields": []},
         "dynamic_tool_locators": [],
         "policy_locators": [],
+        "hook_locators": [],
         "release_targets": {
             "catalog_locator": ".loom/companion/releases/catalog.json",
             "current_target_locator": ".loom/companion/releases/current.json",


### PR DESCRIPTION
## Summary

- Problem: close `#613` Batch 1 locator contract without implementing hook runtime, executing hooks, or generating host-native hook files.
- Scope: add the Loom hook locator contract, extend repo companion `hook_locators`, freeze Codex/Claude Code lifecycle mapping, add repo-interface validation and loom_check fixtures, regenerate skills surface references, and bump the installer package version because the skills payload changed.

## Validation

- [x] Verified locally
- [ ] Verified by automation
- [ ] Not applicable

Validation details:

- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_check.py` (`checked 33 surfaces`)

## Risks And Follow-ups

- Risks: this only freezes declaration, mapping, and validation semantics; it intentionally does not prove any host-native hook execution behavior.
- Follow-ups: future implementation work should use a separate issue-scoped branch and must not expand this PR into hook runtime execution.

## Related Work

- Issue: `#613`
- Work Item: `#614` covers the lifecycle hook locator contract.
- Work Item: `#615` covers repo companion `hook_locators` declaration.
- Work Item: `#616` covers hook locator safety fixtures.
- Work Item: `#735` covers host hook capability matrix and lifecycle mapping.
- Spec / plan: v0.11.0 Batch 1 hook locator contract scope from `#534`.
