### PR TITLE
feat(harness): define hook envelope contract

### DIFF
--- a/docs/methodology/harness/README.md
+++ b/docs/methodology/harness/README.md
@@ -21,6 +21,8 @@
   - 定义 approval / sandbox policy 读面、missing / conflict / unsafe 词表、风险摘要与 host-adapter 边界
 - [hook-locator-contract.md](./hook-locator-contract.md)
   - 定义 lifecycle hook locator、host-native adapter mapping、extension 结果词表与 runtime-evidence-only 边界
+- [hook-envelope-contract.md](./hook-envelope-contract.md)
+  - 定义 mapped hook envelope、context injection / blocking decision / runtime evidence 分类与 failure 语义
 - [structured-event-evidence.md](./structured-event-evidence.md)
   - 定义 agent / tool / validation / failure / tracker event evidence 的字段、fake orchestration fixtures 与禁止承载 authored truth 的边界
 - [subagent-driven-execution.md](./subagent-driven-execution.md)

--- a/docs/methodology/harness/hook-envelope-contract.md
+++ b/docs/methodology/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.95",
+      "version": "0.1.96",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.95",
+  "version": "0.1.96",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/install-layout.json
+++ b/skills/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-adopt/.loom-runtime/install-layout.json
+++ b/skills/loom-adopt/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-adopt/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-adopt/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-build/.loom-runtime/install-layout.json
+++ b/skills/loom-build/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-build/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-build/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-handoff/.loom-runtime/install-layout.json
+++ b/skills/loom-handoff/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-handoff/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-handoff/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-init/.loom-runtime/install-layout.json
+++ b/skills/loom-init/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-init/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-init/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-merge-ready/.loom-runtime/install-layout.json
+++ b/skills/loom-merge-ready/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-merge-ready/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-merge-ready/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-pre-review/.loom-runtime/install-layout.json
+++ b/skills/loom-pre-review/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-pre-review/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-pre-review/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-resume/.loom-runtime/install-layout.json
+++ b/skills/loom-resume/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-resume/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-resume/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-retire/.loom-runtime/install-layout.json
+++ b/skills/loom-retire/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-retire/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-retire/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-review/.loom-runtime/install-layout.json
+++ b/skills/loom-review/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-review/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-review/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-spec-review/.loom-runtime/install-layout.json
+++ b/skills/loom-spec-review/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-spec-review/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-spec-review/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/loom-story/.loom-runtime/install-layout.json
+++ b/skills/loom-story/.loom-runtime/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/skills/loom-story/.loom-runtime/shared/references/harness/hook-envelope-contract.md
+++ b/skills/loom-story/.loom-runtime/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/skills/shared/references/harness/hook-envelope-contract.md
+++ b/skills/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 

--- a/src/skills/install-layout.json
+++ b/src/skills/install-layout.json
@@ -47,6 +47,7 @@
     "shared/references/harness/repo-local-gate-starter.md",
     "shared/references/harness/automation-frontload.md",
     "shared/references/harness/hook-locator-contract.md",
+    "shared/references/harness/hook-envelope-contract.md",
     "shared/references/harness/workspace-lifecycle.md",
     "shared/references/harness/workspace-and-purity.md",
     "shared/references/harness/worker-backend-contract.md",

