### PR TITLE
feat(harness): define hooks extension profile

### DIFF
--- a/docs/evidence/live-smoke-profile.md
+++ b/docs/evidence/live-smoke-profile.md
@@ -1,6 +1,6 @@
 # Live Smoke Profile
 
-本文件定义 v0.10.0 的 adopted-repo live smoke foundation。
+本文件定义 v0.10.0 以来的 adopted-repo live smoke foundation。
 
 它回答的不是“某个 adopted repo 是否已经通过所有治理面”，而是“Loom 是否能用真实 adopted repo 或 versioned prior-pass evidence 产出可消费的 `orchestration-live` confidence input”。
 
@@ -14,11 +14,15 @@
 
 `python3 tools/loom_flow.py live-smoke dynamic-tool-availability --target <repo> [--surface attempt_time|review|merge_ready|closeout|build|admission|pre_review|all]`
 
+`python3 tools/loom_flow.py live-smoke hooks-extension --target <repo>`
+
 输出 schema 固定为 `loom-live-smoke/v1`。
 
 `host-adapter-drift` 输出 schema 固定为 `loom-host-adapter-live-drift/v1`。
 
 `dynamic-tool-availability` 输出 schema 固定为 `loom-dynamic-tool-live-availability/v1`。
+
+`hooks-extension` 输出 schema 固定为 `loom-hooks-extension-profile/v1`。
 
 ## Run Contract
 
@@ -136,3 +140,32 @@
 - repo interface absent 时返回 explicit unavailable evidence 与 `warn`
 - repo interface present 但当前 surface 无 dynamic tools 时返回 `pass`
 - 命令 does not execute the tool, 不得探测宿主协议、不得写 repo companion / host state，也不得固化 tool-specific protocol
+
+## Hooks Extension Profile Contract
+
+`hooks-extension` 读取 adopted repo `.loom/companion/repo-interface.json` 中声明的
+`hook_locators[*]`，并把 declaration-time hook safety 结果包装成
+`orchestration-extension/hooks` profile-local evidence。
+
+最小检查面：
+
+- repo companion interface 是否存在且可读
+- `hook_locators[*]` 是否声明合法的 `id`、`summary`、`lifecycle`、
+  `locator`、`owner`、`requirement`、`fallback_to` 与 `safety`
+- locator 是否缺失、越界、不可读或指向目录
+- safety 是否保持 repo-relative path containment、runtime-evidence-only truth
+  boundary、Loom-owned cleanup scope、trusted/reviewed host trust 与明确
+  permission risk
+- optional/advisory gap 是否保持 profile-local，不污染
+  `orchestration-core`
+
+结果纪律：
+
+- 未声明 `hook_locators` 时返回 `pass`，`hooks_extension.status` 为
+  `not_applicable`
+- required unsafe hook declaration 可以在该命令内返回 `block`
+- optional/advisory hook gap 只返回 profile-local `warn`
+- `core_profile.result` 必须保持 `pass`，`core_profile.hook_enforcement` 固定为
+  `not_applicable`
+- 命令 does not execute hooks，不生成 host-native hook files，不写 repo
+  companion、host state、authored progress 或 status truth

--- a/docs/evidence/orchestration-conformance-profiles.md
+++ b/docs/evidence/orchestration-conformance-profiles.md
@@ -46,6 +46,28 @@ Core 缺口必须 fail closed，因为这些能力构成 Loom v0.7.0 的可恢�
 
 Extension 缺口不得污染 `orchestration-core` pass/fail。若某 adopted repo 显式启用 stronger extension gate，该启用点必须记录 owner、fallback、override path 与 authority-of-truth。
 
+### `orchestration-extension/hooks`
+
+`orchestration-extension/hooks` 是 hooks 的 optional extension profile。未声明
+`hook_locators` 时，该 profile 固定输出 `not_applicable`，core profile remains pass。
+
+启用条件仅来自 repo companion `.loom/companion/repo-interface.json` 的
+`hook_locators`。启用后：
+
+- required hook safety、locator、host trust 或 permission risk 缺口可以在
+  hooks extension path 内返回 `block`
+- optional/advisory hook 缺口只进入 profile-local `warn` 和
+  `missing_optional`
+- mapped hook envelope 的 `adapter_result: unsafe` 只影响对应 configured
+  hook path，不改写 authored progress、status truth、review verdict 或
+  closeout basis
+- `orchestration-core` 不因为 hooks 未启用、optional/advisory hooks 缺失或
+  profile-local warnings 改变 pass/fail
+
+该 profile 的 live evidence 命令是
+`python3 tools/loom_flow.py live-smoke hooks-extension --target <repo>`，输出
+schema 为 `loom-hooks-extension-profile/v1`。
+
 ## 4. `orchestration-live`
 
 `orchestration-live` 是 release confidence profile，不是普通 PR 的默认 blocking gate。

--- a/docs/methodology/harness/hook-envelope-contract.md
+++ b/docs/methodology/harness/hook-envelope-contract.md
@@ -115,8 +115,12 @@ The live check reports:
 The command is profile-local evidence. It must not write authored progress or
 modify host-native hook configuration.
 
+The related `hooks-extension` live smoke command validates declaration-time hook
+locator safety for the optional `orchestration-extension/hooks` profile. This
+envelope command remains scoped to one mapped envelope artifact.
+
 ## Non-goals
 
 - executing hooks
 - generating Codex or Claude Code native hook files
-- defining hooks extension profile gating for #625
+- replacing the `hooks-extension` declaration-time profile check

--- a/docs/methodology/harness/hook-locator-contract.md
+++ b/docs/methodology/harness/hook-locator-contract.md
@@ -30,6 +30,10 @@ Invalid locators fail closed for every requirement level:
 Missing optional or advisory locators are reported as optional gaps. They must
 not pollute core `missing_inputs`.
 
