### PR TITLE
feat(harness): freeze hook safety invariants

### DIFF
--- a/docs/adoption/repo-companion-contract.md
+++ b/docs/adoption/repo-companion-contract.md
@@ -347,6 +347,7 @@
 - `owner`
 - `requirement`
 - `fallback_to`
+- `safety`
 
 其中：
 
@@ -357,10 +358,12 @@
 - `owner` 只允许 `repo | repo-companion | host | host-adapter | platform | external-tool`
 - `requirement` 只允许 `required | optional | advisory`
 - `fallback_to` 只描述声明不可消费时的 Loom 回退面或人工路径，不描述宿主执行动作
+- `safety` 固定声明 `path_containment`、`truth_boundary`、`cleanup_scope`、`host_trust` 与 `permission_risk`
 
 稳定约束：
 
 - `hook_locators` 只承接 declaration-time locator，不承接 runtime state、execution result、authored progress、review verdict、validation status、host action result 或 closeout basis
+- required hook 缺少 `safety`、`host_trust: untrusted`、`permission_risk: unknown` 或 cleanup scope 越界时必须 fail closed
 - host adapter 可以从 `hook_locators` 生成 Codex / Claude Code native hook config，但 generated config 不替代 Loom locator contract
 - host-native hook output 只有经过 adapter 映射后才能成为 runtime evidence
 - cleanup hook 始终受 [workspace-lifecycle.md](../methodology/harness/workspace-lifecycle.md) 约束；Codex cleanup 不能作为 required native hook

--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -37,6 +37,8 @@ Core 缺口必须 fail closed，因为这些能力构成 Loom v0.7.0 的可恢�
 
 - repo companion / repo interop locator-only 合同
 - host action / dynamic tool declaration-time locator contract
+- hook locator safety declarations, mapped hook envelopes, and unsafe
+  host-adapter results
 - host-backed tracker state 只能作为 structured event evidence 或 retained host result 被消费
 - required locator missing / unreadable / invalid boundary 的 fail-closed 行为
 - optional / advisory missing in-repo locator 只进入 profile-local `missing_optional`

--- a/docs/methodology/harness/hook-envelope-contract.md
+++ b/docs/methodology/harness/hook-envelope-contract.md
@@ -41,6 +41,11 @@ produced the Loom envelope. It must include:
 
 `adapter_result` must be `supported`, `not_applicable`, `advisory`, or `unsafe`.
 
+`adapter_result: unsafe` is a hook safety invariant violation. A required hook
+path must fail closed, and optional/advisory hook paths may only report
+profile-local warnings. `not_applicable` and `advisory` are explicit mapped
+states; they do not become authored progress or validation truth.
+
 ## Failure Semantics
 
 Failure classification is limited to:
@@ -73,6 +78,8 @@ Hook envelopes are mapped runtime evidence or mapped blocking decisions. They
 must not carry:
 
 - authored progress
+- recovery authored fields such as `next_step`, `blockers`, `current_checkpoint`,
+  or `latest_validation_summary`
 - recovery or status truth
 - review verdict
 - validation summary
@@ -87,6 +94,12 @@ review verdicts, merge-ready decisions, or closeout basis.
 
 `runtime_evidence` can be consumed as runtime evidence only after adapter
 mapping.
+
+Cleanup intent may appear only as mapped runtime evidence and must be constrained
+to explicit Loom-owned residue. A cleanup envelope that declares repo-owned,
+host-owned, workspace-root, or unknown-ownership targets is unsafe and fails
+closed. This fixture models the attempted deletion; Loom still does not execute
+hooks.
 
 ## Live Check
 
@@ -106,5 +119,4 @@ modify host-native hook configuration.
 
 - executing hooks
 - generating Codex or Claude Code native hook files
-- defining hook safety invariants for #621
 - defining hooks extension profile gating for #625

--- a/docs/methodology/harness/hook-locator-contract.md
+++ b/docs/methodology/harness/hook-locator-contract.md
@@ -44,13 +44,51 @@ Each entry uses:
 - `owner`
 - `requirement`
 - `fallback_to`