--- a/src/skills/shared/references/harness/hook-envelope-contract.md
+++ b/src/skills/shared/references/harness/hook-envelope-contract.md
@@ -1,0 +1,110 @@
+# Hook Envelope Contract
+
+This file defines Loom's mapped hook envelope contract. It freezes how host
+hook output is classified after adapter mapping; it does not introduce hook
+execution or host-native hook file generation.
+
+## Goal
+
+`loom-hook-envelope/v1` lets Loom consume hook-related information without
+treating Codex, Claude Code, or another host's native hook fields as authored
+truth.
+
+The stable output categories are:
+
+- `context_injection`
+- `blocking_decision`
+- `runtime_evidence`
+
+Adapters must map host-native output into one of these categories before Loom
+can consume it.
+
+## Required Shape
+
+Each envelope is a JSON object with:
+
+- `schema_version`: `loom-hook-envelope/v1`
+- `hook`: `id`, `lifecycle`, and `locator`
+- `input`: `item_locator`, `workspace_locator`, `attempt_locator`, and
+  `host_adapter_mapping`
+- `output`: `category`, `summary`, and optional mapped `evidence`
+- `failure`: optional `classification`, `summary`, and `fallback_to`
+
+Allowed lifecycle values are `before-run`, `after-run`, and `cleanup`.
+
+The `host_adapter_mapping` block identifies the host adapter mapping that
+produced the Loom envelope. It must include:
+
+- `host`
+- `event`
+- `adapter_result`
+
+`adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
+
+## Failure Semantics
+
+Failure classification is limited to:
+
+- `invalid_envelope`
+- `missing_required_input`
+- `unsupported`
+- `not_applicable`
+- `permission_unavailable`
+- `unsafe`
+- `host_mapping_failed`
+
+`fallback_to` can only point to a Loom surface or human repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook.
+
+Allowed fallback values are:
+
+- `admission`
+- `pre_review`
+- `review`
+- `build`
+- `merge_ready`
+- `closeout`
+- `manual_repair`
+- `workspace cleanup|retire`
+
+## Truth Boundary
+
+Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
+must not carry:
+
+- authored progress
+- recovery or status truth
+- review verdict
+- validation summary
+- host action result
+- closeout basis
+
+`context_injection` can provide context to a host prompt or tool boundary, but it
+must not author progress, status, review, validation, or closeout truth.
+
+`blocking_decision` can block the configured hook path, but it does not replace
+review verdicts, merge-ready decisions, or closeout basis.
+
+`runtime_evidence` can be consumed as runtime evidence only after adapter
+mapping.
+
+## Live Check
+
+`loom_flow live-smoke hook-envelope --target <repo> --envelope <path>` reads and
+validates a repo-relative envelope file. It does not execute hooks.
+
+The live check reports:
+
+- `pass` for valid envelopes
+- `warn` for optional or advisory missing/invalid envelopes
+- `block` for required missing, invalid, unsafe, or truth-polluting envelopes
+
+The command is profile-local evidence. It must not write authored progress or
+modify host-native hook configuration.
+
+## Non-goals
+
+- executing hooks
+- generating Codex or Claude Code native hook files
+- defining hook safety invariants for #621
+- defining hooks extension profile gating for #625

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -25,8 +25,8 @@ from governance_surface import build_governance_surface
 from loom_flow import allowed_post_review_carrier_paths, repo_specific_requirements_payload, review_head_binding
 from runtime_paths import repo_local_root
 
-DEFAULT_COMMAND_TIMEOUT_SECONDS = 15.0
-ADOPT_VERIFY_TIMEOUT_SECONDS = 60.0
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 30.0
+ADOPT_VERIFY_TIMEOUT_SECONDS = 120.0
 
 TOP_LEVEL_DIRS = (
     "docs",
@@ -2249,6 +2249,122 @@ def require_dynamic_tool_live_availability_payload(
         context=f"{context}.dynamic_tool_availability.tool_availability",
         payload=dynamic_tool_availability.get("tool_availability"),
     )
+
+
+def require_hook_envelope_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hook-envelope":
+        failures.append(Failure(category, f"{context} must report `operation: hook-envelope`"))
+    if payload.get("schema_version") != "loom-hook-envelope-check/v1":
+        failures.append(Failure(category, f"{context} schema_version must be `loom-hook-envelope-check/v1`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hook envelope check contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hook-envelope":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hook-envelope`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    hook_envelope = payload.get("hook_envelope")
+    if not isinstance(hook_envelope, dict):
+        failures.append(Failure(category, f"{context} must include `hook_envelope`"))
+        return
+    if hook_envelope.get("availability") not in {
+        "present",
+        "incomplete",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+        "missing-envelope",
+        "invalid-declaration",
+    }:
+        failures.append(Failure(category, f"{context} hook_envelope.availability is outside the stable vocabulary"))
+    if hook_envelope.get("requirement") not in {"required", "optional", "advisory"}:
+        failures.append(Failure(category, f"{context} hook_envelope.requirement must be `required`, `optional`, or `advisory`"))
+    checks = hook_envelope.get("checks")
+    if not isinstance(checks, list):
+        failures.append(Failure(category, f"{context} hook_envelope.checks must be a list"))
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "requirement", "locator", "result", "classification", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] missing `{field}`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] result must stay within `pass | warn | block`"))
+        if check.get("classification") not in {
+            "none",
+            "invalid_envelope",
+            "missing_required_input",
+            "unsupported",
+            "not_applicable",
+            "permission_unavailable",
+            "unsafe",
+            "host_mapping_failed",
+        }:
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] classification is outside the stable vocabulary"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
+        if not isinstance(check.get("evidence"), dict):
+            failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
 
 
 def require_github_binding_payload(
@@ -11491,6 +11607,272 @@ def check_dynamic_tool_live_availability_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hook_envelope_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    docs = {
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "loom-hook-envelope/v1",
+            "context_injection",
+            "blocking_decision",
+            "runtime_evidence",
+            "permission_unavailable",
+            "host_mapping_failed",
+            "must not carry",
+        ],
+        "docs/methodology/harness/README.md": [
+            "hook-envelope-contract.md",
+            "context injection / blocking decision / runtime evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hook-envelope", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hook-envelope", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+
+    def valid_envelope(category: str) -> dict[str, object]:
+        return {
+            "schema_version": "loom-hook-envelope/v1",
+            "hook": {
+                "id": f"{category}-hook",
+                "lifecycle": "before-run",
+                "locator": ".loom/companion/hooks/before-run.md",
+            },
+            "input": {
+                "item_locator": ".loom/items/WI-617.md",
+                "workspace_locator": ".loom/workspaces/current.json",
+                "attempt_locator": ".loom/runtime/attempts/attempt-1.json",
+                "host_adapter_mapping": {
+                    "host": "codex",
+                    "event": "PreToolUse",
+                    "adapter_result": "supported",
+                },
+            },
+            "output": {
+                "category": category,
+                "summary": f"{category} output mapped into Loom envelope.",
+                "evidence": {"mapped": True},
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hook-envelope-") as tmp:
+        base = Path(tmp)
+        valid_target = base / "valid"
+        shutil.copytree(example_target, valid_target)
+        for category in ("context_injection", "blocking_decision", "runtime_evidence"):
+            locator = f".loom/companion/hooks/{category}.json"
+            write_json_local(valid_target / locator, valid_envelope(category))
+            payload, error = load_command_json(
+                root,
+                [
+                    "python3",
+                    "tools/loom_flow.py",
+                    "live-smoke",
+                    "hook-envelope",
+                    "--target",
+                    str(valid_target),
+                    "--envelope",
+                    locator,
+                ],
+            )
+            if error:
+                failures.append(Failure("hook-envelope", f"`hook-envelope` valid {category} sample failed: {error}"))
+            else:
+                require_hook_envelope_live_check_payload(
+                    failures,
+                    category="hook-envelope",
+                    context=f"valid-{category}-hook-envelope",
+                    payload=payload,
+                )
+                if not isinstance(payload, dict) or payload.get("result") != "pass":
+                    failures.append(Failure("hook-envelope", f"valid {category} hook envelope must pass"))
+
+        missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-required.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing required sample failed: {error}"))
+        elif not isinstance(missing_payload, dict) or missing_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "required missing hook envelope must block"))
+
+        optional_missing_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(valid_target),
+                "--envelope",
+                ".loom/companion/hooks/missing-optional.json",
+                "--requirement",
+                "optional",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` missing optional sample failed: {error}"))
+        elif not isinstance(optional_missing_payload, dict) or optional_missing_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "optional missing hook envelope must warn"))
+
+        invalid_category_target = base / "invalid-category"
+        shutil.copytree(example_target, invalid_category_target)
+        invalid_category = valid_envelope("runtime_evidence")
+        invalid_category["output"] = {"category": "host_raw_output", "summary": "invalid category"}
+        write_json_local(invalid_category_target / ".loom/companion/hooks/invalid-category.json", invalid_category)
+        invalid_category_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(invalid_category_target),
+                "--envelope",
+                ".loom/companion/hooks/invalid-category.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` invalid category sample failed: {error}"))
+        elif not isinstance(invalid_category_payload, dict) or invalid_category_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "invalid hook envelope category must block"))
+
+        truth_target = base / "truth-pollution"
+        shutil.copytree(example_target, truth_target)
+        truth_polluting = valid_envelope("runtime_evidence")
+        truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "truth pollution must fail",
+            "authored_progress": "done",
+        }
+        write_json_local(truth_target / ".loom/companion/hooks/truth.json", truth_polluting)
+        truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(truth_target),
+                "--envelope",
+                ".loom/companion/hooks/truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` truth pollution sample failed: {error}"))
+        elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
+
+        permission_target = base / "permission"
+        shutil.copytree(example_target, permission_target)
+        permission_envelope = valid_envelope("blocking_decision")
+        permission_envelope["failure"] = {
+            "classification": "permission_unavailable",
+            "summary": "host permission is unavailable after adapter mapping.",
+            "fallback_to": "build",
+        }
+        write_json_local(permission_target / ".loom/companion/hooks/permission.json", permission_envelope)
+        permission_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(permission_target),
+                "--envelope",
+                ".loom/companion/hooks/permission.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` permission sample failed: {error}"))
+        elif not isinstance(permission_payload, dict) or permission_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "permission_unavailable hook envelope must block when required"))
+
+        advisory_unsafe_target = base / "advisory-unsafe"
+        shutil.copytree(example_target, advisory_unsafe_target)
+        unsafe_envelope = valid_envelope("blocking_decision")
+        unsafe_envelope["failure"] = {
+            "classification": "unsafe",
+            "summary": "host mapping reported unsafe.",
+            "fallback_to": "manual_repair",
+        }
+        write_json_local(advisory_unsafe_target / ".loom/companion/hooks/unsafe.json", unsafe_envelope)
+        advisory_unsafe_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(advisory_unsafe_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe.json",
+                "--requirement",
+                "advisory",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` advisory unsafe sample failed: {error}"))
+        elif not isinstance(advisory_unsafe_payload, dict) or advisory_unsafe_payload.get("result") != "warn":
+            failures.append(Failure("hook-envelope", "advisory unsafe hook envelope must warn"))
+
+        host_private_target = base / "host-private-fallback"
+        shutil.copytree(example_target, host_private_target)
+        host_private = valid_envelope("blocking_decision")
+        host_private["failure"] = {
+            "classification": "unsupported",
+            "summary": "fallback must not point to host-private action.",
+            "fallback_to": "Codex SessionEnd",
+        }
+        write_json_local(host_private_target / ".loom/companion/hooks/host-private.json", host_private)
+        host_private_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(host_private_target),
+                "--envelope",
+                ".loom/companion/hooks/host-private.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
+        elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13074,6 +13456,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_live_smoke_foundation_contract(root))
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
+    failures.extend(check_hook_envelope_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))
@@ -13088,7 +13471,7 @@ def collect_failures(root: Path) -> list[Failure]:
 
 
 def print_report(root: Path, failures: list[Failure]) -> None:
-    categories_checked = 33
+    categories_checked = 34
     if not failures:
         print(f"loom_check: OK ({root})")
         print(f"checked {categories_checked} surfaces")

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -118,9 +118,43 @@ REVIEW_ENGINE_REASONING_EFFORTS = {"low", "medium", "high", "xhigh"}
 LIVE_SMOKE_SCHEMA = "loom-live-smoke/v1"
 HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
+HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
+HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
+HOOK_ENVELOPE_CATEGORIES = {"context_injection", "blocking_decision", "runtime_evidence"}
+HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS = {
+    "invalid_envelope",
+    "missing_required_input",
+    "unsupported",
+    "not_applicable",
+    "permission_unavailable",
+    "unsafe",
+    "host_mapping_failed",
+}
+HOOK_ENVELOPE_FALLBACKS = {
+    None,
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+}
+HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
+    "authored_progress",
+    "recovery_truth",
+    "status_truth",
+    "review_verdict",
+    "validation_summary",
+    "host_action_result",
+    "closeout_basis",
+}
+HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
     "default": {
         "profile_id": "default",
@@ -508,7 +542,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -518,6 +552,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=("attempt_time", "review", "merge_ready", "closeout", "build", "admission", "pre_review", "all"),
         default="attempt_time",
         help="Dynamic tool live availability surface; defaults to attempt_time",
+    )
+    live_smoke.add_argument("--envelope", help="Repo-relative Loom hook envelope path for live-smoke hook-envelope")
+    live_smoke.add_argument(
+        "--requirement",
+        choices=("required", "optional", "advisory"),
+        default="required",
+        help="Hook envelope requirement level; defaults to required",
     )
     live_smoke.add_argument(
         "--include-blocking-shadow",
@@ -741,6 +782,21 @@ def dynamic_tool_live_availability_command(target_root: Path, *, surface: str) -
     return live_smoke_command(["live-smoke", "dynamic-tool-availability", "--target", str(target_root), "--surface", surface])
 
 
+def hook_envelope_command(target_root: Path, *, envelope: str, requirement: str) -> str:
+    return live_smoke_command(
+        [
+            "live-smoke",
+            "hook-envelope",
+            "--target",
+            str(target_root),
+            "--envelope",
+            envelope,
+            "--requirement",
+            requirement,
+        ]
+    )
+
+
 def host_adapter_live_drift_command_plan(target_root: Path, host_adapters: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     target = command_target(target_root)
     plan = [
@@ -798,6 +854,166 @@ def dynamic_tool_live_availability_command_plan(
             }
         )
     return plan
+
+
+def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading the mapped hook envelope.",
+        },
+        {
+            "id": "hook-envelope",
+            "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
+            "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_label = str(key)
+            nested_prefix = f"{prefix}.{key_label}"
+            if key_label in HOOK_ENVELOPE_FORBIDDEN_FIELDS:
+                found.append(nested_prefix)
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=nested_prefix))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_forbidden_hook_envelope_fields(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
+def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
+    missing_inputs: list[str] = []
+    evidence: dict[str, Any] = {
+        "schema_status": "unknown",
+        "output_category": None,
+        "failure_classification": None,
+    }
+    if not isinstance(envelope, dict):
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope must be a JSON object.",
+            "missing_inputs": ["hook envelope must be a JSON object"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if envelope.get("schema_version") != HOOK_ENVELOPE_SCHEMA:
+        missing_inputs.append("schema_version must be `loom-hook-envelope/v1`")
+    else:
+        evidence["schema_status"] = "valid"
+
+    hook = envelope.get("hook")
+    if not isinstance(hook, dict):
+        missing_inputs.append("hook envelope missing `hook` object")
+    else:
+        for field in ("id", "locator"):
+            value = hook.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"hook missing `{field}`")
+        lifecycle = hook.get("lifecycle")
+        if lifecycle not in HOOK_LIFECYCLES:
+            missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
+
+    input_payload = envelope.get("input")
+    if not isinstance(input_payload, dict):
+        missing_inputs.append("hook envelope missing `input` object")
+    else:
+        for field in ("item_locator", "workspace_locator", "attempt_locator"):
+            value = input_payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_inputs.append(f"input missing `{field}`")
+        mapping = input_payload.get("host_adapter_mapping")
+        if not isinstance(mapping, dict):
+            missing_inputs.append("input missing `host_adapter_mapping` object")
+        else:
+            for field in ("host", "event"):
+                value = mapping.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    missing_inputs.append(f"host_adapter_mapping missing `{field}`")
+            if mapping.get("adapter_result") not in HOOK_ADAPTER_RESULTS:
+                missing_inputs.append(
+                    "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
+                )
+
+    output = envelope.get("output")
+    output_category = None
+    if not isinstance(output, dict):
+        missing_inputs.append("hook envelope missing `output` object")
+    else:
+        output_category = output.get("category")
+        evidence["output_category"] = output_category
+        if output_category not in HOOK_ENVELOPE_CATEGORIES:
+            missing_inputs.append("output.category must be `context_injection`, `blocking_decision`, or `runtime_evidence`")
+        summary = output.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            missing_inputs.append("output missing `summary`")
+
+    forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
+    if forbidden_fields:
+        missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+
+    failure = envelope.get("failure")
+    failure_classification = None
+    fallback_to = None
+    if failure is not None:
+        if not isinstance(failure, dict):
+            missing_inputs.append("failure must be an object when present")
+        else:
+            failure_classification = failure.get("classification")
+            evidence["failure_classification"] = failure_classification
+            if failure_classification not in HOOK_ENVELOPE_FAILURE_CLASSIFICATIONS:
+                missing_inputs.append("failure.classification is outside the stable hook envelope vocabulary")
+            fallback_to = failure.get("fallback_to")
+            if fallback_to not in HOOK_ENVELOPE_FALLBACKS:
+                missing_inputs.append("failure.fallback_to must point to a Loom surface or manual repair path")
+            summary = failure.get("summary")
+            if failure_classification and (not isinstance(summary, str) or not summary.strip()):
+                missing_inputs.append("failure with classification must include `summary`")
+
+    if missing_inputs:
+        return {
+            "result": "block",
+            "classification": "invalid_envelope",
+            "summary": "hook envelope is invalid or truth-polluting.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if failure_classification == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook envelope reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if failure_classification:
+        result = "block" if failure_classification in {"permission_unavailable", "unsafe", "host_mapping_failed"} else "warn"
+        return {
+            "result": result,
+            "classification": failure_classification,
+            "summary": str(failure.get("summary") if isinstance(failure, dict) else "hook envelope reports failure."),
+            "missing_inputs": [f"hook envelope reported {failure_classification}"] if result == "block" else [],
+            "fallback_to": fallback_to if result == "block" else None,
+            "evidence": evidence,
+        }
+    return {
+        "result": "pass",
+        "classification": "none",
+        "summary": f"hook envelope maps output as `{output_category}`.",
+        "missing_inputs": [],
+        "fallback_to": None,
+        "evidence": evidence,
+    }
 
 
 def host_adapter_permission_unavailable(payload: dict[str, Any]) -> bool:
@@ -1268,6 +1484,224 @@ def host_adapter_live_drift_payload(target_root: Path) -> dict[str, Any]:
                 "availability": "present",
                 "expected_host_adapter_version": expected_version,
                 "checks": checks,
+            },
+        }
+    )
+    return payload
+
+
+def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hook-envelope",
+        "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hook_envelope_command_plan(target_root, envelope=envelope),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if requirement not in {"required", "optional", "advisory"}:
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check requires requirement to be required, optional, or advisory.",
+                "missing_inputs": ["--requirement must be `required`, `optional`, or `advisory`"],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "invalid-declaration",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+    if runtime_state.get("result") != "pass":
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "runtime-blocked",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    payload["missing_inputs"] = list(target_report.get("missing_inputs", []))
+    if target_report["result"] != "pass":
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hook envelope check recorded explicit unavailable evidence for the adopted-repo target.",
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "warn"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "target-unavailable",
+                    "requirement": requirement,
+                    "checks": [],
+                },
+            }
+        )
+        return payload
+
+    envelope_path, envelope_errors = resolve_repo_relative_path(target_root, envelope, label="hook envelope locator")
+    if envelope_errors:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook envelope locator is outside the repository boundary or otherwise unsafe.",
+            "missing_inputs": envelope_errors,
+            "fallback_to": "manual_repair",
+            "evidence": {"locator_status": "unsafe"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "unsafe",
+                "result": "block",
+                "summary": check["summary"],
+                "missing_inputs": envelope_errors,
+                "fallback_to": "manual_repair",
+            }
+        )
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hook envelope check found an unsafe locator.",
+                "missing_inputs": live_smoke_missing_inputs(envelope_errors),
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                "profile_check": {"id": "hook-envelope", "result": "block"},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+    assert envelope_path is not None
+
+    if not envelope_path.exists():
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator points to missing path `{envelope}`"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "missing_required_input" if result == "block" else "not_applicable",
+            "summary": "hook envelope locator is missing.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "missing"},
+        }
+        payload["reports"].append(
+            {
+                "id": "hook-envelope",
+                "attempted": True,
+                "command": f"read {envelope}",
+                "reported_command": "hook-envelope",
+                "reported_result": "missing",
+                "result": result,
+                "summary": check["summary"],
+                "missing_inputs": missing_inputs,
+                "fallback_to": check["fallback_to"],
+            }
+        )
+        payload.update(
+            {
+                "result": result,
+                "summary": "hook envelope locator is missing.",
+                "missing_inputs": live_smoke_missing_inputs(missing_inputs) if result == "block" else [],
+                "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+                "profile_check": {"id": "hook-envelope", "result": result},
+                "hook_envelope": {
+                    "contract_locator": envelope,
+                    "availability": "incomplete",
+                    "requirement": requirement,
+                    "checks": [check],
+                },
+            }
+        )
+        return payload
+
+    try:
+        envelope_payload = load_json_file(envelope_path)
+    except (FileNotFoundError, json.JSONDecodeError, OSError) as exc:
+        result = "block" if requirement == "required" else "warn"
+        missing_inputs = [f"hook envelope locator is unreadable: {exc}"]
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            "result": result,
+            "classification": "invalid_envelope",
+            "summary": "hook envelope locator is unreadable.",
+            "missing_inputs": missing_inputs,
+            "fallback_to": "manual_repair" if result == "block" else None,
+            "evidence": {"locator_status": "unreadable"},
+        }
+    else:
+        check = {
+            "id": "hook-envelope",
+            "requirement": requirement,
+            "locator": envelope,
+            **validate_hook_envelope_payload(envelope_payload),
+        }
+        check["evidence"] = {"locator_status": "readable", **dict(check.get("evidence", {}))}
+        if requirement in {"optional", "advisory"} and check["result"] == "block":
+            check["result"] = "warn"
+            check["fallback_to"] = None
+            check["missing_inputs"] = []
+
+    payload["reports"].append(
+        {
+            "id": "hook-envelope",
+            "attempted": True,
+            "command": f"read {envelope}",
+            "reported_command": "hook-envelope",
+            "reported_result": str(check["classification"]),
+            "result": str(check["result"]),
+            "summary": str(check["summary"]),
+            "missing_inputs": list(check.get("missing_inputs", [])),
+            "fallback_to": check.get("fallback_to"),
+        }
+    )
+    result = str(check["result"])
+    payload.update(
+        {
+            "result": result,
+            "summary": "hook envelope is valid." if result == "pass" else "hook envelope check produced warnings." if result == "warn" else "hook envelope check found blocking errors.",
+            "missing_inputs": live_smoke_missing_inputs(list(check.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hook-envelope", "result": result},
+            "hook_envelope": {
+                "contract_locator": envelope,
+                "availability": "present",
+                "requirement": requirement,
+                "checks": [check],
             },
         }
     )
@@ -12066,6 +12500,61 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
             dynamic_tool_live_availability_payload(
                 Path(args.target).expanduser().resolve(),
                 surface=args.surface,
+            )
+        )
+    if args.operation == "hook-envelope":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-target",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        if not args.envelope:
+            target_root = Path(args.target).expanduser().resolve()
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hook-envelope",
+                    "schema_version": HOOK_ENVELOPE_LIVE_CHECK_SCHEMA,
+                    "result": "block",
+                    "summary": "hook envelope check requires --envelope.",
+                    "missing_inputs": ["pass --envelope <repo_relative_envelope_path>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(target_root),
+                    "target": live_smoke_target_metadata(target_root),
+                    "command_plan": hook_envelope_command_plan(target_root, envelope=args.envelope),
+                    "reports": [],
+                    "profile_check": {"id": "hook-envelope", "result": "block"},
+                    "hook_envelope": {
+                        "contract_locator": args.envelope,
+                        "availability": "missing-envelope",
+                        "requirement": args.requirement,
+                        "checks": [],
+                    },
+                }
+            )
+        return emit(
+            hook_envelope_payload(
+                Path(args.target).expanduser().resolve(),
+                envelope=args.envelope,
+                requirement=args.requirement,
             )
         )
 


### PR DESCRIPTION
## Summary

- Problem: close `#617` Batch 2 hook envelope contract without implementing hook runtime, executing hooks, generating host-native hook files, or activating #621/#625.
- Scope: add `loom-hook-envelope/v1`, define context injection / blocking decision / runtime evidence mapping, add `live-smoke hook-envelope` read-only validation, add fixtures, sync skills surface, and bump installer version because the skills payload changed.

## Validation

- [x] Verified locally
- [ ] Verified by automation
- [ ] Not applicable

Validation details:

- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py generate`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_check.py` (`checked 34 surfaces`)

## Risks And Follow-ups

- Risks: this validates mapped hook envelopes only; it intentionally does not prove host-native hook execution behavior.
- Follow-ups: #621 remains deferred and should own hook safety invariants after envelope/failure semantics are closed.

## Related Work

- Issue: `#617`
- Work Item: `#618` covers hook input/output/failure shape documentation.
- Work Item: `#619` covers envelope structure validation.
- Work Item: `#620` covers hook failure shape fixtures.
- Deferred boundary: `#621/#622/#623/#624/#625/#626/#627/#628` remain `closed + deferred-roadmap`.