+Hook locators are evaluated by the optional `orchestration-extension/hooks`
+profile when a repository declares `hook_locators`. Repositories with no
+`hook_locators` stay `not_applicable`.
+
 ## Repo Companion Declaration
 
 Adopted repositories declare hook locators through the repo companion
@@ -72,6 +76,10 @@ The stable safety fields are:
 
 Safety evaluation is declaration-time only. It does not execute hooks, inspect
 host-private hook files, or write status/recovery truth.
+
+Missing or incomplete optional/advisory safety remains profile-local advisory
+evidence. It can produce a hooks extension warning, but it must not become an
+`orchestration-core` missing input.
 
 Stable fail-closed conditions:
 

--- a/packages/loom-installer/package-lock.json
+++ b/packages/loom-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mc-and-his-agents/loom-installer",
-      "version": "0.1.97",
+      "version": "0.1.98",
       "license": "MIT",
       "bin": {
         "loom-installer": "dist/src/cli.js"

--- a/packages/loom-installer/package.json
+++ b/packages/loom-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mc-and-his-agents/loom-installer",
-  "version": "0.1.97",
+  "version": "0.1.98",
   "description": "Node installer for Loom plugin and single-skill installation surfaces.",
   "type": "module",
   "bin": {

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-adopt/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-build/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-handoff/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-init/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-merge-ready/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-pre-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-resume/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-retire/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-spec-review/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
+++ b/skills/loom-story/.loom-runtime/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/skills/shared/scripts/governance_surface.py
+++ b/skills/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/skills/shared/scripts/loom_check.py
+++ b/skills/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/skills/shared/scripts/loom_flow.py
+++ b/skills/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)

--- a/src/skills/shared/scripts/governance_surface.py
+++ b/src/skills/shared/scripts/governance_surface.py
@@ -383,6 +383,7 @@ HOOK_SAFETY_TRUTH_BOUNDARIES = {"runtime_evidence_only", "context_only", "blocki
 HOOK_SAFETY_CLEANUP_SCOPES = {"not_applicable", "loom_owned_only"}
 HOOK_SAFETY_HOST_TRUST = {"trusted", "requires_review", "untrusted"}
 HOOK_SAFETY_PERMISSION_RISKS = {"none", "approval_required", "sandbox_required", "unknown"}
+HOOK_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 POLICY_READ_SCHEMA = "loom-policy-read/v1"
 POLICY_READINESS_SCHEMA = "loom-policy-readiness/v1"
 POLICY_TYPES = {"approval", "sandbox"}
@@ -1258,6 +1259,95 @@ def validate_hook_locator(
     return blocking, optional
 
 
+def empty_hook_extension_profile() -> dict[str, Any]:
+    return {
+        "schema_version": HOOK_EXTENSION_PROFILE_SCHEMA,
+        "profile_id": "orchestration-extension/hooks",
+        "enabled": False,
+        "result": "pass",
+        "status": "not_applicable",
+        "summary": "hooks extension profile is not enabled for this repository.",
+        "missing_inputs": [],
+        "missing_optional": [],
+        "checks": [],
+    }
+
+
+def hook_extension_profile_payload(root: Path, hook_locators: object) -> dict[str, Any]:
+    payload = empty_hook_extension_profile()
+    if hook_locators is None:
+        return payload
+    payload.update(
+        {
+            "enabled": True,
+            "status": "present",
+            "summary": "hooks extension profile is enabled and hook declarations are readable.",
+        }
+    )
+    if not isinstance(hook_locators, list):
+        return {
+            **payload,
+            "result": "block",
+            "status": "invalid_declaration",
+            "summary": "hooks extension profile is enabled but hook_locators is not a list.",
+            "missing_inputs": ["hook_locators must be a list"],
+            "checks": [],
+        }
+
+    checks: list[dict[str, Any]] = []
+    missing_inputs: list[str] = []
+    missing_optional: list[str] = []
+    for index, entry in enumerate(hook_locators):
+        blocking, optional = validate_hook_locator(root=root, entry=entry, index=index)
+        if isinstance(entry, dict):
+            hook_id = entry.get("id") if isinstance(entry.get("id"), str) and entry.get("id") else f"hook-{index}"
+            lifecycle = entry.get("lifecycle") if isinstance(entry.get("lifecycle"), str) else "unknown"
+            requirement = entry.get("requirement") if isinstance(entry.get("requirement"), str) else "required"
+            locator = entry.get("locator") if isinstance(entry.get("locator"), str) else ""
+            fallback_to = entry.get("fallback_to") if isinstance(entry.get("fallback_to"), str) else "manual_repair"
+        else:
+            hook_id = f"invalid-{index}"
+            lifecycle = "unknown"
+            requirement = "required"
+            locator = ""
+            fallback_to = "manual_repair"
+        result = "block" if blocking else "warn" if optional else "pass"
+        checks.append(
+            {
+                "id": hook_id,
+                "lifecycle": lifecycle,
+                "requirement": requirement,
+                "locator": locator,
+                "result": result,
+                "summary": "hook declaration is safe for extension consumption."
+                if result == "pass"
+                else "hook declaration has profile-local warnings."
+                if result == "warn"
+                else "hook declaration is unsafe for the configured hooks extension path.",
+                "missing_inputs": blocking,
+                "missing_optional": optional,
+                "fallback_to": fallback_to if result == "block" else None,
+            }
+        )
+        missing_inputs.extend(message for message in blocking if message not in missing_inputs)
+        missing_optional.extend(message for message in optional if message not in missing_optional)
+
+    result = "block" if missing_inputs else "warn" if missing_optional else "pass"
+    summary = "hooks extension profile is enabled and hook declarations are safe."
+    if result == "warn":
+        summary = "hooks extension profile is enabled with profile-local advisory gaps."
+    if result == "block":
+        summary = "hooks extension profile is enabled and unsafe hook declarations block the configured path."
+    return {
+        **payload,
+        "result": result,
+        "summary": summary,
+        "missing_inputs": missing_inputs,
+        "missing_optional": missing_optional,
+        "checks": checks,
+    }
+
+
 def validate_policy_locator(
     *,
     root: Path,
@@ -2045,6 +2135,7 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
         "release_targets": empty_release_targets_surface(),
         "tool_availability": empty_tool_availability(),
         "policy_readiness": empty_policy_readiness(),
+        "hook_profile": empty_hook_extension_profile(),
         "summary": "no repo companion interface is declared for this repository.",
         "missing_inputs": [],
         "missing_optional": [],
@@ -2236,22 +2327,15 @@ def detect_repo_interface(root: Path) -> tuple[dict[str, Any], list[str]]:
                             missing_optional.extend(optional)
                 hook_locators = interface_payload.get("hook_locators")
                 if hook_locators is not None:
+                    repo_interface_surface["hook_profile"] = hook_extension_profile_payload(
+                        root,
+                        hook_locators,
+                    )
                     repo_interface_surface["hook_locators"] = carrier_entry(
                         "present",
                         ".loom/companion/repo-interface.json",
                         "repo companion interface",
                     )
-                    if not isinstance(hook_locators, list):
-                        missing_inputs.append("hook_locators must be a list")
-                    else:
-                        for index, entry in enumerate(hook_locators):
-                            blocking, optional = validate_hook_locator(
-                                root=root,
-                                entry=entry,
-                                index=index,
-                            )
-                            missing_inputs.extend(blocking)
-                            missing_optional.extend(optional)
                 release_targets = interface_payload.get("release_targets")
                 if release_targets is not None:
                     blocking_inputs = validate_release_targets(root=root, entry=release_targets)

--- a/src/skills/shared/scripts/loom_check.py
+++ b/src/skills/shared/scripts/loom_check.py
@@ -1271,6 +1271,12 @@ def require_repo_interface_payload(
         context=f"{context}.policy_readiness",
         payload=payload.get("policy_readiness"),
     )
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hook_profile",
+        payload=payload.get("hook_profile"),
+    )
 
 
 def require_release_targets_surface_payload(
@@ -1428,6 +1434,65 @@ def require_policy_readiness_payload(
                 failures.append(Failure(category, f"{context} risk_summary.{key} must be a list"))
     if not isinstance(payload.get("missing_inputs"), list):
         failures.append(Failure(category, f"{context} missing_inputs must be a list"))
+
+
+def require_hook_profile_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("profile_id") != "orchestration-extension/hooks":
+        failures.append(Failure(category, f"{context} profile_id must be `orchestration-extension/hooks`"))
+    if not isinstance(payload.get("enabled"), bool):
+        failures.append(Failure(category, f"{context} enabled must be a boolean"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if payload.get("status") not in {
+        "not_applicable",
+        "present",
+        "invalid_declaration",
+        "runtime-blocked",
+        "target-unavailable",
+        "missing-target",
+    }:
+        failures.append(Failure(category, f"{context} status is outside the stable hooks extension vocabulary"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    for field in ("missing_inputs", "missing_optional", "checks"):
+        if not isinstance(payload.get(field), list):
+            failures.append(Failure(category, f"{context}.{field} must be a list"))
+    checks = payload.get("checks")
+    if not isinstance(checks, list):
+        return
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            failures.append(Failure(category, f"{context}.checks[{index}] must be an object"))
+            continue
+        for field in ("id", "lifecycle", "requirement", "result", "summary"):
+            value = check.get(field)
+            if not isinstance(value, str) or not value:
+                failures.append(Failure(category, f"{context}.checks[{index}] missing `{field}`"))
+        if not isinstance(check.get("locator"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] locator must be a string"))
+        if check.get("lifecycle") not in {"before-run", "after-run", "cleanup", "unknown"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] lifecycle is outside the stable vocabulary"))
+        if check.get("requirement") not in {"required", "optional", "advisory"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] requirement must be `required`, `optional`, or `advisory`"))
+        if check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context}.checks[{index}] result must stay within `pass | warn | block`"))
+        if not isinstance(check.get("missing_inputs"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_inputs must be a list"))
+        if not isinstance(check.get("missing_optional"), list):
+            failures.append(Failure(category, f"{context}.checks[{index}] missing_optional must be a list"))
+        if check.get("fallback_to") is not None and not isinstance(check.get("fallback_to"), str):
+            failures.append(Failure(category, f"{context}.checks[{index}] fallback_to must be a string or null"))
 
 
 def require_repo_interop_payload(
@@ -2365,6 +2430,93 @@ def require_hook_envelope_live_check_payload(
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `missing_inputs`"))
         if not isinstance(check.get("evidence"), dict):
             failures.append(Failure(category, f"{context} hook_envelope.checks[{index}] must include `evidence`"))
+
+
+def require_hooks_extension_live_check_payload(
+    failures: list[Failure],
+    *,
+    category: str,
+    context: str,
+    payload: object,
+) -> None:
+    if not isinstance(payload, dict):
+        failures.append(Failure(category, f"{context} must be an object"))
+        return
+    if payload.get("command") != "live-smoke":
+        failures.append(Failure(category, f"{context} must report `command: live-smoke`"))
+    if payload.get("operation") != "hooks-extension":
+        failures.append(Failure(category, f"{context} must report `operation: hooks-extension`"))
+    if payload.get("schema_version") != governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA:
+        failures.append(Failure(category, f"{context} schema_version must be `{governance_surface_module.HOOK_EXTENSION_PROFILE_SCHEMA}`"))
+    if payload.get("result") not in {"pass", "warn", "block"}:
+        failures.append(Failure(category, f"{context} result must stay within `pass | warn | block`"))
+    if not isinstance(payload.get("summary"), str) or not payload.get("summary"):
+        failures.append(Failure(category, f"{context} must include non-empty `summary`"))
+    if not isinstance(payload.get("missing_inputs"), list):
+        failures.append(Failure(category, f"{context} must include `missing_inputs`"))
+    if payload.get("fallback_to") not in {None, "live-smoke-retry-or-record-unavailable", "live-smoke-config-repair"}:
+        failures.append(Failure(category, f"{context} fallback_to must stay within the stable hooks extension contract"))
+    require_runtime_state_payload(
+        failures,
+        category=category,
+        context=context,
+        payload=payload.get("runtime_state"),
+        expected_scene="repo-local-demo",
+        expected_carrier="repo-local-wrapper",
+        allowed_results={"pass", "block"} if payload.get("result") == "block" else {"pass"},
+    )
+    target = payload.get("target")
+    if not isinstance(target, dict):
+        failures.append(Failure(category, f"{context} must include `target`"))
+    else:
+        if not isinstance(target.get("path"), str) or not target.get("path"):
+            failures.append(Failure(category, f"{context} target.path must be non-empty"))
+        if not isinstance(target.get("exists"), bool):
+            failures.append(Failure(category, f"{context} target.exists must be boolean"))
+    if not isinstance(payload.get("command_plan"), list):
+        failures.append(Failure(category, f"{context} must include `command_plan`"))
+    reports = payload.get("reports")
+    if not isinstance(reports, list):
+        failures.append(Failure(category, f"{context} must include `reports`"))
+    else:
+        for index, report in enumerate(reports):
+            if not isinstance(report, dict):
+                failures.append(Failure(category, f"{context} reports[{index}] must be an object"))
+                continue
+            if report.get("result") not in {"pass", "warn", "block"}:
+                failures.append(Failure(category, f"{context} reports[{index}] result must stay within the stable contract"))
+            if not isinstance(report.get("attempted"), bool):
+                failures.append(Failure(category, f"{context} reports[{index}] must include boolean `attempted`"))
+            for field in ("id", "command", "summary", "reported_result"):
+                value = report.get(field)
+                if not isinstance(value, str) or not value:
+                    failures.append(Failure(category, f"{context} reports[{index}] missing `{field}`"))
+            if not isinstance(report.get("missing_inputs"), list):
+                failures.append(Failure(category, f"{context} reports[{index}] must include `missing_inputs`"))
+    profile_check = payload.get("profile_check")
+    if not isinstance(profile_check, dict):
+        failures.append(Failure(category, f"{context} must include `profile_check`"))
+    else:
+        if profile_check.get("id") != "hooks-extension":
+            failures.append(Failure(category, f"{context} profile_check.id must be `hooks-extension`"))
+        if profile_check.get("result") not in {"pass", "warn", "block"}:
+            failures.append(Failure(category, f"{context} profile_check.result must stay within `pass | warn | block`"))
+    core_profile = payload.get("core_profile")
+    if not isinstance(core_profile, dict):
+        failures.append(Failure(category, f"{context} must include `core_profile`"))
+    else:
+        if core_profile.get("id") != "orchestration-core":
+            failures.append(Failure(category, f"{context} core_profile.id must be `orchestration-core`"))
+        if core_profile.get("hook_enforcement") != "not_applicable":
+            failures.append(Failure(category, f"{context} core_profile.hook_enforcement must be `not_applicable`"))
+        if core_profile.get("result") != "pass":
+            failures.append(Failure(category, f"{context} core_profile.result must remain `pass`"))
+    require_hook_profile_payload(
+        failures,
+        category=category,
+        context=f"{context}.hooks_extension",
+        payload=payload.get("hooks_extension"),
+    )
 
 
 def require_github_binding_payload(
@@ -8365,10 +8517,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         write_json(hook_escape_interface_path, hook_escape_payload)
         invalid_hook_escape_surface = build_governance_surface(invalid_hook_escape_target)
         invalid_hook_escape_interface = invalid_hook_escape_surface.get("repo_interface")
-        if not isinstance(invalid_hook_escape_interface, dict) or invalid_hook_escape_interface.get("availability") != "incomplete":
+        invalid_hook_escape_profile = (
+            invalid_hook_escape_interface.get("hook_profile") if isinstance(invalid_hook_escape_interface, dict) else None
+        )
+        invalid_hook_escape_missing = json.dumps(
+            invalid_hook_escape_profile.get("missing_inputs", []) if isinstance(invalid_hook_escape_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_escape_profile, dict) or invalid_hook_escape_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "optional hook path escape must fail closed"))
-        elif "outside-hook.md" not in json.dumps(invalid_hook_escape_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook path escape must stay in blocking missing_inputs"))
+        elif "outside-hook.md" not in invalid_hook_escape_missing:
+            failures.append(Failure("repo-companion", "optional hook path escape must stay in hook_profile missing_inputs"))
 
         invalid_hook_truth_target = base / "invalid-hook-truth"
         shutil.copytree(example_target, invalid_hook_truth_target)
@@ -8400,9 +8559,16 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         invalid_hook_truth_surface = build_governance_surface(invalid_hook_truth_target)
         invalid_hook_truth_interface = invalid_hook_truth_surface.get("repo_interface")
-        if not isinstance(invalid_hook_truth_interface, dict) or invalid_hook_truth_interface.get("availability") != "incomplete":
+        invalid_hook_truth_profile = (
+            invalid_hook_truth_interface.get("hook_profile") if isinstance(invalid_hook_truth_interface, dict) else None
+        )
+        invalid_hook_truth_missing = json.dumps(
+            invalid_hook_truth_profile.get("missing_inputs", []) if isinstance(invalid_hook_truth_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(invalid_hook_truth_profile, dict) or invalid_hook_truth_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "hook locator truth pollution must fail closed"))
-        elif "validation_status" not in json.dumps(invalid_hook_truth_interface.get("missing_inputs", []), ensure_ascii=False):
+        elif "validation_status" not in invalid_hook_truth_missing:
             failures.append(Failure("repo-companion", "hook locator truth pollution must identify forbidden fields"))
 
         required_hook_missing_target = base / "required-hook-missing"
@@ -8434,10 +8600,17 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_surface = build_governance_surface(required_hook_missing_target)
         required_hook_missing_interface = required_hook_missing_surface.get("repo_interface")
-        if not isinstance(required_hook_missing_interface, dict) or required_hook_missing_interface.get("availability") != "incomplete":
+        required_hook_missing_profile = (
+            required_hook_missing_interface.get("hook_profile") if isinstance(required_hook_missing_interface, dict) else None
+        )
+        required_hook_missing_inputs = json.dumps(
+            required_hook_missing_profile.get("missing_inputs", []) if isinstance(required_hook_missing_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if not isinstance(required_hook_missing_profile, dict) or required_hook_missing_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "required missing hook locator must fail closed"))
-        elif "missing-required.md" not in json.dumps(required_hook_missing_interface.get("missing_inputs", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "required missing hook locator must stay in blocking missing_inputs"))
+        elif "missing-required.md" not in required_hook_missing_inputs:
+            failures.append(Failure("repo-companion", "required missing hook locator must stay in hook_profile missing_inputs"))
 
         required_hook_missing_safety_target = base / "required-hook-missing-safety"
         shutil.copytree(example_target, required_hook_missing_safety_target)
@@ -8461,13 +8634,18 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         required_hook_missing_safety_surface = build_governance_surface(required_hook_missing_safety_target)
         required_hook_missing_safety_interface = required_hook_missing_safety_surface.get("repo_interface")
+        required_hook_missing_safety_profile = (
+            required_hook_missing_safety_interface.get("hook_profile")
+            if isinstance(required_hook_missing_safety_interface, dict)
+            else None
+        )
         if (
-            not isinstance(required_hook_missing_safety_interface, dict)
-            or required_hook_missing_safety_interface.get("availability") != "incomplete"
+            not isinstance(required_hook_missing_safety_profile, dict)
+            or required_hook_missing_safety_profile.get("result") != "block"
         ):
             failures.append(Failure("repo-companion", "required missing hook safety declaration must fail closed"))
         elif "missing `safety` declaration" not in json.dumps(
-            required_hook_missing_safety_interface.get("missing_inputs", []),
+            required_hook_missing_safety_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "missing hook safety declaration must identify safety"))
@@ -8501,11 +8679,12 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_hook_surface = build_governance_surface(unsafe_hook_target)
         unsafe_hook_interface = unsafe_hook_surface.get("repo_interface")
+        unsafe_hook_profile = unsafe_hook_interface.get("hook_profile") if isinstance(unsafe_hook_interface, dict) else None
         unsafe_hook_missing = json.dumps(
-            unsafe_hook_interface.get("missing_inputs", []) if isinstance(unsafe_hook_interface, dict) else [],
+            unsafe_hook_profile.get("missing_inputs", []) if isinstance(unsafe_hook_profile, dict) else [],
             ensure_ascii=False,
         )
-        if not isinstance(unsafe_hook_interface, dict) or unsafe_hook_interface.get("availability") != "incomplete":
+        if not isinstance(unsafe_hook_profile, dict) or unsafe_hook_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "untrusted or unknown-permission hook declaration must fail closed"))
         elif "untrusted" not in unsafe_hook_missing or "unknown hook permission risk" not in unsafe_hook_missing:
             failures.append(Failure("repo-companion", "unsafe hook declaration must identify trust and permission risk"))
@@ -8539,10 +8718,11 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
         )
         unsafe_cleanup_surface = build_governance_surface(unsafe_cleanup_target)
         unsafe_cleanup_interface = unsafe_cleanup_surface.get("repo_interface")
-        if not isinstance(unsafe_cleanup_interface, dict) or unsafe_cleanup_interface.get("availability") != "incomplete":
+        unsafe_cleanup_profile = unsafe_cleanup_interface.get("hook_profile") if isinstance(unsafe_cleanup_interface, dict) else None
+        if not isinstance(unsafe_cleanup_profile, dict) or unsafe_cleanup_profile.get("result") != "block":
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must fail closed"))
         elif "cleanup hooks must declare safety.cleanup_scope" not in json.dumps(
-            unsafe_cleanup_interface.get("missing_inputs", []),
+            unsafe_cleanup_profile.get("missing_inputs", []),
             ensure_ascii=False,
         ):
             failures.append(Failure("repo-companion", "unsafe cleanup hook declaration must identify cleanup scope"))
@@ -8590,10 +8770,15 @@ def check_repo_companion_interface_contracts(root: Path) -> list[Failure]:
             failures.append(Failure("repo-companion", "optional dynamic tool locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-build-tool" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "advisory dynamic tool missing locator field must not pollute core missing_inputs"))
-        if isinstance(present_interface, dict) and "missing-after-run.md" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in missing_optional"))
-        if isinstance(present_interface, dict) and "advisory-cleanup-hook" not in json.dumps(present_interface.get("missing_optional", []), ensure_ascii=False):
-            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in missing_optional"))
+        present_hook_profile = present_interface.get("hook_profile") if isinstance(present_interface, dict) else None
+        present_hook_optional = json.dumps(
+            present_hook_profile.get("missing_optional", []) if isinstance(present_hook_profile, dict) else [],
+            ensure_ascii=False,
+        )
+        if "missing-after-run.md" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "optional hook locator gaps must stay in hook_profile missing_optional"))
+        if "advisory-cleanup-hook" not in present_hook_optional:
+            failures.append(Failure("repo-companion", "advisory hook missing locator field must stay in hook_profile missing_optional"))
         if isinstance(present_interface, dict) and "missing-after-run.md" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
             failures.append(Failure("repo-companion", "optional hook locator gaps must not pollute core missing_inputs"))
         if isinstance(present_interface, dict) and "advisory-cleanup-hook" in json.dumps(present_interface.get("missing_inputs", []), ensure_ascii=False):
@@ -12110,6 +12295,213 @@ def check_hook_envelope_contract(root: Path) -> list[Failure]:
     return failures
 
 
+def check_hooks_extension_profile_contract(root: Path) -> list[Failure]:
+    failures: list[Failure] = []
+
+    def write_json_local(path: Path, payload: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    def install_companion_local(target: Path, *, repo_interface: dict[str, object]) -> None:
+        companion_dir = target / ".loom" / "companion"
+        companion_dir.mkdir(parents=True, exist_ok=True)
+        (companion_dir / "README.md").write_text("# Repo Companion\n", encoding="utf-8")
+        write_json_local(
+            companion_dir / "manifest.json",
+            {
+                "schema_version": "loom-repo-companion-manifest/v1",
+                "companion_entry": ".loom/companion/README.md",
+                "repo_interface": ".loom/companion/repo-interface.json",
+            },
+        )
+        write_json_local(companion_dir / "repo-interface.json", repo_interface)
+
+    docs = {
+        "docs/evidence/orchestration-conformance-profiles.md": [
+            "orchestration-extension/hooks",
+            "not_applicable",
+            "profile-local `warn`",
+            "core profile remains pass",
+        ],
+        "docs/evidence/live-smoke-profile.md": [
+            "loom-hooks-extension-profile/v1",
+            "hooks-extension",
+            "optional/advisory",
+            "does not execute hooks",
+        ],
+        "docs/methodology/harness/hook-envelope-contract.md": [
+            "hooks-extension",
+            "profile-local evidence",
+        ],
+        "docs/methodology/harness/hook-locator-contract.md": [
+            "orchestration-extension/hooks",
+            "profile-local advisory evidence",
+        ],
+    }
+    for relative, anchors in docs.items():
+        path = root / relative
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            failures.append(Failure("hooks-extension-profile", f"`{relative}` is unreadable: {exc}"))
+            continue
+        for anchor in anchors:
+            if anchor not in text:
+                failures.append(Failure("hooks-extension-profile", f"`{relative}` must mention `{anchor}`"))
+
+    example_target = root / "examples/new-project"
+    absent_target = Path(tempfile.mkdtemp(prefix="loom-hooks-extension-absent-"))
+    shutil.rmtree(absent_target)
+    shutil.copytree(example_target, absent_target)
+    shutil.rmtree(absent_target / ".loom" / "companion", ignore_errors=True)
+    absent_payload, error = load_command_json(
+        root,
+        ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(absent_target)],
+    )
+    if error:
+        failures.append(Failure("hooks-extension-profile", f"`hooks-extension` absent interface sample failed: {error}"))
+    else:
+        require_hooks_extension_live_check_payload(
+            failures,
+            category="hooks-extension-profile",
+            context="absent-hooks-extension",
+            payload=absent_payload,
+        )
+        hooks_extension = absent_payload.get("hooks_extension") if isinstance(absent_payload, dict) else None
+        if not isinstance(absent_payload, dict) or absent_payload.get("result") != "pass":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must pass"))
+        elif not isinstance(hooks_extension, dict) or hooks_extension.get("status") != "not_applicable":
+            failures.append(Failure("hooks-extension-profile", "absent hooks extension sample must be not_applicable"))
+
+    valid_interface = {
+        "schema_version": "loom-repo-interface/v2",
+        "companion_entry": ".loom/companion/README.md",
+        "repo_specific_requirements": {"review": [], "merge_ready": [], "closeout": []},
+        "specialized_gates": [],
+        "review_instruction_locators": {
+            "spec_review": {"locator": "loom_default", "mode": "loom_default"},
+            "implementation_review": {"locator": "loom_default", "mode": "loom_default"},
+        },
+        "metadata_contract": {"fields": []},
+        "context_schema": {"fields": []},
+        "hook_locators": [],
+    }
+    safe_hook = {
+        "id": "before-run-context",
+        "summary": "Read Loom context before a host run.",
+        "lifecycle": "before-run",
+        "locator": ".loom/companion/hooks/before-run.md",
+        "owner": "host-adapter",
+        "requirement": "required",
+        "fallback_to": "build",
+        "safety": {
+            "path_containment": "repo_relative",
+            "truth_boundary": "context_only",
+            "cleanup_scope": "not_applicable",
+            "host_trust": "trusted",
+            "permission_risk": "none",
+        },
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loom-hooks-extension-") as tmp:
+        base = Path(tmp)
+
+        present_target = base / "present"
+        shutil.copytree(example_target, present_target)
+        present_interface = json.loads(json.dumps(valid_interface))
+        present_interface["hook_locators"] = [safe_hook]
+        install_companion_local(present_target, repo_interface=present_interface)
+        (present_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (present_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        present_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(present_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` present sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="present-hooks-extension",
+                payload=present_payload,
+            )
+            if not isinstance(present_payload, dict) or present_payload.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "safe hooks extension sample must pass"))
+
+        optional_target = base / "optional-warn"
+        shutil.copytree(example_target, optional_target)
+        optional_hook = json.loads(json.dumps(safe_hook))
+        optional_hook["id"] = "optional-after-run"
+        optional_hook["lifecycle"] = "after-run"
+        optional_hook["requirement"] = "optional"
+        optional_hook["locator"] = ".loom/companion/hooks/missing-optional.md"
+        optional_hook.pop("safety")
+        optional_interface = json.loads(json.dumps(valid_interface))
+        optional_interface["hook_locators"] = [optional_hook]
+        install_companion_local(optional_target, repo_interface=optional_interface)
+        optional_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(optional_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` optional sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="optional-hooks-extension",
+                payload=optional_payload,
+            )
+            core_profile = optional_payload.get("core_profile") if isinstance(optional_payload, dict) else None
+            if not isinstance(optional_payload, dict) or optional_payload.get("result") != "warn":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must warn"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "optional hooks extension gaps must not block core profile"))
+
+        required_target = base / "required-block"
+        shutil.copytree(example_target, required_target)
+        required_hook = json.loads(json.dumps(safe_hook))
+        required_hook["id"] = "required-unsafe"
+        required_hook["safety"]["host_trust"] = "untrusted"
+        required_interface = json.loads(json.dumps(valid_interface))
+        required_interface["hook_locators"] = [required_hook]
+        install_companion_local(required_target, repo_interface=required_interface)
+        (required_target / ".loom" / "companion" / "hooks").mkdir(parents=True, exist_ok=True)
+        (required_target / ".loom" / "companion" / "hooks" / "before-run.md").write_text(
+            "# Before Run\n",
+            encoding="utf-8",
+        )
+        required_payload, error = load_command_json(
+            root,
+            ["python3", "tools/loom_flow.py", "live-smoke", "hooks-extension", "--target", str(required_target)],
+        )
+        if error:
+            failures.append(Failure("hooks-extension-profile", f"`hooks-extension` required sample failed: {error}"))
+        else:
+            require_hooks_extension_live_check_payload(
+                failures,
+                category="hooks-extension-profile",
+                context="required-hooks-extension",
+                payload=required_payload,
+            )
+            core_profile = required_payload.get("core_profile") if isinstance(required_payload, dict) else None
+            if not isinstance(required_payload, dict) or required_payload.get("result") != "block":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must block the hooks extension profile"))
+            elif not isinstance(core_profile, dict) or core_profile.get("result") != "pass":
+                failures.append(Failure("hooks-extension-profile", "required unsafe hook must not rewrite core profile result"))
+        governance_surface = build_governance_surface(required_target)
+        repo_interface = governance_surface.get("repo_interface")
+        core_missing = repo_interface.get("missing_inputs", []) if isinstance(repo_interface, dict) else []
+        if any("hook_locators" in str(message) for message in core_missing):
+            failures.append(Failure("hooks-extension-profile", "hooks extension gaps must not pollute repo_interface core missing_inputs"))
+
+    return failures
+
+
 def check_live_validation_only_guardrail_contract(root: Path) -> list[Failure]:
     failures: list[Failure] = []
 
@@ -13694,6 +14086,7 @@ def collect_failures(root: Path) -> list[Failure]:
     failures.extend(check_host_adapter_live_drift_contract(root))
     failures.extend(check_dynamic_tool_live_availability_contract(root))
     failures.extend(check_hook_envelope_contract(root))
+    failures.extend(check_hooks_extension_profile_contract(root))
     failures.extend(check_live_validation_only_guardrail_contract(root))
     failures.extend(check_structured_event_evidence_contract(root))
     failures.extend(check_deferred_roadmap_tree_contract(root))

--- a/src/skills/shared/scripts/loom_flow.py
+++ b/src/skills/shared/scripts/loom_flow.py
@@ -34,6 +34,7 @@ from fact_chain_support import (
 from governance_surface import (
     build_governance_surface,
     derive_execution_budget_risk,
+    empty_hook_extension_profile,
     empty_target_release_status,
     empty_tool_availability,
     workspace_lifecycle_expectations,
@@ -120,6 +121,7 @@ HOST_ADAPTER_LIVE_DRIFT_SCHEMA = "loom-host-adapter-live-drift/v1"
 DYNAMIC_TOOL_LIVE_AVAILABILITY_SCHEMA = "loom-dynamic-tool-live-availability/v1"
 HOOK_ENVELOPE_SCHEMA = "loom-hook-envelope/v1"
 HOOK_ENVELOPE_LIVE_CHECK_SCHEMA = "loom-hook-envelope-check/v1"
+HOOKS_EXTENSION_PROFILE_SCHEMA = "loom-hooks-extension-profile/v1"
 LIVE_SMOKE_RETRY_FALLBACK = "live-smoke-retry-or-record-unavailable"
 LIVE_SMOKE_REPLAY_FALLBACK = "record-prior-evidence"
 LIVE_SMOKE_CONFIG_FALLBACK = "live-smoke-config-repair"
@@ -551,7 +553,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "live-smoke",
         help="Run or replay versioned adopted-repo live smoke evidence without changing core gates",
     )
-    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope"))
+    live_smoke.add_argument("operation", choices=("run", "replay", "host-adapter-drift", "dynamic-tool-availability", "hook-envelope", "hooks-extension"))
     live_smoke.add_argument("--target", help="Adopted repository root for live smoke run")
     live_smoke.add_argument("--item", default="INIT-0001", help="Expected current item id for the optional resume smoke")
     live_smoke.add_argument("--prior-evidence", help="Versioned prior-pass evidence to replay without running adopted-repo commands")
@@ -877,6 +879,22 @@ def hook_envelope_command_plan(target_root: Path, *, envelope: str | None) -> li
             "id": "hook-envelope",
             "command": f"read {envelope if isinstance(envelope, str) and envelope else '<missing-envelope>'}",
             "description": "Read the repo-relative Loom-mapped hook envelope without executing any hook.",
+        },
+    ]
+
+
+def hooks_extension_command_plan(target_root: Path) -> list[dict[str, Any]]:
+    target = command_target(target_root)
+    return [
+        {
+            "id": "target-check",
+            "command": f"test -d {target}",
+            "description": "Confirm the adopted-repo target path exists before reading hooks extension declarations.",
+        },
+        {
+            "id": "repo-interface-contract",
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "description": "Read hook_locators from repo companion without executing hooks or writing host state.",
         },
     ]
 
@@ -1770,6 +1788,93 @@ def hook_envelope_payload(target_root: Path, *, envelope: str, requirement: str)
                 "requirement": requirement,
                 "checks": [check],
             },
+        }
+    )
+    return payload
+
+
+def hooks_extension_payload(target_root: Path) -> dict[str, Any]:
+    runtime_state = runtime_state_payload(target_root)
+    target = live_smoke_target_metadata(target_root)
+    payload: dict[str, Any] = {
+        "command": "live-smoke",
+        "operation": "hooks-extension",
+        "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+        "runtime_state": runtime_state,
+        "target": target,
+        "command_plan": hooks_extension_command_plan(target_root),
+        "reports": [],
+        "missing_inputs": [],
+        "fallback_to": None,
+    }
+    if runtime_state.get("result") != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "runtime-blocked", "result": "block"})
+        payload.update(
+            {
+                "result": "block",
+                "summary": "hooks extension profile is blocked because the Loom runtime state is inconsistent.",
+                "missing_inputs": live_smoke_missing_inputs([str(message) for message in runtime_state.get("missing_inputs", [])]),
+                "fallback_to": runtime_state.get("fallback_to"),
+                "profile_check": {"id": "hooks-extension", "result": "block"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    target_report = live_smoke_target_check_report(target_root)
+    payload["reports"] = [target_report]
+    if target_report["result"] != "pass":
+        hook_profile = empty_hook_extension_profile()
+        hook_profile.update({"status": "target-unavailable", "result": "warn"})
+        payload.update(
+            {
+                "result": "warn",
+                "summary": "hooks extension profile recorded explicit unavailable evidence for the adopted-repo target.",
+                "missing_inputs": list(target_report.get("missing_inputs", [])),
+                "fallback_to": LIVE_SMOKE_RETRY_FALLBACK,
+                "profile_check": {"id": "hooks-extension", "result": "warn"},
+                "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                "hooks_extension": hook_profile,
+            }
+        )
+        return payload
+
+    governance_surface = build_governance_surface(target_root)
+    repo_interface = governance_surface.get("repo_interface")
+    if not isinstance(repo_interface, dict):
+        hook_profile = empty_hook_extension_profile()
+    else:
+        hook_profile = repo_interface.get("hook_profile")
+        if not isinstance(hook_profile, dict):
+            hook_profile = empty_hook_extension_profile()
+
+    result = str(hook_profile.get("result") or "pass")
+    if result not in {"pass", "warn", "block"}:
+        result = "block"
+    payload["reports"].append(
+        {
+            "id": "hooks-extension",
+            "attempted": True,
+            "command": f"read {target_root / '.loom/companion/repo-interface.json'}",
+            "reported_command": "repo-interface.hook_locators",
+            "reported_result": str(hook_profile.get("status") or "not_applicable"),
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": list(hook_profile.get("missing_inputs", [])) if result == "block" else [],
+            "fallback_to": "manual_repair" if result == "block" else None,
+        }
+    )
+    payload.update(
+        {
+            "result": result,
+            "summary": str(hook_profile.get("summary") or "hooks extension profile is not enabled."),
+            "missing_inputs": live_smoke_missing_inputs(list(hook_profile.get("missing_inputs", []))) if result == "block" else [],
+            "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK if result == "block" else None,
+            "profile_check": {"id": "hooks-extension", "result": result},
+            "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+            "hooks_extension": hook_profile,
         }
     )
     return payload
@@ -12624,6 +12729,31 @@ def handle_live_smoke(args: argparse.Namespace) -> int:
                 requirement=args.requirement,
             )
         )
+    if args.operation == "hooks-extension":
+        if not args.target:
+            return emit(
+                {
+                    "command": "live-smoke",
+                    "operation": "hooks-extension",
+                    "schema_version": HOOKS_EXTENSION_PROFILE_SCHEMA,
+                    "result": "block",
+                    "summary": "hooks extension profile requires --target.",
+                    "missing_inputs": ["pass --target <adopted_repo_root>"],
+                    "fallback_to": LIVE_SMOKE_CONFIG_FALLBACK,
+                    "runtime_state": runtime_state_payload(Path.cwd()),
+                    "target": live_smoke_target_metadata(Path.cwd()),
+                    "command_plan": [],
+                    "reports": [],
+                    "profile_check": {"id": "hooks-extension", "result": "block"},
+                    "core_profile": {"id": "orchestration-core", "hook_enforcement": "not_applicable", "result": "pass"},
+                    "hooks_extension": {
+                        **empty_hook_extension_profile(),
+                        "status": "missing-target",
+                        "result": "block",
+                    },
+                }
+            )
+        return emit(hooks_extension_payload(Path(args.target).expanduser().resolve()))
 
     repo_root = Path(os.environ.get("LOOM_SOURCE_REPO_ROOT", Path.cwd())).expanduser().resolve()
     runtime_state = runtime_state_payload(repo_root)


### PR DESCRIPTION
## Summary
- Closes #625; covers #626, #627, #628.
- Adds the optional `orchestration-extension/hooks` profile with `loom-hooks-extension-profile/v1` evidence.
- Keeps hook locator safety and mapped hook envelope failures profile-local so hooks do not pollute `orchestration-core` pass/fail.
- Adds `live-smoke hooks-extension` plus regression fixtures for not_applicable, optional/advisory warn, required block, and core-profile pass preservation.

## Validation
- `python3 -m py_compile src/skills/shared/scripts/governance_surface.py src/skills/shared/scripts/loom_flow.py src/skills/shared/scripts/loom_check.py`
- `python3 tools/skills_surface.py generate`
- `python3 -m py_compile tools/loom_check.py tools/loom_flow.py tools/loom_init.py skills/shared/scripts/*.py src/skills/shared/scripts/*.py`
- `python3 tools/skills_surface.py check`
- `python3 tools/host_adapter_check.py`
- `python3 tools/version_surface_check.py`
- `node packages/loom-installer/scripts/check-version-bump.mjs --base origin/main`
- `git diff --check`
- `python3 tools/loom_flow.py live-smoke hooks-extension --target examples/new-project`
- `python3 tools/loom_check.py`

## Non-goals
- Does not execute hooks.
- Does not generate host-native hook files.
- Does not promote hooks to a default core gate.