+- `safety`
 
 Allowed `lifecycle` values are `before-run`, `after-run`, and `cleanup`.
 Allowed `requirement` values are `required`, `optional`, and `advisory`.
 
+`fallback_to` must point to a Loom surface or manual repair path. It must not
+point to a host-private action such as a Codex or Claude Code native hook event.
+
 `hook_locators` are declaration-time locators. They must not carry runtime
 state, execution result, authored progress, review verdict, validation status,
 host action result, or closeout basis.
+
+## Safety Invariants
+
+Each enabled or required hook declaration must include a `safety` object. Missing
+safety on an optional or advisory hook remains profile-local advisory evidence;
+missing safety on a required hook fails closed.
+
+The stable safety fields are:
+
+- `path_containment`: must be `repo_relative`
+- `truth_boundary`: `runtime_evidence_only`, `context_only`, or `blocking_decision_only`
+- `cleanup_scope`: `not_applicable` or `loom_owned_only`
+- `host_trust`: `trusted`, `requires_review`, or `untrusted`
+- `permission_risk`: `none`, `approval_required`, `sandbox_required`, or `unknown`
+
+Safety evaluation is declaration-time only. It does not execute hooks, inspect
+host-private hook files, or write status/recovery truth.
+
+Stable fail-closed conditions:
+
+- locator is absolute, contains `..`, or resolves outside the repository root
+- a required hook locator is missing or unreadable
+- a required hook lacks a safety declaration
+- the declaration carries authored progress, recovery/status truth, validation,
+  review, host action, or closeout fields
+- `host_trust` is `untrusted`
+- `permission_risk` is `unknown`
+- `cleanup` does not declare `cleanup_scope: loom_owned_only`
+- non-cleanup lifecycle declares cleanup deletion scope
+
+Cleanup safety is constrained to explicit Loom-owned residue. Cleanup hooks must
+not delete the workspace root, host git worktree state, repo-owned artifacts, or
+unmarked files. Unsafe cleanup declarations fail closed before any host-native
+hook mapping can be consumed.
 
 ## Host Adapter Mapping
 
@@ -78,6 +116,10 @@ The adapter result vocabulary is:
 - `not_applicable`
 - `advisory`
 - `unsafe`
+
+`unsafe` adapter results fail closed when the hook path is required. Advisory or
+not-applicable mappings remain profile-local evidence unless an adopted
+repository explicitly opts into a stronger extension gate.
 
 ## Evidence Boundary
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.96",
+      "version": "0.1.97",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.96",
+  "version": "0.1.97",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -366,6 +366,23 @@ DYNAMIC_TOOL_HANDSHAKE_FAILURE_CATEGORIES = {
 }
 DYNAMIC_TOOL_SURFACES = REPO_INTERFACE_GATE_TYPES | {"attempt_time"}
 HOOK_LOCATOR_LIFECYCLES = {"before-run", "after-run", "cleanup"}
+HOOK_LOCATOR_FALLBACKS = {
+    "admission",
+    "pre_review",
+    "review",
+    "build",
+    "merge_ready",
+    "closeout",
+    "manual_repair",
+    "workspace cleanup|retire",
+    "handoff",
+    "merge",
+}
+HOOK_SAFETY_PATH_CONTAINMENT = {"repo_relative"}
+HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocking_decision_only"}
+HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
+HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
+HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1155,6 +1172,9 @@ def validate_hook_locator(
     requirement = entry.get("requirement")
     if requirement not in DECLARED_LOCATOR_REQUIREMENTS:
         blocking.append(f"{prefix} requirement must be `required`, `optional`, or `advisory`")
+    fallback_to = entry.get("fallback_to")
+    if fallback_to not in HOOK_LOCATOR_FALLBACKS:
+        blocking.append(f"{prefix} fallback_to must point to a Loom surface or manual repair path")
 
     forbidden_fields = sorted(
         set(entry)
@@ -1162,6 +1182,14 @@ def validate_hook_locator(
             "runtime_state",
             "execution_result",
             "authored_progress",
+            "current_stop",
+            "next_step",
+            "blockers",
+            "latest_validation_summary",
+            "current_checkpoint",
+            "current_lane",
+            "recovery_boundary",
+            "closing_condition",
             "review_verdict",
             "review_summary",
             "validation_status",
@@ -1171,6 +1199,44 @@ def validate_hook_locator(
     )
     if forbidden_fields:
         blocking.append(f"{prefix} must not carry runtime or authored truth fields: {', '.join(forbidden_fields)}")
+
+    safety = entry.get("safety")
+    safety_errors: list[str] = []
+    if not isinstance(safety, dict):
+        safety_errors.append(f"{prefix} missing `safety` declaration")
+    else:
+        path_containment = safety.get("path_containment")
+        truth_boundary = safety.get("truth_boundary")
+        cleanup_scope = safety.get("cleanup_scope")
+        host_trust = safety.get("host_trust")
+        permission_risk = safety.get("permission_risk")
+        if path_containment not in HOOK_SAFETY_PATH_CONTAINMENT:
+            safety_errors.append(f"{prefix} safety.path_containment must be `repo_relative`")
+        if truth_boundary not in HOOK_SAFETY_TRUTH_BOUNDARIES:
+            safety_errors.append(
+                f"{prefix} safety.truth_boundary must be `runtime_evidence_only`, `context_only`, or `blocking_decision_only`"
+            )
+        if cleanup_scope not in HOOK_SAFETY_CLEANUP_SCOPES:
+            safety_errors.append(f"{prefix} safety.cleanup_scope must be `not_applicable` or `loom_owned_only`")
+        if lifecycle == "cleanup" and cleanup_scope != "loom_owned_only":
+            safety_errors.append(f"{prefix} cleanup hooks must declare safety.cleanup_scope `loom_owned_only`")
+        if lifecycle != "cleanup" and cleanup_scope == "loom_owned_only":
+            safety_errors.append(f"{prefix} non-cleanup hooks must declare safety.cleanup_scope `not_applicable`")
+        if host_trust not in HOOK_SAFETY_HOST_TRUST:
+            safety_errors.append(f"{prefix} safety.host_trust must be `trusted`, `requires_review`, or `untrusted`")
+        elif host_trust == "untrusted":
+            safety_errors.append(f"{prefix} untrusted hook declarations are unsafe and must fail closed")
+        if permission_risk not in HOOK_SAFETY_PERMISSION_RISKS:
+            safety_errors.append(
+                f"{prefix} safety.permission_risk must be `none`, `approval_required`, `sandbox_required`, or `unknown`"
+            )
+        elif permission_risk == "unknown":
+            safety_errors.append(f"{prefix} unknown hook permission risk is unsafe and must fail closed")
+    if safety_errors:
+        if requirement in {"optional", "advisory"}:
+            optional.extend(safety_errors)
+        else:
+            blocking.extend(safety_errors)
 
     locator_value = entry.get("locator")
     locator, target = resolve_locator(root, locator_value)

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -8106,6 +8106,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "required",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "trusted",
+                    "permission_risk": "approval_required",
+                },
             },
             {
                 "id": "optional-after-run-hook",
@@ -8115,6 +8122,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "handoff",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "sandbox_required",
+                },
             },
             {
                 "id": "advisory-cleanup-hook",
@@ -8123,6 +8137,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "host-adapter",
                 "requirement": "advisory",
                 "fallback_to": "workspace cleanup|retire",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "loom_owned_only",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             },
         ],
         "release_targets": {
@@ -8332,6 +8353,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                 "owner": "repo-companion",
                 "requirement": "optional",
                 "fallback_to": "admission",
+                "safety": {
+                    "path_containment": "repo_relative",
+                    "truth_boundary": "runtime_evidence_only",
+                    "cleanup_scope": "not_applicable",
+                    "host_trust": "requires_review",
+                    "permission_risk": "approval_required",
+                },
             }
         ]
         write_json(hook_escape_interface_path, hook_escape_payload)
@@ -8358,6 +8386,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "handoff",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "none",
+                        },
                         "validation_status": "pass",
                     }
                 ],
@@ -8386,6 +8421,13 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
                         "owner": "repo-companion",
                         "requirement": "required",
                         "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "trusted",
+                            "permission_risk": "approval_required",
+                        },
                     }
                 ],
             },
@@ -8396,6 +8438,114 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
         elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+
+        required_hook_missing_safety_target = base / "required-hook-missing-safety"
+        shutil.copytree(example_target, required_hook_missing_safety_target)
+        install_companion(
+            required_hook_missing_safety_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "required-no-safety-hook",
+                        "summary": "Required hook safety declaration must fail closed when absent.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                    }
+                ],
+            },
+        )
+        required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
+        required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        if (
+            not isinstance(required_hook_missing_safety_interface, dict)
+            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+        ):
+            failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
+        elif "missing `safety` declaration" not in json.dumps(
+            required_hook_missing_safety_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
+
+        unsafe_hook_target = base / "unsafe-hook-safety"
+        shutil.copytree(example_target, unsafe_hook_target)
+        install_companion(
+            unsafe_hook_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "untrusted-hook",
+                        "summary": "Untrusted hook declarations must fail closed.",
+                        "lifecycle": "before-run",
+                        "locator": ".loom/companion/hooks/before-run.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "admission",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "untrusted",
+                            "permission_risk": "unknown",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
+        unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_missing = json.dumps(
+            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
+        elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
+            failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
+
+        unsafe_cleanup_target = base / "unsafe-cleanup-scope"
+        shutil.copytree(example_target, unsafe_cleanup_target)
+        install_companion(
+            unsafe_cleanup_target,
+            manifest=valid_manifest,
+            repo_interface={
+                **valid_interface_v2,
+                "hook_locators": [
+                    {
+                        "id": "unsafe-cleanup-hook",
+                        "summary": "Cleanup hooks must be constrained to Loom-owned residue.",
+                        "lifecycle": "cleanup",
+                        "locator": ".loom/companion/hooks/cleanup.md",
+                        "owner": "repo-companion",
+                        "requirement": "required",
+                        "fallback_to": "workspace cleanup|retire",
+                        "safety": {
+                            "path_containment": "repo_relative",
+                            "truth_boundary": "runtime_evidence_only",
+                            "cleanup_scope": "not_applicable",
+                            "host_trust": "requires_review",
+                            "permission_risk": "approval_required",
+                        },
+                    }
+                ],
+            },
+        )
+        unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
+        unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
+        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
+        elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
+            unsafe_cleanup_interface.get("missing_inputs", []),
+            ensure_ascii=False,
+        ):
+            failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
 
         present_v1_target = base / "present-v1"
         shutil.copytree(example_target, present_v1_target)
@@ -11787,6 +11937,70 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
         elif not isinstance(truth_payload, dict) or truth_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "hook envelope authored truth pollution must block"))
 
+        status_truth_target = base / "status-truth-write"
+        shutil.copytree(example_target, status_truth_target)
+        status_truth_polluting = valid_envelope("runtime_evidence")
+        status_truth_polluting["output"] = {
+            "category": "runtime_evidence",
+            "summary": "status authored field write must fail",
+            "evidence": {
+                "latest_validation_summary": "hook tried to author status truth",
+            },
+        }
+        write_json_local(status_truth_target / ".loom/companion/hooks/status-truth.json", status_truth_polluting)
+        status_truth_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(status_truth_target),
+                "--envelope",
+                ".loom/companion/hooks/status-truth.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` status authored field sample failed: {error}"))
+        elif not isinstance(status_truth_payload, dict) or status_truth_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope status authored field write must block"))
+
+        cleanup_target = base / "cleanup-non-loom-owned"
+        shutil.copytree(example_target, cleanup_target)
+        cleanup_intent = valid_envelope("runtime_evidence")
+        cleanup_intent["hook"]["lifecycle"] = "cleanup"
+        cleanup_intent["output"] = {
+            "category": "runtime_evidence",
+            "summary": "cleanup intent must be constrained to Loom-owned residue.",
+            "evidence": {
+                "cleanup_targets": [
+                    {
+                        "locator": "README.md",
+                        "ownership": "repo_owned",
+                    }
+                ],
+            },
+        }
+        write_json_local(cleanup_target / ".loom/companion/hooks/cleanup-non-loom-owned.json", cleanup_intent)
+        cleanup_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(cleanup_target),
+                "--envelope",
+                ".loom/companion/hooks/cleanup-non-loom-owned.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` cleanup non-Loom-owned sample failed: {error}"))
+        elif not isinstance(cleanup_payload, dict) or cleanup_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "hook envelope non-Loom-owned cleanup intent must block"))
+
         permission_target = base / "permission"
         shutil.copytree(example_target, permission_target)
         permission_envelope = valid_envelope("blocking_decision")
@@ -11869,6 +12083,29 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
             failures.append(Failure("hook-envelope", f"`hook-envelope` host-private fallback sample failed: {error}"))
         elif not isinstance(host_private_payload, dict) or host_private_payload.get("result") != "block":
             failures.append(Failure("hook-envelope", "host-private fallback must block"))
+
+        unsafe_mapping_target = base / "unsafe-adapter-mapping"
+        shutil.copytree(example_target, unsafe_mapping_target)
+        unsafe_mapping = valid_envelope("blocking_decision")
+        unsafe_mapping["input"]["host_adapter_mapping"]["adapter_result"] = "unsafe"
+        write_json_local(unsafe_mapping_target / ".loom/companion/hooks/unsafe-adapter.json", unsafe_mapping)
+        unsafe_mapping_payload, error = load_command_json(
+            root,
+            [
+                "python3",
+                "tools/loom_flow.py",
+                "live-smoke",
+                "hook-envelope",
+                "--target",
+                str(unsafe_mapping_target),
+                "--envelope",
+                ".loom/companion/hooks/unsafe-adapter.json",
+            ],
+        )
+        if error:
+            failures.append(Failure("hook-envelope", f"`hook-envelope` unsafe adapter mapping sample failed: {error}"))
+        elif not isinstance(unsafe_mapping_payload, dict) or unsafe_mapping_payload.get("result") != "block":
+            failures.append(Failure("hook-envelope", "unsafe hook adapter mapping must block when required"))
 
     return failures
 

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -152,7 +152,16 @@ HOOK_ENVELOPE_FORBIDDEN_FIELDS = {
     "validation_summary",
     "host_action_result",
     "closeout_basis",
+    "current_stop",
+    "next_step",
+    "blockers",
+    "latest_validation_summary",
+    "current_checkpoint",
+    "current_lane",
+    "recovery_boundary",
+    "closing_condition",
 }
+HOOK_CLEANUP_ALLOWED_OWNERSHIPS = {"loom_owned"}
 HOOK_LIFECYCLES = {"before-run", "after-run", "cleanup"}
 HOOK_ADAPTER_RESULTS = {"supported", "not_applicable", "advisory", "unsafe"}
 REVIEW_ENGINE_PROFILES: dict[str, dict[str, Any]] = {
@@ -887,6 +896,27 @@ def find_forbidden_hook_envelope_fields(value: object, *, prefix: str = "$") -> 
     return found
 
 
+def find_unsafe_hook_cleanup_targets(value: object, *, prefix: str = "$") -> list[str]:
+    found: list[str] = []
+    if isinstance(value, dict):
+        targets = value.get("cleanup_targets")
+        if isinstance(targets, list):
+            for index, target in enumerate(targets):
+                target_prefix = f"{prefix}.cleanup_targets[{index}]"
+                if not isinstance(target, dict):
+                    found.append(f"{target_prefix} must be an object")
+                    continue
+                ownership = target.get("ownership")
+                if ownership not in HOOK_CLEANUP_ALLOWED_OWNERSHIPS:
+                    found.append(f"{target_prefix}.ownership must be `loom_owned`")
+        for key_label, nested in value.items():
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}.{key_label}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            found.extend(find_unsafe_hook_cleanup_targets(nested, prefix=f"{prefix}[{index}]"))
+    return found
+
+
 def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     missing_inputs: list[str] = []
     evidence: dict[str, Any] = {
@@ -922,6 +952,7 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             missing_inputs.append("hook.lifecycle must be `before-run`, `after-run`, or `cleanup`")
 
     input_payload = envelope.get("input")
+    adapter_result = None
     if not isinstance(input_payload, dict):
         missing_inputs.append("hook envelope missing `input` object")
     else:
@@ -941,6 +972,8 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
                 missing_inputs.append(
                     "host_adapter_mapping.adapter_result must be `supported`, `not_applicable`, `advisory`, or `unsafe`"
                 )
+            else:
+                adapter_result = mapping.get("adapter_result")
 
     output = envelope.get("output")
     output_category = None
@@ -958,6 +991,12 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
     forbidden_fields = find_forbidden_hook_envelope_fields(envelope)
     if forbidden_fields:
         missing_inputs.append(f"hook envelope must not carry authored or host truth fields: {', '.join(forbidden_fields)}")
+    unsafe_cleanup_targets = find_unsafe_hook_cleanup_targets(envelope)
+    if unsafe_cleanup_targets:
+        missing_inputs.append(
+            "hook envelope cleanup intent must target Loom-owned residue only: "
+            + ", ".join(unsafe_cleanup_targets)
+        )
 
     failure = envelope.get("failure")
     failure_classification = None
@@ -984,6 +1023,34 @@ def validate_hook_envelope_payload(envelope: object) -> dict[str, Any]:
             "summary": "hook envelope is invalid or truth-polluting.",
             "missing_inputs": missing_inputs,
             "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+
+    if adapter_result == "unsafe":
+        return {
+            "result": "block",
+            "classification": "unsafe",
+            "summary": "hook adapter mapping reports unsafe.",
+            "missing_inputs": ["host_adapter_mapping.adapter_result is unsafe"],
+            "fallback_to": "manual_repair",
+            "evidence": evidence,
+        }
+    if adapter_result == "not_applicable":
+        return {
+            "result": "warn",
+            "classification": "not_applicable",
+            "summary": "hook adapter mapping reports not_applicable.",
+            "missing_inputs": [],
+            "fallback_to": None,
+            "evidence": evidence,
+        }
+    if adapter_result == "advisory":
+        return {
+            "result": "warn",
+            "classification": "unsupported",
+            "summary": "hook adapter mapping is advisory and remains profile-local evidence.",
+            "missing_inputs": [],
+            "fallback_to": None,
             "evidence": evidence,
         }
 


### PR DESCRIPTION
## Summary

- Problem: close `#621` Batch 3 hook safety invariants without implementing hook execution, generating host-native hook files, or activating `#625` extension profile gating.
- Scope: add hook locator `safety` declarations, fail closed for unsafe trust/permission/cleanup declarations, block unsafe adapter mappings, expand truth-pollution checks, add non-Loom-owned cleanup/status-authored-field fixtures, sync the generated skills surface, and bump the installer package version because the skills payload changed.

## Validation

- [x] Verified locally
- [ ] Verified by automation
- [ ] Not applicable

Validation details:

- `python3 -m py_compile src/skills/shared/scripts/governance_surface.py src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py`
- `python3 tools/skills_surface.py generate`
- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `python3 tools/loom_flow.py live-smoke hook-envelope --target examples/new-project --envelope .loom/companion/hooks/missing-required.json` returned the expected required-missing `block` envelope
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_check.py` (`checked 34 surfaces`)

## Risks And Follow-ups

- Risks: this validates declaration-time safety and mapped hook envelope safety; it intentionally does not prove host-native hook execution behavior.
- Follow-ups: `#625` remains the next batch and should own optional hooks extension profile gating and core/extension result separation.

## Related Work

- Issue: `#621`
- Work Item: `#622` covers hook safety invariant documentation.
- Work Item: `#623` covers hook safety checks.
- Work Item: `#624` covers unsafe hook fixtures.
- Deferred boundary: `#625/#626/#627/#628` are not activated by this PR.
